### PR TITLE
Fix running npm task `parser` for Windows users

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postbrowser:build": "tools/header browser/* && cp browser/peggy.min.js docs/vendor/peggy/peggy.min.js",
     "benchmark:build": "browserify benchmark/browser.stub.js -o docs/js/benchmark-bundle.min.js && tools/header docs/js/benchmark-bundle.min.js",
     "test:build": "browserify test/browser.stub.js -o docs/js/test-bundle.min.js && tools/header docs/js/test-bundle.min.js",
-    "parser": "bin/peggy -o lib/parser.js --format commonjs src/parser.pegjs"
+    "parser": "node bin/peggy -o lib/parser.js --format commonjs src/parser.pegjs"
   },
   "devDependencies": {
     "@babel/core": "^7.13.16",


### PR DESCRIPTION
This should fix most important part of #94, because without it I can't normally test my changes. Upgrading infrastructure can take some time, so if this will not break linux builds, could it be merged?