### PR TITLE
Ignore non-npm lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 browser/*
 examples/*.js
 node_modules/
+pnpm-lock.yaml
+yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,5 @@ src
 test
 tools
 .vscode/
+pnpm-lock.yaml
+yarn.lock


### PR DESCRIPTION
Just in case someone likes using pnpm or yarn, don't pollute the repo or the build.