### PR TITLE
Fix some errors found when run typescript compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,22 @@ Released: TBD
   especially if your plugin replaces both `generateBytecode` as `generateJs` passes.
 
   [@Mingun](https://github.com/peggyjs/peggy/pull/117)
+- Default visitor functions, returned by the `visitor.build()`, that just forward
+  call to `node.expression`, now returns the result of underlying `visit` call.
+  [@Mingun](https://github.com/peggyjs/peggy/pull/144)
+
+  Affected functions:
+    - `rule`
+    - `named`
+    - `action`
+    - `labeled`
+    - `text`
+    - `simple_and`
+    - `simple_not`
+    - `optional`
+    - `zero_or_more`
+    - `one_or_more`
+    - `group`
 
 ### Bug fixes
 

--- a/lib/compiler/asts.js
+++ b/lib/compiler/asts.js
@@ -28,32 +28,19 @@ const asts = {
     function consumesTrue()  { return true;  }
     function consumesFalse() { return false; }
 
-    function consumesExpression(node) {
-      return consumes(node.expression);
-    }
-
     const consumes = visitor.build({
-      rule: consumesExpression,
-      named: consumesExpression,
-
       choice(node) {
         return node.alternatives.every(consumes);
       },
-
-      action: consumesExpression,
 
       sequence(node) {
         return node.elements.some(consumes);
       },
 
-      labeled: consumesExpression,
-      text: consumesExpression,
       simple_and: consumesFalse,
       simple_not: consumesFalse,
       optional: consumesFalse,
       zero_or_more: consumesFalse,
-      one_or_more: consumesExpression,
-      group: consumesExpression,
       semantic_and: consumesFalse,
       semantic_not: consumesFalse,
 

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -244,8 +244,8 @@ function generateBytecode(ast) {
     return clone;
   }
 
-  function buildSequence() {
-    return Array.prototype.concat.apply([], arguments);
+  function buildSequence(first, ...args) {
+    return first.concat(...args);
   }
 
   function buildCondition(condCode, thenCode, elseCode) {

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -399,6 +399,7 @@ function generateJS(ast, options) {
 
           case op.WRAP:               // WRAP n
             parts.push(
+              // @ts-expect-error  pop() returns array if argument is specified
               stack.push("[" + stack.pop(bc[ip + 1]).join(", ") + "]")
             );
             ip += 2;
@@ -440,7 +441,7 @@ function generateJS(ast, options) {
             break;
 
           case op.WHILE_NOT_ERROR:    // WHILE_NOT_ERROR b
-            compileLoop(stack.top() + " !== peg$FAILED", 0);
+            compileLoop(stack.top() + " !== peg$FAILED");
             break;
 
           case op.MATCH_ANY:          // MATCH_ANY a, f, ...

--- a/lib/compiler/passes/report-infinite-recursion.js
+++ b/lib/compiler/passes/report-infinite-recursion.js
@@ -24,7 +24,7 @@ function reportInfiniteRecursion(ast) {
     rule(node) {
       visitedRules.push(node.name);
       check(node.expression);
-      visitedRules.pop(node.name);
+      visitedRules.pop();
     },
 
     sequence(node) {

--- a/lib/compiler/visitor.js
+++ b/lib/compiler/visitor.js
@@ -3,45 +3,35 @@
 // Simple AST node visitor builder.
 const visitor = {
   build(functions) {
-    function visit(node) {
-      return functions[node.type].apply(null, arguments);
+    function visit(node, ...args) {
+      return functions[node.type](node, ...args);
     }
 
     function visitNop() {
       // Do nothing.
     }
 
-    function visitExpression(node) {
-      const extraArgs = Array.prototype.slice.call(arguments, 1);
-
-      visit.apply(null, [node.expression].concat(extraArgs));
+    function visitExpression(node, ...args) {
+      visit(node.expression, ...args);
     }
 
     function visitChildren(property) {
-      return function(node) {
-        const extraArgs = Array.prototype.slice.call(arguments, 1);
-
-        node[property].forEach(child => {
-          visit.apply(null, [child].concat(extraArgs));
-        });
+      return function(node, ...args) {
+        node[property].forEach(child => visit(child, ...args));
       };
     }
 
     const DEFAULT_FUNCTIONS = {
-      grammar(node) {
-        const extraArgs = Array.prototype.slice.call(arguments, 1);
-
+      grammar(node, ...args) {
         if (node.topLevelInitializer) {
-          visit.apply(null, [node.topLevelInitializer].concat(extraArgs));
+          visit(node.topLevelInitializer, ...args);
         }
 
         if (node.initializer) {
-          visit.apply(null, [node.initializer].concat(extraArgs));
+          visit(node.initializer, ...args);
         }
 
-        node.rules.forEach(rule => {
-          visit.apply(null, [rule].concat(extraArgs));
-        });
+        node.rules.forEach(rule => visit(rule, ...args));
       },
 
       top_level_initializer: visitNop,

--- a/lib/compiler/visitor.js
+++ b/lib/compiler/visitor.js
@@ -12,11 +12,16 @@ const visitor = {
     }
 
     function visitExpression(node, ...args) {
-      visit(node.expression, ...args);
+      return visit(node.expression, ...args);
     }
 
     function visitChildren(property) {
       return function(node, ...args) {
+        // We do not use .map() here, because if you need the result
+        // of applying visitor to children you probable also need to
+        // process it in some way, therefore you anyway have to override
+        // this method. If you do not needed that, we do not waste time
+        // and memory for creating the output array
         node[property].forEach(child => visit(child, ...args));
       };
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "peggy",
       "version": "1.1.0",
       "license": "MIT",
       "bin": {
@@ -17,6 +18,7 @@
         "@rollup/plugin-multi-entry": "^4.0.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
         "@rollup/plugin-typescript": "^8.2.1",
+        "@types/jest": "^26.0.23",
         "chai": "^4.3.4",
         "eslint": "^7.26.0",
         "express": "4.17.1",
@@ -1137,6 +1139,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "dev": true,
+      "dependencies": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -8739,6 +8751,16 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "26.0.23",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
+      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
       }
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@rollup/plugin-multi-entry": "^4.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-typescript": "^8.2.1",
+    "@types/jest": "^26.0.23",
     "chai": "^4.3.4",
     "eslint": "^7.26.0",
     "express": "4.17.1",

--- a/test/api/pegjs-api.spec.js
+++ b/test/api/pegjs-api.spec.js
@@ -159,13 +159,13 @@ describe("Peggy API", function() {
     });
 
     // The |format|, |exportVars|, and |dependencies| options are not tested
-    // becasue there is no meaningful way to thest their effects without turning
+    // because there is no meaningful way to test their effects without turning
     // this into an integration test.
 
     // The |plugins| option is tested in plugin API tests.
 
     it("accepts custom options", function() {
-      peg.generate("start = 'a'", { foo: 42 });
+      peg.generate("start = 'a'", { grammarSource: 42 });
     });
   });
 });

--- a/test/unit/grammar-error.spec.js
+++ b/test/unit/grammar-error.spec.js
@@ -5,6 +5,7 @@ const GrammarError = require("../../lib/grammar-error");
 
 const expect = chai.expect;
 
+/** @type {import("../../lib/peg").LocationRange} */
 const location = {
   source: undefined,
   start: { offset: 0, line: 1, column: 1 },

--- a/test/unit/parser.spec.js
+++ b/test/unit/parser.spec.js
@@ -111,8 +111,8 @@ describe("Peggy grammar parser", function() {
 
   const stripLocation = (function() {
     function buildVisitor(functions) {
-      return function(node) {
-        return functions[node.type].apply(null, arguments);
+      return function(node, ...args) {
+        return functions[node.type](node, ...args);
       };
     }
 


### PR DESCRIPTION
Some errors, catched with the following change in the `tsconfig.json` and running `npm run ts`:
```diff
 tsconfig.json | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)

diff --git a/tsconfig.json b/tsconfig.json
index fe8a4420..bee30bbf 100644
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     "allowJs": true,                                /* Allow javascript files to be compiled. */
-    "checkJs": false,                               /* Report errors in .js files. */
+    "checkJs": true,                                /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
     "declaration": true,                            /* Generates corresponding '.d.ts' file. */
     "declarationMap": false,                         /* Generates a sourcemap for each corresponding '.d.ts' file. */
@@ -14,8 +14,8 @@
     "removeComments": true,                         /* Do not emit comments to output. */
 
   /* over time we will enable these */
-    // "strict": true,                              /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strict": true,                                 /* Enable all strict type-checking options. */
+    "noImplicitAny": false,                         /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                    /* Enable strict null checks. */
     // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
     // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
@@ -34,5 +34,5 @@
     "skipLibCheck": true,                           /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["./lib/**/*.js", "./test/**/*.spec.js", "./benchmark/*.js"]
+  "include": ["./lib/**/*.js", "./test/**/*.spec.js"]
 }
```
Because I anyway replace all `arguments` usage with the rest parameters, I also made a small improvement in the default visitor behavior for `visitExpression` methods: make it returns a value of the visited expression. Now you no longer need to override that methods just to return values