### PR TITLE
Prepare 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ with excellent error reporting. You can use it to process complex data or
 computer languages and build transformers, interpreters, compilers and other
 tools easily.
 
+Peggy is the successor of [PEG.js](https://github.com/pegjs/pegjs) which had been abandoned by its maintainer.
+Peggy version 1.x.x is backwards compatible with the most recent PEG.js release. Switching from PEG.js to Peggy should be as simple as uninstalling `pegjs` and installing `peggy` instead.
+
 ## Features
 
 - Simple and expressive grammar syntax
@@ -487,13 +490,13 @@ will produce an error message like:
 > Expected integer but "a" found.
 
 when parsing a non-number, referencing the human-readable name "integer."
-Without the human-readable name, PEG.js instead uses a description of the
+Without the human-readable name, Peggy instead uses a description of the
 character class that failed to match:
 
 > Expected [0-9] but "a" found.
 
 Aside from the text content of messages, human-readable names also have a
-subtler effect on _where_ errors are reported. PEG.js prefers to match
+subtler effect on _where_ errors are reported. Peggy prefers to match
 named rules completely or not at all, but not partially. Unnamed rules,
 on the other hand, can produce an error in the middle of their
 subexpressions.
@@ -512,7 +515,7 @@ But if we add a human-readable name to the `seq` production:
     seq "list of numbers"
       = integer ("," integer)*
 
-then PEG.js prefers an error message that implies a smaller attempted parse
+then Peggy prefers an error message that implies a smaller attempted parse
 tree:
 
 > Expected end of input but "," found.
@@ -539,7 +542,7 @@ environments:
 - [Discussions](https://github.com/peggyjs/peggy/discussions)
 
 Peggy was originally developed by [David Majda](https://majda.cz/)
-([@dmajda](http://twitter.com/dmajda)).  It is currently maintained by
+([@dmajda](http://twitter.com/dmajda)). It is currently maintained by
 [Joe Hildebrand](https://github.com/hildjj) ([@hildjj](https://twitter.com/hildjj)).
 
 You are welcome to contribute code. Unless your contribution is really trivial

--- a/README.md
+++ b/README.md
@@ -10,7 +10,16 @@ computer languages and build transformers, interpreters, compilers and other
 tools easily.
 
 Peggy is the successor of [PEG.js](https://github.com/pegjs/pegjs) which had been abandoned by its maintainer.
-Peggy version 1.x.x is backwards compatible with the most recent PEG.js release. Switching from PEG.js to Peggy should be as simple as uninstalling `pegjs` and installing `peggy` instead.
+
+## Migrating from PEG.js
+
+Peggy version 1.x.x is API compatible with the most recent PEG.js release.
+Follow these steps to upgrade:
+
+1. Uninstall `pegjs` (and `@types/pegjs` if you're using the DefinitelyTyped type definitions - we now include type definitions as part of peggy itself).
+2. Replace all `require("pegjs")` or `import ... from "pegjs"` with `require("peggy")` or `import ... from "peggy"` as appropriate.
+3. Any scripts that use the `pegjs` cli should now use `peggy` instead.
+4. That's it!
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peggy",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "description": "Parser generator for JavaScript",
   "keywords": [
     "parser generator",


### PR DESCRIPTION
Small changes to the README to make clear that we're a fork of PEG.js, also increments the version number to 1.0.0