### PR TITLE
Fix #92: Drop support for useless `optimize` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Released: TBD
     - Extends CI testing to `windows`, `macintosh`
     - Increases node testing range to include `node 16`
     - Adds an announcer to make the build process more readable
+- Option for selection optimization mode removed as it has no significant effect on
+  majority of generated parsers and represents only academic interest mostly. You should
+  use minifiers to get smaller parsers. Option `optimize` is deleted from the `generate()`
+  options, flag `--optimize` is deleted from the CLI (you still can supply it, but the CLI
+  will issue a warning that the option is removed).
+  [@Mingun](https://github.com/peggyjs/peggy/pull/147)
 - `location()`s now will have additional `source` property which value is taken
   from the `options.grammarSource` property. That property can contain arbitrary
   data,for example, path to the currently parsed file.

--- a/README.md
+++ b/README.md
@@ -113,8 +113,6 @@ You can tweak the generated parser with several options:
   pass to `peg.generate`
 - `--format` — format of the generated parser: `amd`, `es`, `commonjs`, `globals`,
   `umd` (default: `commonjs`)
-- `--optimize` — selects between optimizing the generated parser for parsing
-  speed (`speed`) or code size (`size`) (default: `speed`)
 - `--plugin` — makes Peggy use a specified plugin (can be specified multiple
   times)
 - `--trace` — makes the parser trace its progress
@@ -164,8 +162,6 @@ object to `peg.generate`. The following options are supported:
 - `format` — format of the generated parser (`"amd"`, `"bare"`, `"commonjs"`,
   `"es"`, `"globals"`, or `"umd"`); valid only when `output` is set to `"source"`
   (default: `"bare"`)
-- `optimize`— selects between optimizing the generated parser for parsing
-  speed (`"speed"`) or code size (`"size"`) (default: `"speed"`)
 - `output` — if set to `"parser"`, the method will return generated parser
   object; if set to `"source"`, it will return parser source code as a string
   (default: `"parser"`)

--- a/benchmark/browser.stub.js
+++ b/benchmark/browser.stub.js
@@ -60,7 +60,6 @@ $("#run").click(() => {
     const runCount = parseInt($("#run-count").val(), 10);
     const options = {
         cache: $("#cache").is(":checked"),
-        optimize: $("#optimize").val(),
     };
 
     if (isNaN(runCount) || runCount <= 0) {

--- a/benchmark/index.css
+++ b/benchmark/index.css
@@ -30,5 +30,4 @@ a, a:visited { color: #3d586c; }
 }
 #options #run-count { width: 3em; }
 #options #cache { margin-left: 2em; }
-#options label[for=optimize] { margin-left: 2em; }
 #options #run { float:right; width: 5em; }

--- a/benchmark/index.html
+++ b/benchmark/index.html
@@ -13,11 +13,6 @@
       <input type="text" id="run-count" value="10"> times
       <input type="checkbox" id="cache">
       <label for="cache">Use results cache</label>
-      <label for="optimize">Optimize:</label>
-      <select id="optimize">
-        <option value="speed">Speed</option>
-        <option value="size">Size</option>
-      </select>
       <input type="button" id="run" value="Run">
     </div>
 

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -62,8 +62,7 @@ $("#run").click(() => {
 
   const runCount = parseInt($("#run-count").val(), 10);
   const options = {
-    cache: $("#cache").is(":checked"),
-    optimize: $("#optimize").val()
+    cache: $("#cache").is(":checked")
   };
 
   if (isNaN(runCount) || runCount <= 0) {

--- a/benchmark/run_bench.js
+++ b/benchmark/run_bench.js
@@ -80,8 +80,6 @@ function printHelp() {
   console.log("Options:");
   console.log("  -n, --run-count <n>          number of runs (default: 10)");
   console.log("      --cache                  make tested parsers cache results");
-  console.log("  -o, --optimize <goal>        select optimization for speed or size (default:");
-  console.log("                               speed)");
 }
 
 function exitSuccess() {
@@ -113,7 +111,6 @@ function nextArg() {
 
 const options = {
   cache: false,
-  optimize: "speed"
 };
 
 let runCount = 10;
@@ -134,18 +131,6 @@ while (args.length > 0 && isOption(args[0])) {
 
     case "--cache":
       options.cache = true;
-      break;
-
-    case "-o":
-    case "--optimize":
-      nextArg();
-      if (args.length === 0) {
-        abort("Missing parameter of the -o/--optimize option.");
-      }
-      if (args[0] !== "speed" && args[0] !== "size") {
-        abort("Optimization goal must be either \"speed\" or \"size\".");
-      }
-      options.optimize = args[0];
       break;
 
     case "-h":

--- a/bin/peggy
+++ b/bin/peggy
@@ -33,8 +33,6 @@ function printHelp() {
   console.log("      --format <format>              format of the generated parser: amd,");
   console.log("                                     commonjs, globals, umd (default: commonjs)");
   console.log("  -h, --help                         print help and exit");
-  console.log("  -O, --optimize <goal>              select optimization for speed or size");
-  console.log("                                     (default: speed)");
   console.log("  -o, --output <file>                output file");
   console.log("      --plugin <plugin>              use a specified plugin (can be specified");
   console.log("                                     multiple times)");
@@ -112,7 +110,6 @@ const options = {
   dependencies: {},
   exportVar: null,
   format: "commonjs",
-  optimize: "speed",
   output: "source",
   plugins: [],
   trace: false
@@ -203,13 +200,9 @@ while (args.length > 0 && isOption(args[0])) {
     case "-O":
     case "--optimize":
       nextArg();
-      if (args.length === 0) {
-        abort("Missing parameter of the -O/--optimize option.");
-      }
-      if (args[0] !== "speed" && args[0] !== "size") {
-        abort("Optimization goal must be either \"speed\" or \"size\".");
-      }
-      options.optimize = args[0];
+      console.error("Option --optimize is deprecated from 1.2.0 and has no effect anymore.");
+      console.error("It will be deleted in 2.0.");
+      console.error("Parser will be generated in the former \"speed\" mode.");
       break;
 
     case "-o":

--- a/docs/css/benchmark.css
+++ b/docs/css/benchmark.css
@@ -30,5 +30,4 @@ a, a:visited { color: #3d586c; }
 }
 #options #run-count { width: 3em; }
 #options #cache { margin-left: 2em; }
-#options label[for=optimize] { margin-left: 2em; }
 #options #run { float:right; width: 5em; }

--- a/docs/css/content.css
+++ b/docs/css/content.css
@@ -136,7 +136,6 @@
 
 #content #settings { padding: .5em 0; }
 #content #settings label { padding-right: 1em; }
-#content #settings label[for=option-optimize] { padding-left: 2em; }
 #content #parser-var { width: 15em; }
 #content #options { padding-top: 1em; }
 #content #parser-download {

--- a/docs/development/benchmark.html
+++ b/docs/development/benchmark.html
@@ -47,11 +47,6 @@
                     <input type="text" id="run-count" value="10"> times
                     <input type="checkbox" id="cache">
                     <label for="cache">Use results cache</label>
-                    <label for="optimize">Optimize:</label>
-                    <select id="optimize">
-                        <option value="speed">Speed</option>
-                        <option value="size">Size</option>
-                    </select>
                     <input type="button" id="run" value="Run">
                 </div>
 

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -160,11 +160,6 @@ override this using the <code>--format</code> option.</p>
   <dd>Format of the generated parser: <code>amd</code>, <code>commonjs</code>,
   <code>globals</code>, <code>umd</code>, <code>es</code> (default: <code>commonjs</code>).</dd>
 
-  <dt><code>--optimize</code></dt>
-  <dd>Selects between optimizing the generated parser for parsing speed
-  (<code>speed</code>) or code size (<code>size</code>) (default:
-  <code>speed</code>)</dd>
-
   <dt><code>--plugin</code></dt>
   <dd>Makes Peggy use a specified plugin (can be specified multiple
   times).</dd>
@@ -237,11 +232,6 @@ supported:</p>
   might use the socket and so on. The supplied object will be available at key
   <code>source</code> in the location objects, that returned by the
   <code>location()</code> API function (default: <code>undefined</code>).</dd>
-
-  <dt><code>optimize</code></dt>
-  <dd>Selects between optimizing the generated parser for parsing speed
-  (<code>"speed"</code>) or code size (<code>"size"</code>) (default:
-  <code>"speed"</code>).</dd>
 
   <dt><code>output</code></dt>
   <dd>If set to <code>"parser"</code>, the method will return generated parser

--- a/docs/js/online.js
+++ b/docs/js/online.js
@@ -11,7 +11,6 @@ $(document).ready(function() {
   var oldGrammar        = null;
   var oldParserVar      = null;
   var oldOptionCache    = null;
-  var oldOptionOptimize = null;
   var oldInput          = null;
 
   var editor = CodeMirror.fromTextArea($("#grammar").get(0), {
@@ -39,7 +38,6 @@ $(document).ready(function() {
     oldGrammar        = getGrammar();
     oldParserVar      = $("#parser-var").val();
     oldOptionCache    = $("#option-cache").is(":checked");
-    oldOptionOptimize = $("#option-optimize").val();
 
     $('#build-message').attr("class", "message progress").text("Building the parser...");
     $("#input").attr("disabled", "disabled");
@@ -47,14 +45,12 @@ $(document).ready(function() {
     $("#output").addClass("disabled").text("Output not available.");
     $("#parser-var").attr("disabled", "disabled");
     $("#option-cache").attr("disabled", "disabled");
-    $("#option-optimize").attr("disabled", "disabled");
     $("#parser-download").attr("disabled", "disabled");
 
     try {
       var timeBefore = (new Date).getTime();
       parserSource = peggy.generate(getGrammar(), {
         cache:    $("#option-cache").is(":checked"),
-        optimize: $("#option-optimize").val(),
         output:   "source"
       });
       var timeAfter = (new Date).getTime();
@@ -72,7 +68,6 @@ $(document).ready(function() {
       $("#input").removeAttr("disabled");
       $("#parser-var").removeAttr("disabled");
       $("#option-cache").removeAttr("disabled");
-      $("#option-optimize").removeAttr("disabled");
       $("#parser-download").removeAttr("disabled");
 
       var result = true;
@@ -126,8 +121,7 @@ $(document).ready(function() {
   function scheduleBuildAndParse() {
     var nothingChanged = getGrammar() === oldGrammar
       && $("#parser-var").val() === oldParserVar
-      && $("#option-cache").is(":checked") === oldOptionCache
-      && $("#option-optimize").val() === oldOptionOptimize;
+      && $("#option-cache").is(":checked") === oldOptionCache;
     if (nothingChanged) { return; }
 
     if (buildAndParseTimer !== null) {
@@ -182,7 +176,7 @@ $(document).ready(function() {
 
   editor.on("change", scheduleBuildAndParse);
 
-  $("#parser-var, #option-cache, #option-optimize")
+  $("#parser-var, #option-cache")
     .change(scheduleBuildAndParse)
     .mousedown(scheduleBuildAndParse)
     .mouseup(scheduleBuildAndParse)
@@ -214,8 +208,8 @@ $(document).ready(function() {
   $("#loader").hide();
   $("#content").show();
 
-  $("#grammar, #parser-var, #option-cache, #option-optimize").removeAttr("disabled");
-  
+  $("#grammar, #parser-var, #option-cache").removeAttr("disabled");
+
   buildAndParse();
 
   editor.refresh();

--- a/docs/online.html
+++ b/docs/online.html
@@ -142,11 +142,6 @@ _ "whitespace"
                             <div id="options">
                                 <input type="checkbox" id="option-cache" disabled>
                                 <label for="option-cache">Use results cache</label>
-                                <label for="option-optimize">Optimize:</label>
-                                <select id="option-optimize" disabled>
-                                    <option value="speed">Parsing speed</option>
-                                    <option value="size">Code size</option>
-                                </select>
                             </div>
                         </div>
                     </td>

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -68,7 +68,6 @@ const compiler = {
       dependencies: {},
       exportVar: null,
       format: "bare",
-      optimize: "speed",
       output: "parser",
       trace: false
     });

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -8,29 +8,10 @@ const VERSION = require("../../version");
 // Generates parser JavaScript code.
 function generateJS(ast, options) {
   // These only indent non-empty lines to avoid trailing whitespace.
-  function indent2(code)  { return code.replace(/^(.+)$/gm, "  $1");         }
-  function indent10(code) { return code.replace(/^(.+)$/gm, "          $1"); }
+  function indent2(code) { return code.replace(/^(.+)$/gm, "  $1"); }
 
   function generateTables() {
-    if (options.optimize === "size") {
-      return [
-        "var peg$consts = [",
-        indent2(ast.consts.join(",\n")),
-        "];",
-        "",
-        "var peg$bytecode = [",
-        indent2(ast.rules.map(rule =>
-             "peg$decode(\""
-               + js.stringEscape(rule.bytecode.map(
-                   b => String.fromCharCode(b + 32)
-                 ).join(""))
-               + "\")"
-           ).join(",\n")),
-        "];"
-      ].join("\n");
-    } else {
-      return ast.consts.map((c, i) => "var peg$c" + i + " = " + c + ";").join("\n");
-    }
+    return ast.consts.map((c, i) => "var peg$c" + i + " = " + c + ";").join("\n");
   }
 
   function generateRuleHeader(ruleNameCode, ruleIndexCode) {
@@ -123,298 +104,6 @@ function generateJS(ast, options) {
       "",
       "return " + resultCode + ";"
     ].join("\n"));
-
-    return parts.join("\n");
-  }
-
-  function generateInterpreter() {
-    const parts = [];
-
-    function generateCondition(cond, argsLength) {
-      const baseLength = argsLength + 3;
-      const thenLengthCode = "bc[ip + " + (baseLength - 2) + "]";
-      const elseLengthCode = "bc[ip + " + (baseLength - 1) + "]";
-
-      return [
-        "ends.push(end);",
-        "ips.push(ip + " + baseLength + " + " + thenLengthCode + " + " + elseLengthCode + ");",
-        "",
-        "if (" + cond + ") {",
-        "  end = ip + " + baseLength + " + " + thenLengthCode + ";",
-        "  ip += " + baseLength + ";",
-        "} else {",
-        "  end = ip + " + baseLength + " + " + thenLengthCode + " + " + elseLengthCode + ";",
-        "  ip += " + baseLength + " + " + thenLengthCode + ";",
-        "}",
-        "",
-        "break;"
-      ].join("\n");
-    }
-
-    function generateLoop(cond) {
-      const baseLength = 2;
-      const bodyLengthCode = "bc[ip + " + (baseLength - 1) + "]";
-
-      return [
-        "if (" + cond + ") {",
-        "  ends.push(end);",
-        "  ips.push(ip);",
-        "",
-        "  end = ip + " + baseLength + " + " + bodyLengthCode + ";",
-        "  ip += " + baseLength + ";",
-        "} else {",
-        "  ip += " + baseLength + " + " + bodyLengthCode + ";",
-        "}",
-        "",
-        "break;"
-      ].join("\n");
-    }
-
-    function generateCall() {
-      const baseLength = 4;
-      const paramsLengthCode = "bc[ip + " + (baseLength - 1) + "]";
-
-      return [
-        "params = bc.slice(ip + " + baseLength + ", ip + " + baseLength + " + " + paramsLengthCode + ")",
-        "  .map(function(p) { return stack[stack.length - 1 - p]; });",
-        "",
-        "stack.splice(",
-        "  stack.length - bc[ip + 2],",
-        "  bc[ip + 2],",
-        "  peg$consts[bc[ip + 1]].apply(null, params)",
-        ");",
-        "",
-        "ip += " + baseLength + " + " + paramsLengthCode + ";",
-        "break;"
-      ].join("\n");
-    }
-
-    parts.push([
-      "function peg$decode(s) {",
-      "  return s.split(\"\").map(function(ch) { return ch.charCodeAt(0) - 32; });",
-      "}",
-      "",
-      "function peg$parseRule(index) {"
-    ].join("\n"));
-
-    if (options.trace) {
-      parts.push([
-        "  var bc = peg$bytecode[index];",
-        "  var ip = 0;",
-        "  var ips = [];",
-        "  var end = bc.length;",
-        "  var ends = [];",
-        "  var stack = [];",
-        "  var startPos = peg$currPos;",
-        "  var params;"
-      ].join("\n"));
-    } else {
-      parts.push([
-        "  var bc = peg$bytecode[index];",
-        "  var ip = 0;",
-        "  var ips = [];",
-        "  var end = bc.length;",
-        "  var ends = [];",
-        "  var stack = [];",
-        "  var params;"
-      ].join("\n"));
-    }
-
-    parts.push(indent2(generateRuleHeader("peg$ruleNames[index]", "index")));
-
-    parts.push([
-      // The point of the outer loop and the |ips| & |ends| stacks is to avoid
-      // recursive calls for interpreting parts of bytecode. In other words, we
-      // implement the |interpret| operation of the abstract machine without
-      // function calls. Such calls would likely slow the parser down and more
-      // importantly cause stack overflows for complex grammars.
-      "  while (true) {",
-      "    while (ip < end) {",
-      "      switch (bc[ip]) {",
-      "        case " + op.PUSH + ":",               // PUSH c
-      "          stack.push(peg$consts[bc[ip + 1]]);",
-      "          ip += 2;",
-      "          break;",
-      "",
-      "        case " + op.PUSH_UNDEFINED + ":",     // PUSH_UNDEFINED
-      "          stack.push(undefined);",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.PUSH_NULL + ":",          // PUSH_NULL
-      "          stack.push(null);",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.PUSH_FAILED + ":",        // PUSH_FAILED
-      "          stack.push(peg$FAILED);",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.PUSH_EMPTY_ARRAY + ":",   // PUSH_EMPTY_ARRAY
-      "          stack.push([]);",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.PUSH_CURR_POS + ":",      // PUSH_CURR_POS
-      "          stack.push(peg$currPos);",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.POP + ":",                // POP
-      "          stack.pop();",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.POP_CURR_POS + ":",       // POP_CURR_POS
-      "          peg$currPos = stack.pop();",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.POP_N + ":",              // POP_N n
-      "          stack.length -= bc[ip + 1];",
-      "          ip += 2;",
-      "          break;",
-      "",
-      "        case " + op.NIP + ":",                // NIP
-      "          stack.splice(-2, 1);",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.APPEND + ":",             // APPEND
-      "          stack[stack.length - 2].push(stack.pop());",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.WRAP + ":",               // WRAP n
-      "          stack.push(stack.splice(stack.length - bc[ip + 1], bc[ip + 1]));",
-      "          ip += 2;",
-      "          break;",
-      "",
-      "        case " + op.TEXT + ":",               // TEXT
-      "          stack.push(input.substring(stack.pop(), peg$currPos));",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.PLUCK + ": {",            // PLUCK n, k, p1, ..., pK
-      "          params = bc.slice(ip + 3, ip + 3 + bc[ip + 2]);",
-      "          params = bc[ip + 2] === 1",
-      "            ? stack[stack.length - 1 - params[0]]",
-      "            : params.map(function(p) { return stack[stack.length - 1 - p]; });",
-      "",
-      "          stack.splice(",
-      "            stack.length - bc[ip + 1],",
-      "            bc[ip + 1],",
-      "            params",
-      "          );",
-      "",
-      "          ip += bc[ip + 2] + 3;",
-      "          break;",
-      "        }",
-      "",
-      "        case " + op.IF + ":",                 // IF t, f
-      indent10(generateCondition("stack[stack.length - 1]", 0)),
-      "",
-      "        case " + op.IF_ERROR + ":",           // IF_ERROR t, f
-      indent10(generateCondition(
-                   "stack[stack.length - 1] === peg$FAILED",
-                   0
-                 )),
-      "",
-      "        case " + op.IF_NOT_ERROR + ":",       // IF_NOT_ERROR t, f
-      indent10(
-                   generateCondition("stack[stack.length - 1] !== peg$FAILED",
-                   0
-                 )),
-      "",
-      "        case " + op.WHILE_NOT_ERROR + ":",    // WHILE_NOT_ERROR b
-      indent10(generateLoop("stack[stack.length - 1] !== peg$FAILED")),
-      "",
-      "        case " + op.MATCH_ANY + ":",          // MATCH_ANY a, f, ...
-      indent10(generateCondition("input.length > peg$currPos", 0)),
-      "",
-      "        case " + op.MATCH_STRING + ":",       // MATCH_STRING s, a, f, ...
-      indent10(generateCondition(
-                   "input.substr(peg$currPos, peg$consts[bc[ip + 1]].length) === peg$consts[bc[ip + 1]]",
-                   1
-                 )),
-      "",
-      "        case " + op.MATCH_STRING_IC + ":",    // MATCH_STRING_IC s, a, f, ...
-      indent10(generateCondition(
-                   "input.substr(peg$currPos, peg$consts[bc[ip + 1]].length).toLowerCase() === peg$consts[bc[ip + 1]]",
-                   1
-                 )),
-      "",
-      "        case " + op.MATCH_REGEXP + ":",       // MATCH_REGEXP r, a, f, ...
-      indent10(generateCondition(
-                   "peg$consts[bc[ip + 1]].test(input.charAt(peg$currPos))",
-                   1
-                 )),
-      "",
-      "        case " + op.ACCEPT_N + ":",           // ACCEPT_N n
-      "          stack.push(input.substr(peg$currPos, bc[ip + 1]));",
-      "          peg$currPos += bc[ip + 1];",
-      "          ip += 2;",
-      "          break;",
-      "",
-      "        case " + op.ACCEPT_STRING + ":",      // ACCEPT_STRING s
-      "          stack.push(peg$consts[bc[ip + 1]]);",
-      "          peg$currPos += peg$consts[bc[ip + 1]].length;",
-      "          ip += 2;",
-      "          break;",
-      "",
-      "        case " + op.FAIL + ":",               // FAIL e
-      "          stack.push(peg$FAILED);",
-      "          if (peg$silentFails === 0) {",
-      "            peg$fail(peg$consts[bc[ip + 1]]);",
-      "          }",
-      "          ip += 2;",
-      "          break;",
-      "",
-      "        case " + op.LOAD_SAVED_POS + ":",     // LOAD_SAVED_POS p
-      "          peg$savedPos = stack[stack.length - 1 - bc[ip + 1]];",
-      "          ip += 2;",
-      "          break;",
-      "",
-      "        case " + op.UPDATE_SAVED_POS + ":",   // UPDATE_SAVED_POS
-      "          peg$savedPos = peg$currPos;",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.CALL + ":",               // CALL f, n, pc, p1, p2, ..., pN
-      indent10(generateCall()),
-      "",
-      "        case " + op.RULE + ":",               // RULE r
-      "          stack.push(peg$parseRule(bc[ip + 1]));",
-      "          ip += 2;",
-      "          break;",
-      "",
-      "        case " + op.SILENT_FAILS_ON + ":",    // SILENT_FAILS_ON
-      "          peg$silentFails++;",
-      "          ip++;",
-      "          break;",
-      "",
-      "        case " + op.SILENT_FAILS_OFF + ":",   // SILENT_FAILS_OFF
-      "          peg$silentFails--;",
-      "          ip++;",
-      "          break;",
-      "",
-      "        default:",
-      "          throw new Error(\"Invalid opcode: \" + bc[ip] + \".\");",
-      "      }",
-      "    }",
-      "",
-      "    if (ends.length > 0) {",
-      "      end = ends.pop();",
-      "      ip = ips.pop();",
-      "    } else {",
-      "      break;",
-      "    }",
-      "  }"
-    ].join("\n"));
-
-    parts.push(indent2(generateRuleFooter("peg$ruleNames[index]", "stack[0]")));
-    parts.push("}");
 
     return parts.join("\n");
   }
@@ -548,7 +237,7 @@ function generateJS(ast, options) {
             ip++;
             break;
 
-          case op.PUSH_UNDEFINED:      // PUSH_UNDEFINED
+          case op.PUSH_UNDEFINED:     // PUSH_UNDEFINED
             parts.push(stack.push("undefined"));
             ip++;
             break;
@@ -961,47 +650,24 @@ function generateJS(ast, options) {
       ].join("\n"));
     }
 
+      const startRuleFunctions = "{ "
+      + options.allowedStartRules.map(
+          r => r + ": peg$parse" + r
+        ).join(", ")
+      + " }";
+      const startRuleFunction = "peg$parse" + options.allowedStartRules[0];
+
     parts.push([
       "function peg$parse(input, options) {",
       "  options = options !== undefined ? options : {};",
       "",
       "  var peg$FAILED = {};",
       "  var peg$source = options.grammarSource;",
-      ""
-    ].join("\n"));
-
-    if (options.optimize === "size") {
-      const startRuleIndices = "{ "
-        + options.allowedStartRules.map(
-            r => r + ": " + asts.indexOfRule(ast, r)
-          ).join(", ")
-        + " }";
-      const startRuleIndex
-        = asts.indexOfRule(ast, options.allowedStartRules[0]);
-
-      parts.push([
-        "  var peg$startRuleIndices = " + startRuleIndices + ";",
-        "  var peg$startRuleIndex = " + startRuleIndex + ";"
-      ].join("\n"));
-    } else {
-      const startRuleFunctions = "{ "
-        + options.allowedStartRules.map(
-            r => r + ": peg$parse" + r
-          ).join(", ")
-        + " }";
-      const startRuleFunction = "peg$parse" + options.allowedStartRules[0];
-
-      parts.push([
-        "  var peg$startRuleFunctions = " + startRuleFunctions + ";",
-        "  var peg$startRuleFunction = " + startRuleFunction + ";"
-      ].join("\n"));
-    }
-
-    parts.push("");
-
-    parts.push(indent2(generateTables()));
-
-    parts.push([
+      "",
+      "  var peg$startRuleFunctions = " + startRuleFunctions + ";",
+      "  var peg$startRuleFunction = " + startRuleFunction + ";",
+      "",
+      indent2(generateTables()),
       "",
       "  var peg$currPos = 0;",
       "  var peg$savedPos = 0;",
@@ -1020,19 +686,6 @@ function generateJS(ast, options) {
     }
 
     if (options.trace) {
-      if (options.optimize === "size") {
-        const ruleNames = "["
-          + ast.rules.map(
-              r => "\"" + js.stringEscape(r.name) + "\""
-            ).join(", ")
-          + "]";
-
-        parts.push([
-          "  var peg$ruleNames = " + ruleNames + ";",
-          ""
-        ].join("\n"));
-      }
-
       parts.push([
         "  var peg$tracer = \"tracer\" in options ? options.tracer : new peg$DefaultTracer();",
         ""
@@ -1041,32 +694,14 @@ function generateJS(ast, options) {
 
     parts.push([
       "  var peg$result;",
-      ""
-    ].join("\n"));
-
-    if (options.optimize === "size") {
-      parts.push([
-        "  if (\"startRule\" in options) {",
-        "    if (!(options.startRule in peg$startRuleIndices)) {",
-        "      throw new Error(\"Can't start parsing from rule \\\"\" + options.startRule + \"\\\".\");",
-        "    }",
-        "",
-        "    peg$startRuleIndex = peg$startRuleIndices[options.startRule];",
-        "  }"
-      ].join("\n"));
-    } else {
-      parts.push([
-        "  if (\"startRule\" in options) {",
-        "    if (!(options.startRule in peg$startRuleFunctions)) {",
-        "      throw new Error(\"Can't start parsing from rule \\\"\" + options.startRule + \"\\\".\");",
-        "    }",
-        "",
-        "    peg$startRuleFunction = peg$startRuleFunctions[options.startRule];",
-        "  }"
-      ].join("\n"));
-    }
-
-    parts.push([
+      "",
+      "  if (\"startRule\" in options) {",
+      "    if (!(options.startRule in peg$startRuleFunctions)) {",
+      "      throw new Error(\"Can't start parsing from rule \\\"\" + options.startRule + \"\\\".\");",
+      "    }",
+      "",
+      "    peg$startRuleFunction = peg$startRuleFunctions[options.startRule];",
+      "  }",
       "",
       "  function text() {",
       "    return input.substring(peg$savedPos, peg$currPos);",
@@ -1196,28 +831,18 @@ function generateJS(ast, options) {
       ""
     ].join("\n"));
 
-    if (options.optimize === "size") {
-      parts.push(indent2(generateInterpreter()));
+    ast.rules.forEach(rule => {
+      parts.push(indent2(generateRuleFunction(rule)));
       parts.push("");
-    } else {
-      ast.rules.forEach(rule => {
-        parts.push(indent2(generateRuleFunction(rule)));
-        parts.push("");
-      });
-    }
+    });
 
     if (ast.initializer) {
       parts.push(indent2(ast.initializer.code));
       parts.push("");
     }
 
-    if (options.optimize === "size") {
-      parts.push("  peg$result = peg$parseRule(peg$startRuleIndex);");
-    } else {
-      parts.push("  peg$result = peg$startRuleFunction();");
-    }
-
     parts.push([
+      "  peg$result = peg$startRuleFunction();",
       "",
       "  if (peg$result !== peg$FAILED && peg$currPos === input.length) {",
       "    return peg$result;",

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -87,7 +87,14 @@ export interface BuildOptionsBase {
    * File object.
    */
   grammarSource?: any;
-  /** selects between optimizing the generated parser for parsing speed (`"speed"`) or code size (`"size"`) (default: `"speed"`) */
+  /**
+   * Selects between optimizing the generated parser for parsing speed (`"speed"`)
+   * or code size (`"size"`) (default: `"speed"`)
+   *
+   * @deprecated This feature was deleted in 1.2.0 release and has no effect anymore.
+   *             It will be deleted in 2.0.
+   *             Parser is always generated in the former `"speed"` mode
+   */
   optimize?: "speed" | "size";
   /** plugins to use */
   plugins?: any[];

--- a/test/api/pegjs-api.spec.js
+++ b/test/api/pegjs-api.spec.js
@@ -35,56 +35,25 @@ describe("Peggy API", function() {
         "c = 'x'"
       ].join("\n");
 
-      // The |allowedStartRules| option is implemented separately for each
-      // optimization mode, so we need to test it in both.
+      describe("when |allowedStartRules| is not set", function() {
+        it("generated parser can start only from the first rule", function() {
+          const parser = peg.generate(grammar);
 
-      describe("when optimizing for parsing speed", function() {
-        describe("when |allowedStartRules| is not set", function() {
-          it("generated parser can start only from the first rule", function() {
-            const parser = peg.generate(grammar, { optimize: "speed" });
-
-            expect(parser.parse("x", { startRule: "a" })).to.equal("x");
-            expect(() => { parser.parse("x", { startRule: "b" }); }).to.throw();
-            expect(() => { parser.parse("x", { startRule: "c" }); }).to.throw();
-          });
-        });
-
-        describe("when |allowedStartRules| is set", function() {
-          it("generated parser can start only from specified rules", function() {
-            const parser = peg.generate(grammar, {
-              optimize: "speed",
-              allowedStartRules: ["b", "c"]
-            });
-
-            expect(() => { parser.parse("x", { startRule: "a" }); }).to.throw();
-            expect(parser.parse("x", { startRule: "b" })).to.equal("x");
-            expect(parser.parse("x", { startRule: "c" })).to.equal("x");
-          });
+          expect(parser.parse("x", { startRule: "a" })).to.equal("x");
+          expect(() => { parser.parse("x", { startRule: "b" }); }).to.throw();
+          expect(() => { parser.parse("x", { startRule: "c" }); }).to.throw();
         });
       });
 
-      describe("when optimizing for code size", function() {
-        describe("when |allowedStartRules| is not set", function() {
-          it("generated parser can start only from the first rule", function() {
-            const parser = peg.generate(grammar, { optimize: "size" });
-
-            expect(parser.parse("x", { startRule: "a" })).to.equal("x");
-            expect(() => { parser.parse("x", { startRule: "b" }); }).to.throw();
-            expect(() => { parser.parse("x", { startRule: "c" }); }).to.throw();
+      describe("when |allowedStartRules| is set", function() {
+        it("generated parser can start only from specified rules", function() {
+          const parser = peg.generate(grammar, {
+            allowedStartRules: ["b", "c"]
           });
-        });
 
-        describe("when |allowedStartRules| is set", function() {
-          it("generated parser can start only from specified rules", function() {
-            const parser = peg.generate(grammar, {
-              optimize: "size",
-              allowedStartRules: ["b", "c"]
-            });
-
-            expect(() => { parser.parse("x", { startRule: "a" }); }).to.throw();
-            expect(parser.parse("x", { startRule: "b" })).to.equal("x");
-            expect(parser.parse("x", { startRule: "c" })).to.equal("x");
-          });
+          expect(() => { parser.parse("x", { startRule: "a" }); }).to.throw();
+          expect(parser.parse("x", { startRule: "b" })).to.equal("x");
+          expect(parser.parse("x", { startRule: "c" })).to.equal("x");
         });
       });
     });
@@ -157,9 +126,6 @@ describe("Peggy API", function() {
         });
       });
     });
-
-    // The |optimize| option isn't tested because there is no meaningful way to
-    // write the tests without turning this into a performance test.
 
     describe("output", function() {
       const grammar = "start = 'a'";

--- a/test/behavior/generated-parser-behavior.spec.js
+++ b/test/behavior/generated-parser-behavior.spec.js
@@ -19,14 +19,14 @@ describe("generated parser behavior", function() {
     }
 
     const optionsVariants = [
-      { cache: false, optimize: "speed", trace: false },
-      { cache: false, optimize: "speed", trace: true  },
-      { cache: false, optimize: "size",  trace: false },
-      { cache: false, optimize: "size",  trace: true  },
-      { cache: true,  optimize: "speed", trace: false },
-      { cache: true,  optimize: "speed", trace: true  },
-      { cache: true,  optimize: "size",  trace: false },
-      { cache: true,  optimize: "size",  trace: true  }
+      { cache: false, trace: false },
+      { cache: false, trace: true  },
+      { cache: false, trace: false },
+      { cache: false, trace: true  },
+      { cache: true,  trace: false },
+      { cache: true,  trace: true  },
+      { cache: true,  trace: false },
+      { cache: true,  trace: true  }
     ];
 
     optionsVariants.forEach(variant => {


### PR DESCRIPTION
There no reasons for use value other than `speed`.

CLI option and definition in `.d.ts` are left for backward compatibility