### PR TITLE
Add `grammarSource` option and new `source` key to the location information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ Change Log
 
 This file documents all notable changes to Peggy.
 
+1.2.0
+-----
+
+Released: TBD
+
+### Minor Changes
+
+- `location()`s now will have additional `source` property which value is taken
+  from the `options.grammarSource` property. That property can contain arbitrary
+  data,for example, path to the currently parsed file.
+  [@Mingun](https://github.com/peggyjs/peggy/pull/95)
+
 1.1.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ object to `peg.generate`. The following options are supported:
   (default: `"parser"`)
 - `plugins` — plugins to use
 - `trace` — makes the parser trace its progress (default: `false`)
+- `grammarSource` — this object will be passed to any `location()` objects as the
+  `source` property (default: `undefined`). This object will be used even if
+  `options.grammarSource` would be redefined in the grammar. It is usefull to attach
+  the file information to the errors, for example
 
 ## Using the Parser
 
@@ -401,6 +405,7 @@ The code inside the predicate can also access location information using the
 
 ```javascript
 {
+  source: options.grammarSource,
   start: { offset: 23, line: 5, column: 6 },
   end: { offset: 23, line: 5, column: 6 }
 }
@@ -432,6 +437,7 @@ The code inside the predicate can also access location information using the
 
 ```javascript
 {
+  source: options.grammarSource,
   start: { offset: 23, line: 5, column: 6 },
   end: { offset: 23, line: 5, column: 6 }
 }
@@ -512,6 +518,7 @@ The code inside the action can also access location information using the
 
 ```javascript
 {
+  source: options.grammarSource,
   start: { offset: 23, line: 5, column: 6 },
   end: { offset: 25, line: 5, column: 8 }
 }

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ object to `peg.generate`. The following options are supported:
 - `trace` — makes the parser trace its progress (default: `false`)
 - `grammarSource` — this object will be passed to any `location()` objects as the
   `source` property (default: `undefined`). This object will be used even if
-  `options.grammarSource` would be redefined in the grammar. It is usefull to attach
+  `options.grammarSource` is redefined in the grammar. It is useful to attach
   the file information to the errors, for example
 
 ## Using the Parser

--- a/bin/peggy
+++ b/bin/peggy
@@ -106,6 +106,8 @@ let inputFile = null;
 let outputFile = null;
 
 let options = {
+  // Path to the grammar file
+  grammarSource: null,
   cache: false,
   dependencies: {},
   exportVar: null,
@@ -297,6 +299,7 @@ if (inputFile === "-") {
     abort("Can't read from file \"" + inputFile + "\".");
   });
 } else {
+  options.grammarSource = inputFile;
   inputStream = fs.createReadStream(inputFile);
 }
 

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -232,9 +232,9 @@ supported:</p>
   <code>"source"</code> (default: <code>"bare"</code>).</dd>
 
   <dt><code>grammarSource</code></dt>
-  <dd>any object that represent origin of the input grammar. CLI would set
-  in to the string with the path to the file; parser in the network application
-  could use the socket and so on. Supplied object will be available at key
+  <dd>any object that represent origin of the input grammar. The CLI will set
+  it to a string with the path to the file; parsers in network applications
+  might use the socket and so on. The supplied object will be available at key
   <code>source</code> in the location objects, that returned by the
   <code>location()</code> API function (default: <code>undefined</code>).</dd>
 

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -231,6 +231,13 @@ supported:</p>
   <code>"umd"</code>); valid only when <code>output</code> is set to
   <code>"source"</code> (default: <code>"bare"</code>).</dd>
 
+  <dt><code>grammarSource</code></dt>
+  <dd>any object that represent origin of the input grammar. CLI would set
+  in to the string with the path to the file; parser in the network application
+  could use the socket and so on. Supplied object will be available at key
+  <code>source</code> in the location objects, that returned by the
+  <code>location()</code> API function (default: <code>undefined</code>).</dd>
+
   <dt><code>optimize</code></dt>
   <dd>Selects between optimizing the generated parser for parsing speed
   (<code>"speed"</code>) or code size (<code>"size"</code>) (default:

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -966,6 +966,7 @@ function generateJS(ast, options) {
       "  options = options !== undefined ? options : {};",
       "",
       "  var peg$FAILED = {};",
+      "  var peg$source = options.grammarSource;",
       ""
     ].join("\n"));
 
@@ -1155,6 +1156,7 @@ function generateJS(ast, options) {
       "    var endPosDetails = peg$computePosDetails(endPos);",
       "",
       "    return {",
+      "      source: peg$source,",
       "      start: {",
       "        offset: startPos,",
       "        line: startPosDetails.line,",

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -159,6 +159,7 @@ function peg$parse(input, options) {
   options = options !== undefined ? options : {};
 
   var peg$FAILED = {};
+  var peg$source = options.grammarSource;
 
   var peg$startRuleFunctions = { Grammar: peg$parseGrammar };
   var peg$startRuleFunction = peg$parseGrammar;
@@ -633,6 +634,7 @@ function peg$parse(input, options) {
     var endPosDetails = peg$computePosDetails(endPos);
 
     return {
+      source: peg$source,
       start: {
         offset: startPos,
         line: startPosDetails.line,

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -10,6 +10,8 @@ declare namespace PEG {
   }
 
   interface LocationRange {
+    /** Any object that was supplied to the `parse()` call as the `grammarSource` option. */
+    source: any;
     start: Location;
     end: Location;
   }
@@ -48,6 +50,12 @@ export type GrammarError = PeggyError;
 export var GrammarError: any;
 
 export interface ParserOptions {
+  /**
+   * Object that will be attached to the each `LocationRange` object created by
+   * the parser. For example, this can be path to the parsed file or even the
+   * File object.
+   */
+  grammarSource?: any;
   startRule?: string;
   tracer?: ParserTracer;
   [key: string]: any;
@@ -73,6 +81,12 @@ export interface BuildOptionsBase {
   allowedStartRules?: string[];
   /** if `true`, makes the parser cache results, avoiding exponential parsing time in pathological cases but making the parser slower (default: `false`) */
   cache?: boolean;
+  /**
+   * Object that will be attached to the each `LocationRange` object created by
+   * the parser. For example, this can be path to the parsed file or even the
+   * File object.
+   */
+  grammarSource?: any;
   /** selects between optimizing the generated parser for parsing speed (`"speed"`) or code size (`"size"`) (default: `"speed"`) */
   optimize?: "speed" | "size";
   /** plugins to use */

--- a/lib/peg.js
+++ b/lib/peg.js
@@ -44,7 +44,7 @@ const peg = {
     plugins.forEach(p => { p.use(config, options); });
 
     return peg.compiler.compile(
-      config.parser.parse(grammar),
+      config.parser.parse(grammar, { grammarSource: options.grammarSource }),
       config.passes,
       options
     );

--- a/test/api/generated-parser-api.spec.js
+++ b/test/api/generated-parser-api.spec.js
@@ -95,6 +95,7 @@ describe("generated parser API", function() {
                 type: "rule.enter",
                 rule: "start",
                 location: {
+                  source: undefined,
                   start: { offset: 0, line: 1, column: 1 },
                   end: { offset: 0, line: 1, column: 1 }
                 }
@@ -103,6 +104,7 @@ describe("generated parser API", function() {
                 type: "rule.enter",
                 rule: "a",
                 location: {
+                  source: undefined,
                   start: { offset: 0, line: 1, column: 1 },
                   end: { offset: 0, line: 1, column: 1 }
                 }
@@ -111,6 +113,7 @@ describe("generated parser API", function() {
                 type: "rule.fail",
                 rule: "a",
                 location: {
+                  source: undefined,
                   start: { offset: 0, line: 1, column: 1 },
                   end: { offset: 0, line: 1, column: 1 }
                 }
@@ -119,6 +122,7 @@ describe("generated parser API", function() {
                 type: "rule.enter",
                 rule: "b",
                 location: {
+                  source: undefined,
                   start: { offset: 0, line: 1, column: 1 },
                   end: { offset: 0, line: 1, column: 1 }
                 }
@@ -128,6 +132,7 @@ describe("generated parser API", function() {
                 rule: "b",
                 result: "b",
                 location: {
+                  source: undefined,
                   start: { offset: 0, line: 1, column: 1 },
                   end: { offset: 1, line: 1, column: 2 }
                 }
@@ -137,6 +142,7 @@ describe("generated parser API", function() {
                 rule: "start",
                 result: "b",
                 location: {
+                  source: undefined,
                   start: { offset: 0, line: 1, column: 1 },
                   end: { offset: 1, line: 1, column: 2 }
                 }

--- a/test/behavior/generated-parser-behavior.spec.js
+++ b/test/behavior/generated-parser-behavior.spec.js
@@ -567,16 +567,19 @@ describe("generated parser behavior", function() {
           ].join("\n"), options);
 
           expect(parser).to.parse("1\n2\n\n3\n\n\n4 5 x", {
+            source: undefined,
             start: { offset: 13, line: 7, column: 5 },
             end: { offset: 13, line: 7, column: 5 }
           });
 
           // Newline representations
           expect(parser).to.parse("1\nx", {     // Unix
+            source: undefined,
             start: { offset: 2, line: 2, column: 1 },
             end: { offset: 2, line: 2, column: 1 }
           });
           expect(parser).to.parse("1\r\nx", {   // Windows
+            source: undefined,
             start: { offset: 3, line: 2, column: 1 },
             end: { offset: 3, line: 2, column: 1 }
           });
@@ -760,16 +763,19 @@ describe("generated parser behavior", function() {
           ].join("\n"), options);
 
           expect(parser).to.parse("1\n2\n\n3\n\n\n4 5 x", {
+            source: undefined,
             start: { offset: 13, line: 7, column: 5 },
             end: { offset: 13, line: 7, column: 5 }
           });
 
           // Newline representations
           expect(parser).to.parse("1\nx", {     // Unix
+            source: undefined,
             start: { offset: 2, line: 2, column: 1 },
             end: { offset: 2, line: 2, column: 1 }
           });
           expect(parser).to.parse("1\r\nx", {   // Windows
+            source: undefined,
             start: { offset: 3, line: 2, column: 1 },
             end: { offset: 3, line: 2, column: 1 }
           });
@@ -1183,16 +1189,19 @@ describe("generated parser behavior", function() {
             ].join("\n"), options);
 
             expect(parser).to.parse("1\n2\n\n3\n\n\n4 5 x", {
+              source: undefined,
               start: { offset: 13, line: 7, column: 5 },
               end: { offset: 14, line: 7, column: 6 }
             });
 
             // Newline representations
             expect(parser).to.parse("1\nx", {     // Unix
+              source: undefined,
               start: { offset: 2, line: 2, column: 1 },
               end: { offset: 3, line: 2, column: 2 }
             });
             expect(parser).to.parse("1\r\nx", {   // Windows
+              source: undefined,
               start: { offset: 3, line: 2, column: 1 },
               end: { offset: 4, line: 2, column: 2 }
             });
@@ -1210,6 +1219,7 @@ describe("generated parser behavior", function() {
                 expected: [{ type: "other", description: "a" }],
                 found: "a",
                 location: {
+                  source: undefined,
                   start: { offset: 0, line: 1, column: 1 },
                   end: { offset: 1, line: 1, column: 2 }
                 }
@@ -1250,6 +1260,7 @@ describe("generated parser behavior", function() {
                 found: null,
                 expected: null,
                 location: {
+                  source: undefined,
                   start: { offset: 0, line: 1, column: 1 },
                   end: { offset: 1, line: 1, column: 2 }
                 }
@@ -1437,6 +1448,7 @@ describe("generated parser behavior", function() {
 
           expect(parser).to.failToParse("", {
             location: {
+              source: undefined,
               start: { offset: 0, line: 1, column: 1 },
               end: { offset: 0, line: 1, column: 1 }
             }
@@ -1448,6 +1460,7 @@ describe("generated parser behavior", function() {
 
           expect(parser).to.failToParse("b", {
             location: {
+              source: undefined,
               start: { offset: 0, line: 1, column: 1 },
               end: { offset: 1, line: 1, column: 2 }
             }
@@ -1459,6 +1472,7 @@ describe("generated parser behavior", function() {
 
           expect(parser).to.failToParse("aa", {
             location: {
+              source: undefined,
               start: { offset: 1, line: 1, column: 2 },
               end: { offset: 2, line: 1, column: 3 }
             }
@@ -1475,6 +1489,7 @@ describe("generated parser behavior", function() {
 
           expect(parser).to.failToParse("1\n2\n\n3\n\n\n4 5 x", {
             location: {
+              source: undefined,
               start: { offset: 13, line: 7, column: 5 },
               end: { offset: 14, line: 7, column: 6 }
             }
@@ -1483,16 +1498,36 @@ describe("generated parser behavior", function() {
           // Newline representations
           expect(parser).to.failToParse("1\nx", {     // Old Mac
             location: {
+              source: undefined,
               start: { offset: 2, line: 2, column: 1 },
               end: { offset: 3, line: 2, column: 2 }
             }
           });
           expect(parser).to.failToParse("1\r\nx", {   // Windows
             location: {
+              source: undefined,
               start: { offset: 3, line: 2, column: 1 },
               end: { offset: 4, line: 2, column: 2 }
             }
           });
+        });
+
+        it("reports location source correctly", function() {
+          const source = { source: "object" };
+          const parser = peg.generate([
+            "start = line (nl+ line)*",
+            "line = digit (' '+ digit)*",
+            "digit = [0-9]",
+            "nl = '\\r'? '\\n'"
+          ].join("\n"), options);
+
+          expect(parser).to.failToParse("1\n2\n\n3\n\n\n4 5 x", {
+            location: {
+              source,
+              start: { offset: 13, line: 7, column: 5 },
+              end: { offset: 14, line: 7, column: 6 }
+            }
+          }, { grammarSource: source });
         });
       });
     });

--- a/test/unit/compiler/passes/report-duplicate-labels.spec.js
+++ b/test/unit/compiler/passes/report-duplicate-labels.spec.js
@@ -14,6 +14,7 @@ describe("compiler pass |reportDuplicateLabels|", function() {
       expect(pass).to.reportError("start = a:'a' a:'a'", {
         message: "Label \"a\" is already defined at line 1, column 9.",
         location: {
+          source: undefined,
           start: { offset: 14, line: 1, column: 15 },
           end: { offset: 19, line: 1, column: 20 }
         }
@@ -46,6 +47,7 @@ describe("compiler pass |reportDuplicateLabels|", function() {
       expect(pass).to.reportError("start = a:'a' (a:'a')", {
         message: "Label \"a\" is already defined at line 1, column 9.",
         location: {
+          source: undefined,
           start: { offset: 15, line: 1, column: 16 },
           end: { offset: 20, line: 1, column: 21 }
         }

--- a/test/unit/compiler/passes/report-duplicate-rules.spec.js
+++ b/test/unit/compiler/passes/report-duplicate-rules.spec.js
@@ -16,6 +16,7 @@ describe("compiler pass |reportDuplicateRules|", function() {
     ].join("\n"), {
       message: "Rule \"start\" is already defined at line 1, column 1.",
       location: {
+        source: undefined,
         start: { offset: 12, line: 2, column: 1 },
         end: { offset: 23, line: 2, column: 12 }
       }

--- a/test/unit/compiler/passes/report-incorrect-plucking.spec.js
+++ b/test/unit/compiler/passes/report-incorrect-plucking.spec.js
@@ -11,12 +11,18 @@ const expect = chai.expect;
 describe("compiler pass |reportIncorrectPlucking|", function() {
   it("prevents \"@\" from being used with an action block", function() {
     expect(pass).to.reportError("start1 = 'a' @'b' 'c' { /* empty action block */ }", {
-      message: "\"@\" cannot be used with an action block at line 1, column 14."
+      message: "\"@\" cannot be used with an action block at line 1, column 14.",
+      location: {
+        source: undefined,
+        start: { offset: 13, line: 1, column: 14 },
+        end: { offset: 17, line: 1, column: 18 }
+      }
     });
 
     expect(pass).to.reportError("start2 = 'a' @('b' @'c' { /* empty action block */ })", {
       message: "\"@\" cannot be used with an action block at line 1, column 20.",
       location: {
+        source: undefined,
         start: { offset: 19, line: 1, column: 20 },
         end: { offset: 23, line: 1, column: 24 }
       }

--- a/test/unit/compiler/passes/report-infinite-recursion.spec.js
+++ b/test/unit/compiler/passes/report-infinite-recursion.spec.js
@@ -13,6 +13,7 @@ describe("compiler pass |reportInfiniteRecursion|", function() {
     expect(pass).to.reportError("start = start", {
       message: "Possible infinite loop when parsing (left recursion: start -> start).",
       location: {
+        source: undefined,
         start: { offset: 8, line: 1, column: 9 },
         end: { offset: 13, line: 1, column: 14 }
       }
@@ -26,6 +27,7 @@ describe("compiler pass |reportInfiniteRecursion|", function() {
     ].join("\n"), {
       message: "Possible infinite loop when parsing (left recursion: start -> stop -> start).",
       location: {
+        source: undefined,
         start: { offset: 20, line: 2, column: 8 },
         end: { offset: 25, line: 2, column: 13 }
       }

--- a/test/unit/compiler/passes/report-infinite-repetition.spec.js
+++ b/test/unit/compiler/passes/report-infinite-repetition.spec.js
@@ -13,6 +13,7 @@ describe("compiler pass |reportInfiniteRepetition|", function() {
     expect(pass).to.reportError("start = ('')*", {
       message: "Possible infinite loop when parsing (repetition used with an expression that may not consume any input).",
       location: {
+        source: undefined,
         start: { offset: 8, line: 1, column: 9 },
         end: { offset: 13, line: 1, column: 14 }
       }
@@ -23,6 +24,7 @@ describe("compiler pass |reportInfiniteRepetition|", function() {
     expect(pass).to.reportError("start = ('')+", {
       message: "Possible infinite loop when parsing (repetition used with an expression that may not consume any input).",
       location: {
+        source: undefined,
         start: { offset: 8, line: 1, column: 9 },
         end: { offset: 13, line: 1, column: 14 }
       }

--- a/test/unit/compiler/passes/report-undefined-rules.spec.js
+++ b/test/unit/compiler/passes/report-undefined-rules.spec.js
@@ -13,6 +13,7 @@ describe("compiler pass |reportUndefinedRules|", function() {
     expect(pass).to.reportError("start = undefined", {
       message: "Rule \"undefined\" is not defined.",
       location: {
+        source: undefined,
         start: { offset: 8, line: 1, column: 9 },
         end: { offset: 17, line: 1, column: 18 }
       }


### PR DESCRIPTION
This is the first step to the `import` feature.

New option allows to specify source location information and in the future will help to distinguish errors from different files when import other grammars will be supported.

I'll plan to move from WIP status after #89 will be merged. Now you can comment on overall design.