### PR TITLE
Add eslint dev dependency and add lint step to the CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -37,5 +37,7 @@ jobs:
         with:
           version: 5.18.9
           run_install: true
+      - name: Lint ${{ matrix.node-version }}
+        run: npm run lint
       - name: Test ${{ matrix.node-version }}
         run: npm run test:bare

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babelify": "10.0.0",
     "browserify": "17.0.0",
     "chai": "4.3.4",
+    "eslint": "^7.24.0",
     "express": "4.17.1",
     "mocha": "^8.3.2",
     "morgan": "1.10.0",


### PR DESCRIPTION
While @StoneCypher is working on upgrading build infrastructure this stop-gap solution should catch silly mistakes