### PR TITLE
Optimize redundant fail checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ Released: TBD
 
   By default this new option contains an array with [reserved JavaScript words][reserved]
   [@Mingun](https://github.com/peggyjs/peggy/pull/150)
+- Several optimizations in the generator. Generated parsers should now be faster and smaller
+  [@Mingun](https://github.com/peggyjs/peggy/pull/118)
 
 [reserved]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_keywords_as_of_ecmascript_2015
 

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -39,22 +39,22 @@ const compiler = {
   // or modify it as needed. If the pass encounters a semantic error, it throws
   // |peg.GrammarError|.
   passes: {
-    check: {
+    check: [
       reportUndefinedRules,
       reportDuplicateRules,
       reportDuplicateLabels,
       reportInfiniteRecursion,
       reportInfiniteRepetition,
       reportIncorrectPlucking
-    },
-    transform: {
+    ],
+    transform: [
       removeProxyRules,
       inferenceMatchResult,
-    },
-    generate: {
+    ],
+    generate: [
       generateBytecode,
       generateJS
-    }
+    ]
   },
 
   // Generates a parser from a specified grammar AST. Throws |peg.GrammarError|

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -2,6 +2,7 @@
 
 const generateBytecode = require("./passes/generate-bytecode");
 const generateJS = require("./passes/generate-js");
+const inferenceMatchResult = require("./passes/inference-match-result");
 const removeProxyRules = require("./passes/remove-proxy-rules");
 const reportDuplicateLabels = require("./passes/report-duplicate-labels");
 const reportDuplicateRules = require("./passes/report-duplicate-rules");
@@ -47,7 +48,8 @@ const compiler = {
       reportIncorrectPlucking
     },
     transform: {
-      removeProxyRules
+      removeProxyRules,
+      inferenceMatchResult,
     },
     generate: {
       generateBytecode,

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -3,6 +3,7 @@
 const asts = require("../asts");
 const op = require("../opcodes");
 const visitor = require("../visitor");
+const { ALWAYS_MATCH, SOMETIMES_MATCH, NEVER_MATCH } = require("./inference-match-result");
 
 // Generates bytecode.
 //
@@ -195,6 +196,27 @@ const visitor = require("../visitor");
 // [29] SILENT_FAILS_OFF
 //
 //        silentFails--;
+//
+// This pass can use the results of other previous passes, each of which can
+// change the AST (and, as consequence, the bytecode).
+//
+// In particular, if the pass |inferenceMatchResult| has been run before this pass,
+// then each AST node will contain a |match| property, which represents a possible
+// match result of the node:
+// - `<0` - node is never matched, for example, `!('a'*)` (negation of the always
+//          matched node). Generator can put |FAILED| to the stack immediately
+// - `=0` - sometimes node matched, sometimes not. This is the same behavior
+//          when |match| is missed
+// - `>0` - node is always matched, for example, `'a'*` (because result is an
+//          empty array, or an array with some elements). The generator does not
+//          need to add a check for |FAILED|, because it is impossible
+//
+// To handle the situation, when the |inferenceMatchResult| has not run (that
+// happens, for example, in tests), the |match| value extracted using the
+// `|0` trick, which performing cast of any value to an integer with value `0`
+// that is equivalent of an unknown match result and signals the generator that
+// runtime check for the |FAILED| is required. Trick is explained on the
+// Wikipedia page (https://en.wikipedia.org/wiki/Asm.js#Code_generation)
 function generateBytecode(ast) {
   const literals = [];
   const classes = [];
@@ -248,7 +270,10 @@ function generateBytecode(ast) {
     return first.concat(...args);
   }
 
-  function buildCondition(condCode, thenCode, elseCode) {
+  function buildCondition(match, condCode, thenCode, elseCode) {
+    if (match === ALWAYS_MATCH) { return thenCode; }
+    if (match === NEVER_MATCH)  { return elseCode; }
+
     return condCode.concat(
       [thenCode.length, elseCode.length],
       thenCode,
@@ -267,6 +292,8 @@ function generateBytecode(ast) {
   }
 
   function buildSimplePredicate(expression, negative, context) {
+    const match = expression.match | 0;
+
     return buildSequence(
       [op.PUSH_CURR_POS],
       [op.SILENT_FAILS_ON],
@@ -277,6 +304,7 @@ function generateBytecode(ast) {
       }),
       [op.SILENT_FAILS_OFF],
       buildCondition(
+        negative ? -match : match,
         [negative ? op.IF_ERROR : op.IF_NOT_ERROR],
         buildSequence(
           [op.POP],
@@ -292,15 +320,16 @@ function generateBytecode(ast) {
     );
   }
 
-  function buildSemanticPredicate(code, negative, context) {
+  function buildSemanticPredicate(node, negative, context) {
     const functionIndex = addFunctionConst(
-      true, Object.keys(context.env), code
+      true, Object.keys(context.env), node.code
     );
 
     return buildSequence(
       [op.UPDATE_SAVED_POS],
       buildCall(functionIndex, 0, context.env, context.sp),
       buildCondition(
+        node.match | 0,
         [op.IF],
         buildSequence(
           [op.POP],
@@ -341,7 +370,11 @@ function generateBytecode(ast) {
     },
 
     named(node, context) {
-      const nameIndex = addExpectedConst({ type: "rule", value: node.name });
+      const match = node.match | 0;
+      // Expectation not required if node always fail
+      const nameIndex = match === NEVER_MATCH ? null : addExpectedConst(
+        { type: "rule", value: node.name }
+      );
 
       // The code generated below is slightly suboptimal because |FAIL| pushes
       // to the stack, so we need to stick a |POP| in front of it. We lack a
@@ -351,20 +384,34 @@ function generateBytecode(ast) {
         [op.SILENT_FAILS_ON],
         generate(node.expression, context),
         [op.SILENT_FAILS_OFF],
-        buildCondition([op.IF_ERROR], [op.FAIL, nameIndex], [])
+        buildCondition(match, [op.IF_ERROR], [op.FAIL, nameIndex], [])
       );
     },
 
     choice(node, context) {
       function buildAlternativesCode(alternatives, context) {
+        const match = alternatives[0].match | 0;
+        const first = generate(alternatives[0], {
+          sp: context.sp,
+          env: cloneEnv(context.env),
+          action: null
+        });
+        // If an alternative always match, no need to generate code for the next
+        // alternatives. Because their will never tried to match, any side-effects
+        // from next alternatives is impossible so we can skip their generation
+        if (match === ALWAYS_MATCH) {
+          return first;
+        }
+
+        // Even if an alternative never match it can have side-effects from
+        // a semantic predicates or an actions, so we can not skip generation
+        // of the first alternative.
+        // We can do that when analysis for possible side-effects will be introduced
         return buildSequence(
-          generate(alternatives[0], {
-            sp: context.sp,
-            env: cloneEnv(context.env),
-            action: null
-          }),
+          first,
           alternatives.length > 1
             ? buildCondition(
+                SOMETIMES_MATCH,
                 [op.IF_ERROR],
                 buildSequence(
                   [op.POP],
@@ -382,21 +429,24 @@ function generateBytecode(ast) {
     action(node, context) {
       const env = cloneEnv(context.env);
       const emitCall = node.expression.type !== "sequence"
-                  || node.expression.elements.length === 0;
+                    || node.expression.elements.length === 0;
       const expressionCode = generate(node.expression, {
         sp: context.sp + (emitCall ? 1 : 0),
         env,
         action: node
       });
-      const functionIndex = addFunctionConst(
-        false, Object.keys(env), node.code
-      );
+      const match = node.expression.match | 0;
+      // Function only required if expression can match
+      const functionIndex = emitCall && match !== NEVER_MATCH
+        ? addFunctionConst(false, Object.keys(env), node.code)
+        : null;
 
       return emitCall
         ? buildSequence(
             [op.PUSH_CURR_POS],
             expressionCode,
             buildCondition(
+              match,
               [op.IF_NOT_ERROR],
               buildSequence(
                 [op.LOAD_SAVED_POS, 1],
@@ -412,8 +462,7 @@ function generateBytecode(ast) {
     sequence(node, context) {
       function buildElementsCode(elements, context) {
         if (elements.length > 0) {
-          const processedCount
-            = node.elements.length - elements.slice(1).length;
+          const processedCount = node.elements.length - elements.length + 1;
 
           return buildSequence(
             generate(elements[0], {
@@ -423,6 +472,7 @@ function generateBytecode(ast) {
               action: null
             }),
             buildCondition(
+              elements[0].match | 0,
               [op.IF_NOT_ERROR],
               buildElementsCode(elements.slice(1), {
                 sp: context.sp + 1,
@@ -508,6 +558,7 @@ function generateBytecode(ast) {
           action: null
         }),
         buildCondition(
+          node.match | 0,
           [op.IF_NOT_ERROR],
           buildSequence([op.POP], [op.TEXT]),
           [op.NIP]
@@ -531,6 +582,10 @@ function generateBytecode(ast) {
           action: null
         }),
         buildCondition(
+          // Check expression match, not the node match
+          // If expression always match, no need to replace FAILED to NULL,
+          // because FAILED will never appeared
+          -(node.expression.match | 0),
           [op.IF_ERROR],
           buildSequence([op.POP], [op.PUSH_NULL]),
           []
@@ -564,6 +619,8 @@ function generateBytecode(ast) {
         [op.PUSH_EMPTY_ARRAY],
         expressionCode,
         buildCondition(
+          // Condition depends on the expression match, not the node match
+          node.expression.match | 0,
           [op.IF_NOT_ERROR],
           buildSequence(buildAppendLoop(expressionCode), [op.POP]),
           buildSequence([op.POP], [op.POP], [op.PUSH_FAILED])
@@ -580,11 +637,11 @@ function generateBytecode(ast) {
     },
 
     semantic_and(node, context) {
-      return buildSemanticPredicate(node.code, false, context);
+      return buildSemanticPredicate(node, false, context);
     },
 
     semantic_not(node, context) {
-      return buildSemanticPredicate(node.code, true, context);
+      return buildSemanticPredicate(node, true, context);
     },
 
     rule_ref(node) {
@@ -593,19 +650,26 @@ function generateBytecode(ast) {
 
     literal(node) {
       if (node.value.length > 0) {
-        const stringIndex = addLiteralConst(
+        const match = node.match | 0;
+        // String only required if condition is generated or string is
+        // case-sensitive and node always match
+        const needConst = match === SOMETIMES_MATCH
+                      || (match === ALWAYS_MATCH && !node.ignoreCase);
+        const stringIndex = needConst ? addLiteralConst(
           node.ignoreCase ? node.value.toLowerCase() : node.value
-        );
-        const expectedIndex = addExpectedConst({
+        ) : null;
+        // Expectation not required if node always match
+        const expectedIndex = match !== ALWAYS_MATCH ? addExpectedConst({
           type: "literal",
           value: node.value,
           ignoreCase: node.ignoreCase
-        });
+        }) : null;
 
         // For case-sensitive strings the value must match the beginning of the
         // remaining input exactly. As a result, we can use |ACCEPT_STRING| and
         // save one |substr| call that would be needed if we used |ACCEPT_N|.
         return buildCondition(
+          match,
           node.ignoreCase
             ? [op.MATCH_STRING_IC, stringIndex]
             : [op.MATCH_STRING, stringIndex],
@@ -620,25 +684,34 @@ function generateBytecode(ast) {
     },
 
     class(node) {
-      const classIndex = addClassConst(node);
-      const expectedIndex = addExpectedConst({
+      const match = node.match | 0;
+      // Character class constant only required if condition is generated
+      const classIndex = match === SOMETIMES_MATCH ? addClassConst(node) : null;
+      // Expectation not required if node always match
+      const expectedIndex = match !== ALWAYS_MATCH ? addExpectedConst({
         type: "class",
         value: node.parts,
         inverted: node.inverted,
         ignoreCase: node.ignoreCase
-      });
+      }) : null;
 
       return buildCondition(
+        match,
         [op.MATCH_CHAR_CLASS, classIndex],
         [op.ACCEPT_N, 1],
         [op.FAIL, expectedIndex]
       );
     },
 
-    any() {
-      const expectedIndex = addExpectedConst({ type: "any" });
+    any(node) {
+      const match = node.match | 0;
+      // Expectation not required if node always match
+      const expectedIndex = match !== ALWAYS_MATCH ? addExpectedConst({
+        type: "any"
+      }) : null;
 
       return buildCondition(
+        match,
         [op.MATCH_ANY],
         [op.ACCEPT_N, 1],
         [op.FAIL, expectedIndex]

--- a/lib/compiler/passes/inference-match-result.js
+++ b/lib/compiler/passes/inference-match-result.js
@@ -59,6 +59,14 @@ function inferenceMatchResult(ast) {
           // 6 == 3! -- permutations count for all transitions from one match
           // state to another.
           // After 6 iterations the cycle with guarantee begins
+          // For example, an input of `start = [] start` will generate the
+          // sequence: 0 -> -1 -> -1 (then stop)
+          //
+          // A more complex grammar theoretically would generate the
+          // sequence: 0 -> 1 -> 0 -> -1 -> 0 -> 1 -> ... (then cycle)
+          // but there are no examples of such grammars yet (possible, they
+          // do not exist at all)
+
           // istanbul ignore next  This is canary test, shouldn't trigger in real life
           if (++count > 6) {
             throw new GrammarError(

--- a/lib/compiler/passes/inference-match-result.js
+++ b/lib/compiler/passes/inference-match-result.js
@@ -1,0 +1,122 @@
+"use strict";
+
+const visitor      = require("../visitor");
+const asts         = require("../asts");
+const GrammarError = require("../../grammar-error");
+
+const ALWAYS_MATCH = 1;
+const SOMETIMES_MATCH = 0;
+const NEVER_MATCH = -1;
+
+// Inference match result of the each node. Can be:
+// -1: negative result, matching of that node always fails
+//  0: neutral result, may be fail, may be match
+//  1: positive result, always match
+function inferenceMatchResult(ast) {
+  function sometimesMatch(node) { return (node.match = SOMETIMES_MATCH); }
+  function alwaysMatch(node) {
+    inference(node.expression);
+
+    return (node.match = ALWAYS_MATCH);
+  }
+
+  function inferenceExpression(node) {
+    return (node.match = inference(node.expression));
+  }
+  function inferenceElements(elements, forChoice) {
+    const length = elements.length;
+    let always = 0;
+    let never = 0;
+
+    for (let i = 0; i < length; ++i) {
+      const result = inference(elements[i]);
+
+      if (result === ALWAYS_MATCH) { ++always; }
+      if (result === NEVER_MATCH)  { ++never;  }
+    }
+
+    if (always === length) {
+      return ALWAYS_MATCH;
+    }
+    if (forChoice) {
+      return never === length ? NEVER_MATCH : SOMETIMES_MATCH;
+    }
+
+    return never > 0 ? NEVER_MATCH : SOMETIMES_MATCH;
+  }
+
+  const inference = visitor.build({
+    rule(node) {
+      let oldResult;
+      let count = 0;
+
+      // If property not yet calculated, do that
+      if (typeof node.match === "undefined") {
+        node.match = SOMETIMES_MATCH;
+        do {
+          oldResult = node.match;
+          node.match = inference(node.expression);
+          // 6 == 3! -- permutations count for all transitions from one match
+          // state to another.
+          // After 6 iterations the cycle with guarantee begins
+          // istanbul ignore next  This is canary test, shouldn't trigger in real life
+          if (++count > 6) {
+            throw new GrammarError(
+              "Infinity cycle detected when trying to evaluate node match result",
+              node.location
+            );
+          }
+        } while (oldResult !== node.match);
+      }
+
+      return node.match;
+    },
+    named:        inferenceExpression,
+    choice(node) {
+      return (node.match = inferenceElements(node.alternatives, true));
+    },
+    action:       inferenceExpression,
+    sequence(node) {
+      return (node.match = inferenceElements(node.elements, false));
+    },
+    labeled:      inferenceExpression,
+    text:         inferenceExpression,
+    simple_and:   inferenceExpression,
+    simple_not(node) {
+      return (node.match = -inference(node.expression));
+    },
+    optional:     alwaysMatch,
+    zero_or_more: alwaysMatch,
+    one_or_more:  inferenceExpression,
+    group:        inferenceExpression,
+    semantic_and: sometimesMatch,
+    semantic_not: sometimesMatch,
+    rule_ref(node) {
+      const rule = asts.findRule(ast, node.name);
+
+      return (node.match = inference(rule));
+    },
+    literal(node) {
+      // Empty literal always match on any input
+      const match = node.value.length === 0 ? ALWAYS_MATCH : SOMETIMES_MATCH;
+
+      return (node.match = match);
+    },
+    class(node) {
+      // Empty character class never match on any input
+      const match = node.parts.length === 0 ? NEVER_MATCH : SOMETIMES_MATCH;
+
+      return (node.match = match);
+    },
+    // |any| not match on empty input
+    any:          sometimesMatch
+  });
+
+  inference(ast);
+}
+
+inferenceMatchResult.ALWAYS_MATCH    = ALWAYS_MATCH;
+inferenceMatchResult.SOMETIMES_MATCH = SOMETIMES_MATCH;
+inferenceMatchResult.NEVER_MATCH     = NEVER_MATCH;
+
+module.exports = inferenceMatchResult;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -671,94 +671,59 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      s3 = peg$parseTopLevelInitializer();
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s2 = s3;
+    s2 = peg$currPos;
+    s3 = peg$parseTopLevelInitializer();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse__();
+      s2 = s3;
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    if (s2 === peg$FAILED) {
+      s2 = null;
+    }
+    s3 = peg$currPos;
+    s4 = peg$parseInitializer();
+    if (s4 !== peg$FAILED) {
+      s5 = peg$parse__();
+      s3 = s4;
+    } else {
+      peg$currPos = s3;
+      s3 = peg$FAILED;
+    }
+    if (s3 === peg$FAILED) {
+      s3 = null;
+    }
+    s4 = [];
+    s5 = peg$currPos;
+    s6 = peg$parseRule();
+    if (s6 !== peg$FAILED) {
+      s7 = peg$parse__();
+      s5 = s6;
+    } else {
+      peg$currPos = s5;
+      s5 = peg$FAILED;
+    }
+    if (s5 !== peg$FAILED) {
+      while (s5 !== peg$FAILED) {
+        s4.push(s5);
+        s5 = peg$currPos;
+        s6 = peg$parseRule();
+        if (s6 !== peg$FAILED) {
+          s7 = peg$parse__();
+          s5 = s6;
         } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
+          peg$currPos = s5;
+          s5 = peg$FAILED;
         }
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
       }
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$currPos;
-        s4 = peg$parseInitializer();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parse__();
-          if (s5 !== peg$FAILED) {
-            s3 = s4;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-        if (s3 === peg$FAILED) {
-          s3 = null;
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = [];
-          s5 = peg$currPos;
-          s6 = peg$parseRule();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parse__();
-            if (s7 !== peg$FAILED) {
-              s5 = s6;
-            } else {
-              peg$currPos = s5;
-              s5 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s5;
-            s5 = peg$FAILED;
-          }
-          if (s5 !== peg$FAILED) {
-            while (s5 !== peg$FAILED) {
-              s4.push(s5);
-              s5 = peg$currPos;
-              s6 = peg$parseRule();
-              if (s6 !== peg$FAILED) {
-                s7 = peg$parse__();
-                if (s7 !== peg$FAILED) {
-                  s5 = s6;
-                } else {
-                  peg$currPos = s5;
-                  s5 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s5;
-                s5 = peg$FAILED;
-              }
-            }
-          } else {
-            s4 = peg$FAILED;
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s0 = peg$f0(s2, s3, s4);
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+    } else {
+      s4 = peg$FAILED;
+    }
+    if (s4 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s0 = peg$f0(s2, s3, s4);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -842,53 +807,33 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$currPos;
-        s4 = peg$parseStringLiteral();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parse__();
-          if (s5 !== peg$FAILED) {
-            s3 = s4;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-        if (s3 === peg$FAILED) {
-          s3 = null;
-        }
-        if (s3 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 61) {
-            s4 = peg$c2;
-            peg$currPos++;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e2); }
-          }
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parse__();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parseChoiceExpression();
-              if (s6 !== peg$FAILED) {
-                s7 = peg$parseEOS();
-                if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s0 = peg$f3(s1, s3, s6);
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
+      s3 = peg$currPos;
+      s4 = peg$parseStringLiteral();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parse__();
+        s3 = s4;
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      if (s3 === peg$FAILED) {
+        s3 = null;
+      }
+      if (input.charCodeAt(peg$currPos) === 61) {
+        s4 = peg$c2;
+        peg$currPos++;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e2); }
+      }
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parse__();
+        s6 = peg$parseChoiceExpression();
+        if (s6 !== peg$FAILED) {
+          s7 = peg$parseEOS();
+          if (s7 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s0 = peg$f3(s1, s3, s6);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -918,28 +863,18 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 47) {
-          s5 = peg$c3;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e3); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseActionExpression();
-            if (s7 !== peg$FAILED) {
-              s3 = s7;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
+      if (input.charCodeAt(peg$currPos) === 47) {
+        s5 = peg$c3;
+        peg$currPos++;
+      } else {
+        s5 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e3); }
+      }
+      if (s5 !== peg$FAILED) {
+        s6 = peg$parse__();
+        s7 = peg$parseActionExpression();
+        if (s7 !== peg$FAILED) {
+          s3 = s7;
         } else {
           peg$currPos = s3;
           s3 = peg$FAILED;
@@ -952,28 +887,18 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 47) {
-            s5 = peg$c3;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e3); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseActionExpression();
-              if (s7 !== peg$FAILED) {
-                s3 = s7;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
+        if (input.charCodeAt(peg$currPos) === 47) {
+          s5 = peg$c3;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e3); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          s7 = peg$parseActionExpression();
+          if (s7 !== peg$FAILED) {
+            s3 = s7;
           } else {
             peg$currPos = s3;
             s3 = peg$FAILED;
@@ -983,13 +908,8 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f4(s1, s2);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      peg$savedPos = s0;
+      s0 = peg$f4(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1006,14 +926,9 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       s3 = peg$parse__();
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parseCodeBlock();
-        if (s4 !== peg$FAILED) {
-          s2 = s4;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
+      s4 = peg$parseCodeBlock();
+      if (s4 !== peg$FAILED) {
+        s2 = s4;
       } else {
         peg$currPos = s2;
         s2 = peg$FAILED;
@@ -1021,13 +936,8 @@ function peg$parse(input, options) {
       if (s2 === peg$FAILED) {
         s2 = null;
       }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f5(s1, s2);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      peg$savedPos = s0;
+      s0 = peg$f5(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1045,14 +955,9 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseLabeledExpression();
-        if (s5 !== peg$FAILED) {
-          s3 = s5;
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+      s5 = peg$parseLabeledExpression();
+      if (s5 !== peg$FAILED) {
+        s3 = s5;
       } else {
         peg$currPos = s3;
         s3 = peg$FAILED;
@@ -1061,26 +966,16 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseLabeledExpression();
-          if (s5 !== peg$FAILED) {
-            s3 = s5;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
+        s5 = peg$parseLabeledExpression();
+        if (s5 !== peg$FAILED) {
+          s3 = s5;
         } else {
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
       }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f6(s1, s2);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      peg$savedPos = s0;
+      s0 = peg$f6(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1099,15 +994,10 @@ function peg$parse(input, options) {
       if (s2 === peg$FAILED) {
         s2 = null;
       }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parsePrefixedExpression();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f7(s1, s2, s3);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      s3 = peg$parsePrefixedExpression();
+      if (s3 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f7(s1, s2, s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1121,15 +1011,10 @@ function peg$parse(input, options) {
       s1 = peg$parseLabelColon();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parsePrefixedExpression();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s0 = peg$f8(s1, s3);
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
+        s3 = peg$parsePrefixedExpression();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s0 = peg$f8(s1, s3);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1173,21 +1058,16 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c5;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e5); }
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f10(s1);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      if (input.charCodeAt(peg$currPos) === 58) {
+        s3 = peg$c5;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e5); }
+      }
+      if (s3 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f10(s1);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1207,15 +1087,10 @@ function peg$parse(input, options) {
     s1 = peg$parsePrefixedOperator();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseSuffixedExpression();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f11(s1, s3);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      s3 = peg$parseSuffixedExpression();
+      if (s3 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f11(s1, s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1270,15 +1145,10 @@ function peg$parse(input, options) {
     s1 = peg$parsePrimaryExpression();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseSuffixedOperator();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f12(s1, s3);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      s3 = peg$parseSuffixedOperator();
+      if (s3 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f12(s1, s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1349,29 +1219,19 @@ function peg$parse(input, options) {
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
-                if (s2 !== peg$FAILED) {
-                  s3 = peg$parseChoiceExpression();
-                  if (s3 !== peg$FAILED) {
-                    s4 = peg$parse__();
-                    if (s4 !== peg$FAILED) {
-                      if (input.charCodeAt(peg$currPos) === 41) {
-                        s5 = peg$c13;
-                        peg$currPos++;
-                      } else {
-                        s5 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$e13); }
-                      }
-                      if (s5 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s0 = peg$f13(s3);
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
+                s3 = peg$parseChoiceExpression();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parse__();
+                  if (input.charCodeAt(peg$currPos) === 41) {
+                    s5 = peg$c13;
+                    peg$currPos++;
+                  } else {
+                    s5 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$e13); }
+                  }
+                  if (s5 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s0 = peg$f13(s3);
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -1403,44 +1263,29 @@ function peg$parse(input, options) {
       peg$silentFails++;
       s3 = peg$currPos;
       s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$currPos;
-        s6 = peg$parseStringLiteral();
-        if (s6 !== peg$FAILED) {
-          s7 = peg$parse__();
-          if (s7 !== peg$FAILED) {
-            s6 = [s6, s7];
-            s5 = s6;
-          } else {
-            peg$currPos = s5;
-            s5 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s5;
-          s5 = peg$FAILED;
-        }
-        if (s5 === peg$FAILED) {
-          s5 = null;
-        }
-        if (s5 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 61) {
-            s6 = peg$c2;
-            peg$currPos++;
-          } else {
-            s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e2); }
-          }
-          if (s6 !== peg$FAILED) {
-            s4 = [s4, s5, s6];
-            s3 = s4;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+      s5 = peg$currPos;
+      s6 = peg$parseStringLiteral();
+      if (s6 !== peg$FAILED) {
+        s7 = peg$parse__();
+        s6 = [s6, s7];
+        s5 = s6;
+      } else {
+        peg$currPos = s5;
+        s5 = peg$FAILED;
+      }
+      if (s5 === peg$FAILED) {
+        s5 = null;
+      }
+      if (input.charCodeAt(peg$currPos) === 61) {
+        s6 = peg$c2;
+        peg$currPos++;
+      } else {
+        s6 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e2); }
+      }
+      if (s6 !== peg$FAILED) {
+        s4 = [s4, s5, s6];
+        s3 = s4;
       } else {
         peg$currPos = s3;
         s3 = peg$FAILED;
@@ -1474,15 +1319,10 @@ function peg$parse(input, options) {
     s1 = peg$parseSemanticPredicateOperator();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseCodeBlock();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f15(s1, s3);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      s3 = peg$parseCodeBlock();
+      if (s3 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f15(s1, s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1763,21 +1603,16 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       }
-      if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c26) {
-          s3 = peg$c26;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e31); }
-        }
-        if (s3 !== peg$FAILED) {
-          s1 = [s1, s2, s3];
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      if (input.substr(peg$currPos, 2) === peg$c26) {
+        s3 = peg$c26;
+        peg$currPos += 2;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e31); }
+      }
+      if (s3 !== peg$FAILED) {
+        s1 = [s1, s2, s3];
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1872,21 +1707,16 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       }
-      if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c26) {
-          s3 = peg$c26;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e31); }
-        }
-        if (s3 !== peg$FAILED) {
-          s1 = [s1, s2, s3];
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      if (input.substr(peg$currPos, 2) === peg$c26) {
+        s3 = peg$c26;
+        peg$currPos += 2;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e31); }
+      }
+      if (s3 !== peg$FAILED) {
+        s1 = [s1, s2, s3];
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1963,13 +1793,8 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       }
-      if (s2 !== peg$FAILED) {
-        s1 = [s1, s2];
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      s1 = [s1, s2];
+      s0 = s1;
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1991,13 +1816,8 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$parseIdentifierPart();
       }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f16(s1, s2);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      peg$savedPos = s0;
+      s0 = peg$f16(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2145,13 +1965,8 @@ function peg$parse(input, options) {
       if (s2 === peg$FAILED) {
         s2 = null;
       }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f17(s1, s2);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      peg$savedPos = s0;
+      s0 = peg$f17(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2184,21 +1999,16 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$parseDoubleStringCharacter();
       }
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c33;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e41); }
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s0 = peg$f18(s2);
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      if (input.charCodeAt(peg$currPos) === 34) {
+        s3 = peg$c33;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e41); }
+      }
+      if (s3 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f18(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2223,21 +2033,16 @@ function peg$parse(input, options) {
           s2.push(s3);
           s3 = peg$parseSingleStringCharacter();
         }
-        if (s2 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c34;
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e42); }
-          }
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s0 = peg$f18(s2);
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
+        if (input.charCodeAt(peg$currPos) === 39) {
+          s3 = peg$c34;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e42); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s0 = peg$f18(s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2439,53 +2244,38 @@ function peg$parse(input, options) {
       if (s2 === peg$FAILED) {
         s2 = null;
       }
-      if (s2 !== peg$FAILED) {
-        s3 = [];
+      s3 = [];
+      s4 = peg$parseClassCharacterRange();
+      if (s4 === peg$FAILED) {
+        s4 = peg$parseClassCharacter();
+      }
+      while (s4 !== peg$FAILED) {
+        s3.push(s4);
         s4 = peg$parseClassCharacterRange();
         if (s4 === peg$FAILED) {
           s4 = peg$parseClassCharacter();
         }
-        while (s4 !== peg$FAILED) {
-          s3.push(s4);
-          s4 = peg$parseClassCharacterRange();
-          if (s4 === peg$FAILED) {
-            s4 = peg$parseClassCharacter();
-          }
-        }
-        if (s3 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 93) {
-            s4 = peg$c37;
-            peg$currPos++;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e46); }
-          }
-          if (s4 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 105) {
-              s5 = peg$c32;
-              peg$currPos++;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e39); }
-            }
-            if (s5 === peg$FAILED) {
-              s5 = null;
-            }
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s0 = peg$f19(s2, s3, s5);
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
+      }
+      if (input.charCodeAt(peg$currPos) === 93) {
+        s4 = peg$c37;
+        peg$currPos++;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e46); }
+      }
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 105) {
+          s5 = peg$c32;
+          peg$currPos++;
         } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e39); }
         }
+        if (s5 === peg$FAILED) {
+          s5 = null;
+        }
+        peg$savedPos = s0;
+        s0 = peg$f19(s2, s3, s5);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3063,20 +2853,15 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseBareCodeBlock();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 125) {
-          s3 = peg$c1;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e1); }
-        }
-        if (s3 !== peg$FAILED) {
-          s0 = s2;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      if (input.charCodeAt(peg$currPos) === 125) {
+        s3 = peg$c1;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e1); }
+      }
+      if (s3 !== peg$FAILED) {
+        s0 = s2;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3099,10 +2884,8 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$parseCode();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f31(s1);
-    }
+    peg$savedPos = s0;
+    s1 = peg$f31(s1);
     s0 = s1;
 
     return s0;
@@ -3192,21 +2975,16 @@ function peg$parse(input, options) {
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseCode();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 125) {
-            s5 = peg$c1;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e1); }
-          }
-          if (s5 !== peg$FAILED) {
-            s3 = [s3, s4, s5];
-            s2 = s3;
-          } else {
-            peg$currPos = s2;
-            s2 = peg$FAILED;
-          }
+        if (input.charCodeAt(peg$currPos) === 125) {
+          s5 = peg$c1;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e1); }
+        }
+        if (s5 !== peg$FAILED) {
+          s3 = [s3, s4, s5];
+          s2 = s3;
         } else {
           peg$currPos = s2;
           s2 = peg$FAILED;
@@ -3297,21 +3075,16 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseCode();
-          if (s4 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c1;
-              peg$currPos++;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e1); }
-            }
-            if (s5 !== peg$FAILED) {
-              s3 = [s3, s4, s5];
-              s2 = s3;
-            } else {
-              peg$currPos = s2;
-              s2 = peg$FAILED;
-            }
+          if (input.charCodeAt(peg$currPos) === 125) {
+            s5 = peg$c1;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e1); }
+          }
+          if (s5 !== peg$FAILED) {
+            s3 = [s3, s4, s5];
+            s2 = s3;
           } else {
             peg$currPos = s2;
             s2 = peg$FAILED;
@@ -3322,11 +3095,7 @@ function peg$parse(input, options) {
         }
       }
     }
-    if (s1 !== peg$FAILED) {
-      s0 = input.substring(s0, peg$currPos);
-    } else {
-      s0 = s1;
-    }
+    s0 = input.substring(s0, peg$currPos);
 
     return s0;
   }
@@ -3534,21 +3303,16 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c49;
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e73); }
-      }
-      if (s2 !== peg$FAILED) {
-        s1 = [s1, s2];
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+    if (input.charCodeAt(peg$currPos) === 59) {
+      s2 = peg$c49;
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e73); }
+    }
+    if (s2 !== peg$FAILED) {
+      s1 = [s1, s2];
+      s0 = s1;
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -3556,24 +3320,14 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$parse_();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parseSingleLineComment();
-        if (s2 === peg$FAILED) {
-          s2 = null;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseLineTerminatorSequence();
-          if (s3 !== peg$FAILED) {
-            s1 = [s1, s2, s3];
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      s2 = peg$parseSingleLineComment();
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      s3 = peg$parseLineTerminatorSequence();
+      if (s3 !== peg$FAILED) {
+        s1 = [s1, s2, s3];
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3581,15 +3335,10 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         s1 = peg$parse__();
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parseEOF();
-          if (s2 !== peg$FAILED) {
-            s1 = [s1, s2];
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
+        s2 = peg$parseEOF();
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -641,12 +641,6 @@ export namespace compiler {
     function build<F extends NodeTypes>(functions: F): Visitor<F>;
   }
 
-  /** Mapping from the pass name to the function that represents pass. */
-  interface Passes {
-    /** List of passes in the stage. Any concrete set of passes are not guaranteed. */
-    [key: string]: Pass;
-  }
-
   /**
    * Mapping from the stage name to the default pass suite.
    * Plugins can extend or replace the list of passes during configuration.
@@ -656,17 +650,17 @@ export namespace compiler {
      * Pack of passes that performing checks on the AST. This bunch of passes
      * executed in the very beginning of the compilation stage.
      */
-    check: Passes;
+    check: Pass[];
     /**
      * Pack of passes that performing transformation of the AST.
      * Various types of optimizations are performed here.
      */
-    transform: Passes;
+    transform: Pass[];
     /** Pack of passes that generates the code. */
-    generate: Passes;
+    generate: Pass[];
 
     /** Any additional stages that can be added in the future. */
-    [key: string]: Passes;
+    [key: string]: Pass[];
   }
 
   /** List of the compilation stages. */

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -17,6 +17,30 @@ declare namespace ast {
     location: LocationRange;
   }
 
+  enum MatchResult {
+    ALWAYS = 1,
+    SOMETIMES = 0,
+    NEVER = -1,
+  }
+
+  /**
+   * Base interface for all nodes that forming a rule expression.
+   *
+   * @template {T} Type of the node
+   */
+  interface Expr<T> extends Node<T> {
+    /**
+     * The estimated result of matching this node against any input:
+     *
+     * - `-1`: negative result, matching of that node always fails
+     * -  `0`: neutral result, may be fail, may be match
+     * -  `1`: positive result, always match
+     *
+     * This property is created by the `inferenceMatchResult` pass.
+     */
+    match?: MatchResult;
+  }
+
   /** The main Peggy AST class returned by the parser. */
   interface Grammar extends Node<"grammar"> {
     /** Initializer that run once when importing generated parser module. */
@@ -31,11 +55,23 @@ declare namespace ast {
   }
 
   /**
-   * Base interface for all nodes with the code.
+   * Base interface for all initializer nodes with the code.
    *
    * @template {T} Type of the node
    */
   interface CodeBlock<T> extends Node<T> {
+    /** The code from the grammar. */
+    code: string;
+    /** Span that covers all code between `{` and `}`. */
+    codeLocation: LocationRange;
+  }
+
+  /**
+   * Base interface for all expression nodes with the code.
+   *
+   * @template {T} Type of the node
+   */
+  interface CodeBlockExpr<T> extends Expr<T> {
     /** The code from the grammar. */
     code: string;
     /** Span that covers all code between `{` and `}`. */
@@ -51,7 +87,7 @@ declare namespace ast {
   /** Code that runs on each `parse()` call of the generated parser. */
   interface Initializer extends CodeBlock<"initializer"> {}
 
-  interface Rule extends Node<"rule"> {
+  interface Rule extends Expr<"rule"> {
     /** Identifier of the rule. Should be unique in the grammar. */
     name: string;
     /**
@@ -67,7 +103,7 @@ declare namespace ast {
   }
 
   /** Represents rule body if it has a name. */
-  interface Named extends Node<"named"> {
+  interface Named extends Expr<"named"> {
     /** Name of the rule that will appear in the error messages. */
     name: string;
     expression: Expression;
@@ -92,7 +128,7 @@ declare namespace ast {
     | Suffixed
     | Primary;
 
-  interface Choice extends Node<"choice"> {
+  interface Choice extends Expr<"choice"> {
     /**
      * List of expressions to match. Only one of them could match the input,
      * the first one that matched is used as a result of the `choice` node.
@@ -100,7 +136,7 @@ declare namespace ast {
     alternatives: Alternative[];
   }
 
-  interface Action extends CodeBlock<"action"> {
+  interface Action extends CodeBlockExpr<"action"> {
     expression: (
         Sequence
       | Labeled
@@ -117,12 +153,12 @@ declare namespace ast {
     | Suffixed
     | Primary;
 
-  interface Sequence extends Node<"sequence"> {
+  interface Sequence extends Expr<"sequence"> {
     /** List of expressions each of them should match in order to match the sequence. */
     elements: Element[];
   }
 
-  interface Labeled extends Node<"labeled"> {
+  interface Labeled extends Expr<"labeled"> {
     /** If `true`, labeled expression is one of automatically returned. */
     pick?: true;
     /**
@@ -141,12 +177,12 @@ declare namespace ast {
   }
 
   /** Expression with a preceding operator. */
-  interface Prefixed extends Node<"text" | "simple_and" | "simple_not"> {
+  interface Prefixed extends Expr<"text" | "simple_and" | "simple_not"> {
     expression: Suffixed | Primary;
   }
 
   /** Expression with a following operator. */
-  interface Suffixed extends Node<"optional" | "zero_or_more" | "one_or_more"> {
+  interface Suffixed extends Expr<"optional" | "zero_or_more" | "one_or_more"> {
     expression: Primary;
   }
 
@@ -158,20 +194,20 @@ declare namespace ast {
     | CharacterClass
     | Any;
 
-  interface RuleReference extends Node<"rule_ref"> {
+  interface RuleReference extends Expr<"rule_ref"> {
     /** Name of the rule to refer. */
     name: string;
   }
 
-  interface SemanticPredicate extends CodeBlock<"semantic_and" | "semantic_not"> {}
+  interface SemanticPredicate extends CodeBlockExpr<"semantic_and" | "semantic_not"> {}
 
   /** Group node introduces new scope for labels. */
-  interface Group extends Node<"group"> {
+  interface Group extends Expr<"group"> {
     expression: Labeled | Sequence;
   }
 
   /** Matches continuous sequence of symbols. */
-  interface Literal extends Node<"literal"> {
+  interface Literal extends Expr<"literal"> {
     /** Sequence of symbols to match. */
     value: string;
     /** If `true`, symbols matches even if they case do not match case in the `value`. */
@@ -179,7 +215,7 @@ declare namespace ast {
   }
 
   /** Matches single UTF-16 character. */
-  interface CharacterClass extends Node<"class"> {
+  interface CharacterClass extends Expr<"class"> {
     /**
      * Each part represents either symbol range or single symbol.
      * If empty, such character class never matches anything, even end-of-stream marker.
@@ -198,7 +234,7 @@ declare namespace ast {
   }
 
   /** Matches any UTF-16 code unit in the input, but doesn't match the empty string. */
-  interface Any extends Node<"any"> {}
+  interface Any extends Expr<"any"> {}
 }
 
 /** Current Peggy version in semver format. */

--- a/lib/peg.js
+++ b/lib/peg.js
@@ -91,12 +91,10 @@ const peg = {
   generate(grammar, options) {
     options = options !== undefined ? options : {};
 
-    function convertPasses(passes) {
+    function copyPasses(passes) {
       const converted = {};
-
       Object.keys(passes).forEach(stage => {
-        converted[stage] = Object.keys(passes[stage])
-          .map(name => passes[stage][name]);
+        converted[stage] = passes[stage].slice();
       });
 
       return converted;
@@ -105,7 +103,7 @@ const peg = {
     const plugins = "plugins" in options ? options.plugins : [];
     const config = {
       parser: peg.parser,
-      passes: convertPasses(peg.compiler.passes),
+      passes: copyPasses(peg.compiler.passes),
       reservedWords: peg.RESERVED_WORDS.slice(),
     };
 

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -308,6 +308,21 @@ describe("peg.d.ts", () => {
       "zero_or_more",
     ]);
   });
+
+  it("compiles", () => {
+    const ast = peggy.parser.parse("start = 'foo'", {
+      grammarSource: "it compiles",
+      reservedWords: peggy.RESERVED_WORDS.slice(),
+    });
+    expectType<peggy.ast.Grammar>(ast);
+    const parser = peggy.compiler.compile(
+      ast,
+      peggy.compiler.passes
+    );
+    expectType<peggy.Parser>(parser);
+    expectType<peggy.ast.MatchResult|undefined>(ast.rules[0].match);
+    expect(ast.rules[0].match).toBe(0);
+  });
 });
 
 describe("run tsd", () => {

--- a/test/unit/compiler/passes/inference-match-result.spec.js
+++ b/test/unit/compiler/passes/inference-match-result.spec.js
@@ -1,0 +1,137 @@
+"use strict";
+
+const chai = require("chai");
+const helpers = require("./helpers");
+const pass = require("../../../../lib/compiler/passes/inference-match-result");
+
+chai.use(helpers);
+
+const expect = chai.expect;
+
+describe("compiler pass |inferenceMatchResult|", function() {
+  it("calculate |match| property for |any| correctly", function() {
+    expect(pass).to.changeAST("start = .",       { rules: [{ match:  0 }] });
+  });
+
+  it("calculate |match| property for |literal| correctly", function() {
+    expect(pass).to.changeAST("start = ''",      { rules: [{ match:  1 }] });
+    expect(pass).to.changeAST("start = ''i",     { rules: [{ match:  1 }] });
+    expect(pass).to.changeAST("start = 'a'",     { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = 'a'i",    { rules: [{ match:  0 }] });
+  });
+
+  it("calculate |match| property for |class| correctly", function() {
+    expect(pass).to.changeAST("start = []",      { rules: [{ match: -1 }] });
+    expect(pass).to.changeAST("start = []i",     { rules: [{ match: -1 }] });
+    expect(pass).to.changeAST("start = [a]",     { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = [a]i",    { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = [a-b]",   { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = [a-b]i",  { rules: [{ match:  0 }] });
+  });
+
+  it("calculate |match| property for |sequence| correctly", function() {
+    expect(pass).to.changeAST("start = 'a' 'b'", { rules: [{ match:  0 }] });
+
+    expect(pass).to.changeAST("start = 'a' ''",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = '' 'b'",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = '' ''",   { rules: [{ match:  1 }] });
+
+    expect(pass).to.changeAST("start = 'a' []",  { rules: [{ match: -1 }] });
+    expect(pass).to.changeAST("start = [] 'b'",  { rules: [{ match: -1 }] });
+    expect(pass).to.changeAST("start = [] []",   { rules: [{ match: -1 }] });
+  });
+
+  it("calculate |match| property for |choice| correctly", function() {
+    expect(pass).to.changeAST("start = 'a' / 'b'", { rules: [{ match:  0 }] });
+
+    expect(pass).to.changeAST("start = 'a' / ''",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = ''  / 'b'", { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = ''  / ''",  { rules: [{ match:  1 }] });
+
+    expect(pass).to.changeAST("start = 'a' / []",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = []  / 'b'", { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = []  / []",  { rules: [{ match: -1 }] });
+  });
+
+  it("calculate |match| property for predicates correctly", function() {
+    expect(pass).to.changeAST("start = &.",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = &''", { rules: [{ match:  1 }] });
+    expect(pass).to.changeAST("start = &[]", { rules: [{ match: -1 }] });
+
+    expect(pass).to.changeAST("start = !.",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = !''", { rules: [{ match: -1 }] });
+    expect(pass).to.changeAST("start = ![]", { rules: [{ match:  1 }] });
+
+    expect(pass).to.changeAST("start = &{ code }", { rules: [{ match: 0 }] });
+    expect(pass).to.changeAST("start = !{ code }", { rules: [{ match: 0 }] });
+  });
+
+  it("calculate |match| property for |text| correctly", function() {
+    expect(pass).to.changeAST("start = $.",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = $''", { rules: [{ match:  1 }] });
+    expect(pass).to.changeAST("start = $[]", { rules: [{ match: -1 }] });
+  });
+
+  it("calculate |match| property for |action| correctly", function() {
+    expect(pass).to.changeAST("start = .  { code }", { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = '' { code }", { rules: [{ match:  1 }] });
+    expect(pass).to.changeAST("start = [] { code }", { rules: [{ match: -1 }] });
+  });
+
+  it("calculate |match| property for |labeled| correctly", function() {
+    expect(pass).to.changeAST("start = a:.",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = a:''", { rules: [{ match:  1 }] });
+    expect(pass).to.changeAST("start = a:[]", { rules: [{ match: -1 }] });
+  });
+
+  it("calculate |match| property for |named| correctly", function() {
+    expect(pass).to.changeAST("start 'start' = .",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start 'start' = ''", { rules: [{ match:  1 }] });
+    expect(pass).to.changeAST("start 'start' = []", { rules: [{ match: -1 }] });
+  });
+
+  it("calculate |match| property for |optional| correctly", function() {
+    expect(pass).to.changeAST("start = .?",  { rules: [{ match: 1 }] });
+    expect(pass).to.changeAST("start = ''?", { rules: [{ match: 1 }] });
+    expect(pass).to.changeAST("start = []?", { rules: [{ match: 1 }] });
+  });
+
+  it("calculate |match| property for |zero_or_more| correctly", function() {
+    expect(pass).to.changeAST("start = .*",  { rules: [{ match: 1 }] });
+    expect(pass).to.changeAST("start = ''*", { rules: [{ match: 1 }] });
+    expect(pass).to.changeAST("start = []*", { rules: [{ match: 1 }] });
+  });
+
+  it("calculate |match| property for |one_or_more| correctly", function() {
+    expect(pass).to.changeAST("start = .+",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = ''+", { rules: [{ match:  1 }] });
+    expect(pass).to.changeAST("start = []+", { rules: [{ match: -1 }] });
+  });
+
+  it("calculate |match| property for |group| correctly", function() {
+    expect(pass).to.changeAST("start = (.)",  { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = ('')", { rules: [{ match:  1 }] });
+    expect(pass).to.changeAST("start = ([])", { rules: [{ match: -1 }] });
+  });
+
+  it("calculate |match| property for |rule_ref| correctly", function() {
+    expect(pass).to.changeAST(
+      ["start = end", "end = . "].join("\n"),
+      { rules: [{ match:  0 }, { match:  0 }] }
+    );
+    expect(pass).to.changeAST(
+      ["start = end", "end = ''"].join("\n"),
+      { rules: [{ match:  1 }, { match:  1 }] }
+    );
+    expect(pass).to.changeAST(
+      ["start = end", "end = []"].join("\n"),
+      { rules: [{ match: -1 }, { match: -1 }] }
+    );
+
+    expect(pass).to.changeAST("start = .  start", { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = '' start", { rules: [{ match:  0 }] });
+    expect(pass).to.changeAST("start = [] start", { rules: [{ match: -1 }] });
+
+    expect(pass).to.changeAST("start = . start []", { rules: [{ match: -1 }] });
+  });
+});


### PR DESCRIPTION
Port of my optimization pegjs/pegjs#400, that reduce many dumb comparisons (that is not cut by minifiers). You can see some of them on the `parser.js` (but enable whitespace-ignored mode on github)

I calculate possible values of the match result and do not generate conditions, that are always `true` or `false` and also didn't generate not used constants.
