### PR TITLE
Fixes typo: general initializer => global initializer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ object to `peg.generate`. The following options are supported:
   variables used to access the dependencies in the parser to module IDs used
   to load them; valid only when `format` is set to `"amd"`, `"commonjs"`,
   `"es"`, or `"umd"`. Dependencies variables will be available in both the
-  _general initializer_ and the _per-parse initializer_. Unless the parser is
+  _global initializer_ and the _per-parse initializer_. Unless the parser is
   to be generated in different formats, it is recommended to rather import
   dependencies from within the _global initializer_. (default: `{}`)
 - `exportVar` — name of a global variable into which the parser object is

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -213,7 +213,7 @@ supported:</p>
   access the dependencies in the parser to module IDs used to load them; valid
   only when <code>format</code> is set to <code>"amd"</code>,
   <code>"commonjs"</code>, <code>"es"</code>, or <code>"umd"</code>.
-  Dependencies variables will be available in both the <em>general
+  Dependencies variables will be available in both the <em>global
   initializer</em> and the <em>per-parse initializer</em>. Unless the parser is
   to be generated in different formats, it is recommended to rather import
   dependencies from within the <em>global initializer</em> (default:


### PR DESCRIPTION
That's what happens when you write documentation too fast and late at night ;)