### PR TITLE
API for registering multipli errors, warnings and informational messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This file documents all notable changes to Peggy.
 
 Released: TBD
 
+### Major Changes
+
+- Introduce an API to reporting errors, warnings and information messages from
+  passes. New API allows to report several diagnostics at once with intermediate
+  results checking after each compilation stage.
+  [@Mingun](https://github.com/peggyjs/peggy/pull/160)
+
 ### Minor Changes
 
 - Infrastructural rebake [@StoneCypher](https://github.com/peggyjs/peggy/pull/107)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ object to `peg.generate`. The following options are supported:
   _global initializer_ and the _per-parse initializer_. Unless the parser is
   to be generated in different formats, it is recommended to rather import
   dependencies from within the _global initializer_. (default: `{}`)
+- `error` — callback for errors. See [Error Reporting](#error-reporting)
 - `exportVar` — name of a global variable into which the parser object is
   assigned to when no module loader is detected; valid only when `format` is
   set to `"globals"` or `"umd"` (default: `null`)
@@ -173,11 +174,32 @@ object to `peg.generate`. The following options are supported:
   `source` property (default: `undefined`). This object will be used even if
   `options.grammarSource` is redefined in the grammar. It is useful to attach
   the file information to the errors, for example
+- `info` — callback for informational messages. See [Error Reporting](#error-reporting)
 - `output` — if set to `"parser"`, the method will return generated parser
   object; if set to `"source"`, it will return parser source code as a string
   (default: `"parser"`)
 - `plugins` — plugins to use. See the [Plugins API](#plugins-api) section
 - `trace` — makes the parser trace its progress (default: `false`)
+- `warn` — callback for warnings. See [Error Reporting](#error-reporting)
+
+#### Error Reporting
+
+During the generation compiler can throw a `GrammarError`s.
+
+There is also another way to collect problems as fast as they are reported —
+register an one of callbacks:
+
+- `error(stage: Stage, message: string, location?: LocationRange, notes?: DiagnosticNote[]): void`
+- `warn(stage: Stage, message: string, location?: LocationRange, notes?: DiagnosticNote[]): void`
+- `info(stage: Stage, message: string, location?: LocationRange, notes?: DiagnosticNote[]): void`
+
+All parameters are the same as the parameters of the [reporting API](#session-api)
+except the first. The `stage` represent one of possible stages during which execution
+a diagnostic was generated. This is a string enumeration, that currently has a three
+values:
+- `check`
+- `transform`
+- `generate`
 
 ## Using the Parser
 
@@ -674,6 +696,10 @@ note: Step 3: call itself without input consumption - left recursion
   |        ^^^^^
 ```
 
+A plugins can register additional passes that can generate `GrammarError`s to report
+about problems, but they shouldn't does that by throwing an instance of `GrammarError`.
+They should use a [session API](#session-api) instead.
+
 ## Locations
 
 During the parsing you can access to the information of the current parse location,
@@ -769,11 +795,13 @@ method.
     - `generate` — passes used for actual code generating
 
     A plugin that implement a pass usually should push it to the end of one of that
-    arrays. Pass is a simple function with signature `pass(ast, options)`:
+    arrays. Pass is a simple function with signature `pass(ast, options, session)`:
     - `ast` — the AST created by the `config.parser.parse()` method
     - `options` — compilation options passed to the `peggy.compiler.compile()` method.
       If parser generation is started because `generate()` function was called that
       is also an options, passed to the `generate()` method
+    - `session` — a [`Session`](#session-api) object that allow to raise errors,
+      warnings and informational messages
   - `reservedWords` — string array with a list of words that shouldn't be used as
     label names. This list can be modified by plugins. That property is not required
     to be sorted or not contain duplicates, but it is recommend to remove duplicates.
@@ -782,6 +810,59 @@ method.
     in the `peggy.RESERVED_WORDS` property.
 - `options` — build options passed to the `generate()` method. A best practice for
   a plugin would look for its own options under a `<plugin_name>` key.
+
+### Session API
+
+Each compilation request is represented by a `Session` instance. Object of this class
+is created by the compiler and passed to an each pass as a 3rd parameter. The session
+object gives access to the various compiler services. By present time there is only
+one such service: reporting of diagnostics.
+
+All diagnostics are divided into three groups: errors, warnings and informational
+messages. For an each of them the `Session` object has a method, described below.
+
+All reporting methods have an identical signature:
+
+```typescript
+(message: string, location?: LocationRange, notes?: DiagnosticNote[]) => void;
+```
+
+- `message`: a main diagnostic message
+- `location`: an optional location information if diagnostic is related to the grammar
+  source code
+- `details`: an array with additional details about diagnostic, pointing to the
+  different places in the grammar. For example, each note could be a location of
+  a duplicated rule definition
+
+#### `error(...)`
+
+Reports an error. Compilation process is subdivided into peaces called _stages_ and
+each stage consist of one or more _passes_. Within the one stage all errors, reported
+by different passes, are collected, but does not interrupt the parsing process.
+
+When all passes in the stage are completed, the stage is checked for errors. If one
+was registered, a `GrammarError` with all found problems in the `problems` property
+is thrown. If there are no errors, then the next stage is processed.
+
+After processing all three stages (`check`, `transform` and `generate`) compilation
+process is finished.
+
+The process, described above, means that passes should be careful about what they
+doing. For example, if you place your pass into the `check` stage there is no
+guaranties that all rules exists, because checking for existing rules is also
+performing during the `check` stage. On the contrary, passes in the `transform`
+and `generate` stages can be sure that all rules exists, because that precondition
+was checked on the `check` stage.
+
+#### `warn(...)`
+
+Reports a warning. Warnings are similar to errors, but they does not lead to interrupt
+a compilation.
+
+#### `info(...)`
+
+Report an informational message. This method can be used to inform user about significant
+changes in the grammar, for example, replacing proxy rules.
 
 ## Compatibility
 

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -54,7 +54,12 @@
     <a href="#generating-a-parser">Generating a Parser</a>
     <ul>
       <li><a href="#generating-a-parser-command-line">Command Line</a></li>
-      <li><a href="#generating-a-parser-javascript-api">JavaScript API</a></li>
+      <li>
+        <a href="#generating-a-parser-javascript-api">JavaScript API</a>
+        <ul>
+          <li><a href="#error-reporting">Error Reporting</a></li>
+        </ul>
+      </li>
     </ul>
   </li>
   <li><a href="#using-the-parser">Using the Parser</a></li>
@@ -68,7 +73,12 @@
   </li>
   <li><a href="#error-messages">Error Messages</a></li>
   <li><a href="#locations">Locations</a></li>
-  <li><a href="#plugins-api">Plugins API</a></li>
+  <li>
+    <a href="#plugins-api">Plugins API</a>
+    <ul>
+      <li><a href="#session-api">Session API</a></li>
+    </ul>
+  </li>
   <li><a href="#compatibility">Compatibility</a></li>
 </ul>
 
@@ -222,6 +232,9 @@ supported:</p>
   dependencies from within the <em>global initializer</em> (default:
   <code>{}</code>).</dd>
 
+  <dt><code>error</code></dt>
+  <dd>Callback for errors. See <a href="#error-reporting">Error Reporting</a></dd>
+
   <dt><code>exportVar</code></dt>
   <dd>Name of a global variable into which the parser object is assigned to when
   no module loader is detected; valid only when <code>format</code> is set to
@@ -241,6 +254,9 @@ supported:</p>
   <code>source</code> in the location objects, that returned by the
   <code>location()</code> API function (default: <code>undefined</code>).</dd>
 
+  <dt><code>info</code></dt>
+  <dd>Callback for informational messages. See <a href="#error-reporting">Error Reporting</a></dd>
+
   <dt><code>output</code></dt>
   <dd>If set to <code>"parser"</code>, the method will return generated parser
   object; if set to <opde>"source"</code>, it will return parser source code as
@@ -251,7 +267,33 @@ supported:</p>
 
   <dt><code>trace</code></dt>
   <dd>Makes the parser trace its progress (default: <code>false</code>).</dd>
+
+  <dt><code>warn</code></dt>
+  <dd>Callback for warnings. See <a href="#error-reporting">Error Reporting</a></dd>
 </dl>
+
+<h4 id="error-reporting">Error Reporting</h4>
+
+<p>During the generation compiler can throw a <code>GrammarError</code>s.</p>
+
+<p>There is also another way to collect problems as fast as they are reported —
+register an one of callbacks:</p>
+
+<ul>
+  <li><code>error(stage: Stage, message: string, location?: LocationRange, notes?: DiagnosticNote[]): void</code></li>
+  <li><code>warn(stage: Stage, message: string, location?: LocationRange, notes?: DiagnosticNote[]): void</code></li>
+  <li><code>info(stage: Stage, message: string, location?: LocationRange, notes?: DiagnosticNote[]): void</code></li>
+</ul>
+
+<p>All parameters are the same as the parameters of the <a href="#session-api">reporting API</a> except the first.
+The <code>stage</code> represent one of possible stages during which execution a diagnostic was generated.
+This is a string enumeration, that currently has a three values:</p>
+
+<ul>
+  <li><code>check</code></li>
+  <li><code>transform</code></li>
+  <li><code>generate</code></li>
+</ul>
 
 <h2 id="using-the-parser">Using the Parser</h2>
 
@@ -765,6 +807,10 @@ note: Step 3: call itself without input consumption - left recursion
 3 | end = !start
   |        ^^^^^</code></pre>
 
+<p>A plugins can register additional passes that can generate <code>GrammarError</code>s to report about
+problems, but they shouldn't does that by throwing an instance of <code>GrammarError</code>. They should
+use a <a href="#session-api">session API</a> instead.</p>
+
 <h2 id="locations">Locations</h2>
 
 <p>During the parsing you can access to the information of the current parse location,
@@ -866,13 +912,15 @@ method.</p>
     </ul>
 
     <p>A plugin that implement a pass usually should push it to the end of one of that
-    arrays. Pass is a simple function with signature <code>pass(ast, options)</code>:</p>
+    arrays. Pass is a simple function with signature <code>pass(ast, options, session)</code>:</p>
 
     <ul>
       <li><code>ast</code> — the AST created by the <code>config.parser.parse()</code> method</li>
       <li><code>options</code> — compilation options passed to the <code>peggy.compiler.compile()</code> method.
       If parser generation is started because <code>generate()</code> function was called that
       is also an options, passed to the <code>generate()</code> method</li>
+      <li><code>session</code> — a <a href="#session-api"><code>Session</code></a> object that allow to raise errors,
+      warnings and informational messages</li>
     </ul>
   </dd>
 
@@ -890,6 +938,62 @@ method.</p>
 <h3><code>options</code></h3>
 <dd>Build options passed to the <code>generate()</code> method. A best practice for
 a plugin would look for its own options under a <code>&lt;plugin_name&gt;</code> key.</dd>
+
+
+<h3 id="session-api">Session API</h3>
+
+<p>Each compilation request is represented by a <code>Session</code> instance. Object of this class
+is created by the compiler and passed to an each pass as a 3rd parameter. The session
+object gives access to the various compiler services. By present time there is only
+one such service: reporting of diagnostics.</p>
+
+<p>All diagnostics are divided into three groups: errors, warnings and informational
+messages. For an each of them the <code>Session</code> object has a method, described below.</p>
+
+<p>All reporting methods have an identical signature:</p>
+
+<pre><code class="language-typescript">(message: string, location?: LocationRange, notes?: DiagnosticNote[]) =&gt; void;
+</code></pre>
+
+<ul>
+  <li><code>message</code>: a main diagnostic message</li>
+  <li><code>location</code>: an optional location information if diagnostic is related to the grammar
+  source code</li>
+  <li><code>details</code>: an array with additional details about diagnostic, pointing to the
+  different places in the grammar. For example, each note could be a location of
+  a duplicated rule definition</li>
+</ul>
+
+<dl>
+  <dt><code>error(...)</code></dt>
+  <dd>
+    <p>Reports an error. Compilation process is subdivided into peaces called <em>stages</em> and
+    each stage consist of one or more <em>passes</em>. Within the one stage all errors, reported
+    by different passes, are collected, but does not interrupt the parsing process.</p>
+
+    <p>When all passes in the stage are completed, the stage is checked for errors. If one
+    was registered, a <code>GrammarError</code> with all found problems in the <code>problems</code> property
+    is thrown. If there are no errors, then the next stage is processed.</p>
+
+    <p>After processing all three stages (<code>check</code>, <code>transform</code> and <code>generate</code>) compilation
+    process is finished.</p>
+
+    <p>The process, described above, means that passes should be careful about what they
+    doing. For example, if you place your pass into the <code>check</code> stage there is no
+    guaranties that all rules exists, because checking for existing rules is also
+    performing during the <code>check</code> stage. On the contrary, passes in the <code>transform</code>
+    and <code>generate</code> stages can be sure that all rules exists, because that precondition
+    was checked on the <code>check</code> stage.</p>
+  </dd>
+
+  <dt><code>warn(...)</code></dt>
+  <dd>Reports a warning. Warnings are similar to errors, but they does not lead to
+  interrupt a compilation.</dd>
+
+  <dt><code>info(...)</code></dt>
+  <dd>Report an informational message. This method can be used to inform user about
+  significant changes in the grammar, for example, replacing proxy rules.</dd>
+</dl>
 
 <h2 id="compatibility">Compatibility</h2>
 

--- a/lib/compiler/asts.js
+++ b/lib/compiler/asts.js
@@ -45,7 +45,11 @@ const asts = {
       semantic_not: consumesFalse,
 
       rule_ref(node) {
-        return consumes(asts.findRule(ast, node.name));
+        const rule = asts.findRule(ast, node.name);
+
+        // Because we run all checks in one stage, some rules could be missing.
+        // Checking for missing rules could be executed in parallel to this check
+        return rule ? consumes(rule) : undefined;
       },
 
       literal(node) {

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -83,6 +83,9 @@ const compiler = {
 
         pass(ast, options, session);
       });
+
+      // Collect all errors by stage
+      session.checkErrors();
     });
 
     switch (options.output) {

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -9,6 +9,7 @@ const reportInfiniteRecursion = require("./passes/report-infinite-recursion");
 const reportInfiniteRepetition = require("./passes/report-infinite-repetition");
 const reportUndefinedRules = require("./passes/report-undefined-rules");
 const reportIncorrectPlucking = require("./passes/report-incorrect-plucking");
+const Session = require("./session");
 const visitor = require("./visitor");
 
 function processOptions(options, defaults) {
@@ -72,8 +73,16 @@ const compiler = {
       trace: false
     });
 
+    const session = new Session(options);
     Object.keys(passes).forEach(stage => {
-      passes[stage].forEach(p => { p(ast, options); });
+      session.stage = stage;
+      session.info(`Process stage ${stage}`);
+
+      passes[stage].forEach((pass, i) => {
+        session.info(`Process pass ${stage}.${i}`);
+
+        pass(ast, options, session);
+      });
     });
 
     switch (options.output) {

--- a/lib/compiler/passes/remove-proxy-rules.js
+++ b/lib/compiler/passes/remove-proxy-rules.js
@@ -1,9 +1,10 @@
 "use strict";
 
+const asts = require("../asts");
 const visitor = require("../visitor");
 
 // Removes proxy rules -- that is, rules that only delegate to other rule.
-function removeProxyRules(ast, options) {
+function removeProxyRules(ast, options, session) {
   function isProxyRule(node) {
     return node.type === "rule" && node.expression.type === "rule_ref";
   }
@@ -13,6 +14,15 @@ function removeProxyRules(ast, options) {
       rule_ref(node) {
         if (node.name === from) {
           node.name = to;
+
+          session.info(
+            `Proxy rule ${from} replaced to the rule ${to}`,
+            node.location,
+            [{
+              message: "This rule will be used",
+              location: asts.findRule(ast, to).nameLocation
+            }]
+          );
         }
       }
     });

--- a/lib/compiler/passes/report-duplicate-labels.js
+++ b/lib/compiler/passes/report-duplicate-labels.js
@@ -1,10 +1,9 @@
 "use strict";
 
-const GrammarError = require("../../grammar-error");
 const visitor = require("../visitor");
 
 // Checks that each label is defined only once within each scope.
-function reportDuplicateLabels(ast) {
+function reportDuplicateLabels(ast, options, session) {
   function cloneEnv(env) {
     const clone = {};
 
@@ -35,7 +34,7 @@ function reportDuplicateLabels(ast) {
     labeled(node, env) {
       const label = node.label;
       if (label && Object.prototype.hasOwnProperty.call(env, label)) {
-        throw new GrammarError(
+        session.error(
           `Label "${node.label}" is already defined`,
           node.labelLocation,
           [{

--- a/lib/compiler/passes/report-duplicate-rules.js
+++ b/lib/compiler/passes/report-duplicate-rules.js
@@ -1,16 +1,15 @@
 "use strict";
 
-const GrammarError = require("../../grammar-error");
 const visitor = require("../visitor");
 
 // Checks that each rule is defined only once.
-function reportDuplicateRules(ast) {
+function reportDuplicateRules(ast, options, session) {
   const rules = {};
 
   const check = visitor.build({
     rule(node) {
       if (Object.prototype.hasOwnProperty.call(rules, node.name)) {
-        throw new GrammarError(
+        session.error(
           `Rule "${node.name}" is already defined`,
           node.nameLocation,
           [{
@@ -18,6 +17,9 @@ function reportDuplicateRules(ast) {
             location: rules[node.name]
           }]
         );
+
+        // Do not rewrite original rule location
+        return;
       }
 
       rules[node.name] = node.nameLocation;

--- a/lib/compiler/passes/report-incorrect-plucking.js
+++ b/lib/compiler/passes/report-incorrect-plucking.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const GrammarError = require("../../grammar-error");
 const visitor = require("../visitor");
 
 //
@@ -8,7 +7,7 @@ const visitor = require("../visitor");
 //
 //   - plucking can not be done with an action block
 //
-function reportIncorrectPlucking(ast) {
+function reportIncorrectPlucking(ast, options, session) {
   const check = visitor.build({
     action(node) {
       check(node.expression, node);
@@ -17,7 +16,7 @@ function reportIncorrectPlucking(ast) {
     labeled(node, action) {
       if (node.pick) {
         if (action) {
-          throw new GrammarError(
+          session.error(
             "\"@\" cannot be used with an action block",
             node.labelLocation,
             [{

--- a/lib/compiler/passes/report-infinite-recursion.js
+++ b/lib/compiler/passes/report-infinite-recursion.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const GrammarError = require("../../grammar-error");
 const asts = require("../asts");
 const visitor = require("../visitor");
 
@@ -14,7 +13,7 @@ const visitor = require("../visitor");
 //
 // In general, if a rule reference can be reached without consuming any input,
 // it can lead to left recursion.
-function reportInfiniteRecursion(ast) {
+function reportInfiniteRecursion(ast, options, session) {
   // Array with rule names for error message
   const visitedRules = [];
   // Array with rule_refs for diagnostic
@@ -43,7 +42,7 @@ function reportInfiniteRecursion(ast) {
       if (visitedRules.indexOf(node.name) !== -1) {
         visitedRules.push(node.name);
 
-        throw new GrammarError(
+        session.error(
           "Possible infinite loop when parsing (left recursion: "
             + visitedRules.join(" -> ")
             + ")",
@@ -57,9 +56,16 @@ function reportInfiniteRecursion(ast) {
             };
           })
         );
+
+        // Because we enter into recursion we should break it
+        return;
       }
 
-      check(rule);
+      // Because we run all checks in one stage, some rules could be missing - this check
+      // executed in parallel
+      if (rule) {
+        check(rule);
+      }
       backtraceRefs.pop();
     }
   });

--- a/lib/compiler/passes/report-infinite-repetition.js
+++ b/lib/compiler/passes/report-infinite-repetition.js
@@ -1,16 +1,15 @@
 "use strict";
 
-const GrammarError = require("../../grammar-error");
 const asts = require("../asts");
 const visitor = require("../visitor");
 
 // Reports expressions that don't consume any input inside |*| or |+| in the
 // grammar, which prevents infinite loops in the generated parser.
-function reportInfiniteRepetition(ast) {
+function reportInfiniteRepetition(ast, options, session) {
   const check = visitor.build({
     zero_or_more(node) {
       if (!asts.alwaysConsumesOnSuccess(ast, node.expression)) {
-        throw new GrammarError(
+        session.error(
           "Possible infinite loop when parsing (repetition used with an expression that may not consume any input)",
           node.location
         );
@@ -19,7 +18,7 @@ function reportInfiniteRepetition(ast) {
 
     one_or_more(node) {
       if (!asts.alwaysConsumesOnSuccess(ast, node.expression)) {
-        throw new GrammarError(
+        session.error(
           "Possible infinite loop when parsing (repetition used with an expression that may not consume any input)",
           node.location
         );

--- a/lib/compiler/passes/report-undefined-rules.js
+++ b/lib/compiler/passes/report-undefined-rules.js
@@ -1,15 +1,14 @@
 "use strict";
 
-const GrammarError = require("../../grammar-error");
 const asts = require("../asts");
 const visitor = require("../visitor");
 
 // Checks that all referenced rules exist.
-function reportUndefinedRules(ast) {
+function reportUndefinedRules(ast, options, session) {
   const check = visitor.build({
     rule_ref(node) {
       if (!asts.findRule(ast, node.name)) {
-        throw new GrammarError(
+        session.error(
           `Rule "${node.name}" is not defined`,
           node.location
         );

--- a/lib/compiler/session.js
+++ b/lib/compiler/session.js
@@ -10,8 +10,8 @@ class Defaults {
     if (typeof options.warn === "function") { this.warn = options.warn; }
     if (typeof options.info === "function") { this.info = options.info; }
   }
-  error(stage, ...args) {
-    throw new GrammarError(...args);
+  error() {
+    // intentionally empty placeholder
   }
   warn() {
     // intentionally empty placeholder
@@ -24,12 +24,33 @@ class Defaults {
 class Session {
   constructor(options) {
     this._callbacks = new Defaults(options);
+    this._firstError = null;
     this.errors = 0;
     this.problems = [];
     this.stage = null;
   }
   error(...args) {
     ++this.errors;
+    // In order to preserve backward compatibility we cannot change `GrammarError`
+    // constructor, nor throw another class of error:
+    // - if we change `GrammarError` constructor, this will break plugins that
+    //   throws `GrammarError`
+    // - if we throw another Error class, this will break parser clients that
+    //   catches GrammarError
+    //
+    // So we use a compromise: we throw an `GrammarError` with all found problems
+    // in the `problems` property, but the thrown error itself is the first
+    // registered error.
+    //
+    // Thus when the old client catches the error it can find all properties on
+    // the Grammar error that it want. On the other hand the new client can
+    // inspect the `problems` property to get all problems.
+    if (this._firstError === null) {
+      this._firstError = new GrammarError(...args);
+      this._firstError.stage = this.stage;
+      this._firstError.problems = this.problems;
+    }
+
     this.problems.push(["error", ...args]);
     this._callbacks.error(this.stage, ...args);
   }
@@ -40,6 +61,12 @@ class Session {
   info(...args) {
     this.problems.push(["info", ...args]);
     this._callbacks.info(this.stage, ...args);
+  }
+
+  checkErrors() {
+    if (this.errors !== 0) {
+      throw this._firstError;
+    }
   }
 }
 

--- a/lib/compiler/session.js
+++ b/lib/compiler/session.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const GrammarError = require("../grammar-error");
+
+class Defaults {
+  constructor(options) {
+    options = typeof options !== "undefined" ? options : {};
+
+    if (typeof options.error === "function") { this.error = options.error; }
+    if (typeof options.warn === "function") { this.warn = options.warn; }
+    if (typeof options.info === "function") { this.info = options.info; }
+  }
+  error(stage, ...args) {
+    throw new GrammarError(...args);
+  }
+  warn() {
+    // intentionally empty placeholder
+  }
+  info() {
+    // intentionally empty placeholder
+  }
+}
+
+class Session {
+  constructor(options) {
+    this._callbacks = new Defaults(options);
+    this.errors = 0;
+    this.problems = [];
+    this.stage = null;
+  }
+  error(...args) {
+    ++this.errors;
+    this.problems.push(["error", ...args]);
+    this._callbacks.error(this.stage, ...args);
+  }
+  warn(...args) {
+    this.problems.push(["warn", ...args]);
+    this._callbacks.warn(this.stage, ...args);
+  }
+  info(...args) {
+    this.problems.push(["info", ...args]);
+    this._callbacks.info(this.stage, ...args);
+  }
+}
+
+module.exports = Session;

--- a/lib/grammar-error.js
+++ b/lib/grammar-error.js
@@ -27,6 +27,10 @@ class GrammarError extends Error {
       diagnostics = [];
     }
     this.diagnostics = diagnostics;
+    // All problems if this error is thrown by the plugin and not at stage
+    // checking phase
+    this.stage = null;
+    this.problems = [["error", message, location, diagnostics]];
   }
 
   toString() {

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -230,12 +230,36 @@ export interface DiagnosticNote {
   location: LocationRange;
 }
 
+/** Possible compilation stage name. */
+type Stage = keyof Stages;
+/** Severity level of problems that can be registered in compilation session. */
+type Severity = "error" | "warn" | "info";
+
+type Problem = [
+  /** Problem severity. */
+  Severity,
+  /** Diagnostic message. */
+  string,
+  /** Location where message is generated, if applicable. */
+  LocationRange?,
+  /** List of additional messages with their locations, if applicable. */
+  DiagnosticNote[]?,
+];
+
 /** Thrown if the grammar contains a semantic error. */
 export class GrammarError extends Error {
   /** Location of the error in the source. */
   location?: LocationRange;
   /** Additional messages with context information. */
   diagnostics: DiagnosticNote[];
+
+  /** Compilation stage during which error was generated. */
+  stage: Stage | null;
+  /**
+   * List of diagnostics containing all errors, warnings and information
+   * messages generated during compilation stage `stage`.
+   */
+  problems: Problem[];
 
   constructor(message: string, location?: LocationRange, diagnostics?: DiagnosticNote[]);
 
@@ -849,6 +873,36 @@ export interface Session {
   info(message: string, location?: LocationRange, notes?: DiagnosticNote[]): void;
 }
 
+export interface DiagnosticCallback {
+  /**
+   * Called when compiler reports an error.
+   *
+   * @param stage Stage in which this diagnostic was originated
+   * @param message Main message, which should describe error objectives
+   * @param location If defined, this is location described in the `message`
+   * @param notes Additional messages with context information
+   */
+  error?(stage: Stage, message: string, location?: LocationRange, notes?: DiagnosticNote[]): void;
+  /**
+   * Called when compiler reports a warning.
+   *
+   * @param stage Stage in which this diagnostic was originated
+   * @param message Main message, which should describe warning objectives
+   * @param location If defined, this is location described in the `message`
+   * @param notes Additional messages with context information
+   */
+  warn?(stage: Stage, message: string, location?: LocationRange, notes?: DiagnosticNote[]): void;
+  /**
+   * Called when compiler reports an informational message.
+   *
+   * @param stage Stage in which this diagnostic was originated
+   * @param message Main message, which gives information about an event
+   * @param location If defined, this is location described in the `message`
+   * @param notes Additional messages with context information
+   */
+  info?(stage: Stage, message: string, location?: LocationRange, notes?: DiagnosticNote[]): void;
+}
+
 export interface BuildOptionsBase {
   /** rules the parser will be allowed to start parsing from (default: the first rule in the grammar) */
   allowedStartRules?: string[];
@@ -873,6 +927,13 @@ export interface BuildOptionsBase {
   plugins?: Plugin[];
   /** makes the parser trace its progress (default: `false`) */
   trace?: boolean;
+
+  /** Called when a semantic error during build was detected. */
+  error?: DiagnosticCallback;
+  /** Called when a warning during build was registered. */
+  warn?: DiagnosticCallback;
+  /** Called when an informational message during build was registered. */
+  info?: DiagnosticCallback;
 }
 
 export interface ParserBuildOptions extends BuildOptionsBase {

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -723,9 +723,12 @@ export type ParserTracerEvent =
  *
  * @param ast Reference to the parsed grammar. Pass can change it
  * @param options Options that was supplied to the `PEG.generate()` call.
- *        All passes shared the same options object
+ *        All passes shares the same options object
+ * @param session An object that stores information about current compilation
+ *        session and allows passes to report errors, warnings, and information
+ *        messages. All passes shares the same session object
  */
-export type Pass = (ast: ast.Grammar, options: ParserBuildOptions) => void;
+export type Pass = (ast: ast.Grammar, options: ParserBuildOptions, session: Session) => void;
 
 /**
  * List of possible compilation stages. Each stage consist of the one or
@@ -789,6 +792,61 @@ export interface Plugin {
    *        options in the object with name of plugin to reduce possible clashes
    */
   use(config: Config, options: ParserBuildOptions): void;
+}
+
+/**
+ * Compiler session, that allow a pass to register an error, warning or
+ * an informational message.
+ *
+ * A new session is created for the each `PEG.generate()` call.
+ * All passes, involved in the compilation, shares the one session object.
+ *
+ * Passes should use that object to reporting errors instead of throwing
+ * exceptions, because reporting via this object allows report multiply
+ * errors from different passes. Throwing `GrammarError` are also allowed
+ * for backward compatibility.
+ *
+ * Errors will be reported after completion of each compilation stage where
+ * each of them can have multiply passes. Plugins can register as many
+ * stages as they want, but it is recommended to register pass in the
+ * one of default stages, if possible:
+ * - `check`
+ * - `transform`
+ * - `generate`
+ */
+export interface Session {
+  /**
+   * Reports an error. Pass shouldn't assume that after reporting error it
+   * will be interrupted by throwing exception or in the other way. Therefore,
+   * if after reporting error further execution of the pass is impossible, it
+   * should use control flow statements, such as `break`, `continue`, `return`
+   * to stop their execution.
+   *
+   * @param message Main message, which should describe error objectives
+   * @param location If defined, this is location described in the `message`
+   * @param notes Additional messages with context information
+   */
+  error(message: string, location?: LocationRange, notes?: DiagnosticNote[]): void;
+  /**
+   * Reports a warning. Warning is a diagnostic, that doesn't prevent further
+   * execution of a pass, but possible points to the some mistake, that should
+   * be fixed.
+   *
+   * @param message Main message, which should describe warning objectives
+   * @param location If defined, this is location described in the `message`
+   * @param notes Additional messages with context information
+   */
+  warn(message: string, location?: LocationRange, notes?: DiagnosticNote[]): void;
+  /**
+   * Reports an informational message. such messages can report some important
+   * details of pass execution that could be useful for the user, for example,
+   * performed transformations over the AST.
+   *
+   * @param message Main message, which gives information about an event
+   * @param location If defined, this is location described in the `message`
+   * @param notes Additional messages with context information
+   */
+  info(message: string, location?: LocationRange, notes?: DiagnosticNote[]): void;
 }
 
 export interface BuildOptionsBase {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@rollup/plugin-multi-entry": "^4.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-typescript": "^8.2.1",
+    "@types/chai": "^4.2.18",
     "@types/jest": "^26.0.23",
     "chai": "^4.3.4",
     "eslint": "^7.26.0",

--- a/test/behavior/generated-parser-behavior.spec.js
+++ b/test/behavior/generated-parser-behavior.spec.js
@@ -1682,5 +1682,36 @@ Error: Expected "{", code block, comment, end of line, identifier, or whitespace
         }
       }).to.throw(peg.parser.SyntaxError);
     });
+
+    it("reports multiply errors in each compilation stage", function() {
+      try {
+        peg.generate(`
+          start = leftRecursion
+          leftRecursion = duplicatedLabel:duplicatedRule duplicatedLabel:missingRule
+          duplicatedRule = missingRule
+          duplicatedRule = start
+        `);
+      } catch (e) {
+        expect(e).with.property("stage", "check");
+        expect(e).with.property("problems").to.be.an("array");
+
+        // Check that each problem is an array with at least two members and the first is a severity
+        e.problems.forEach(problem => {
+          expect(problem).to.be.an("array").lengthOf.gte(2);
+          expect(problem[0]).to.be.oneOf(["error", "warn", "info"]);
+        });
+
+        // Get second elements of errors (error messages)
+        const messages = e.problems.filter(p => p[0] === "error").map(p => p[1]);
+
+        // Check that all messages present in the list
+        expect(messages).to.include.members([
+          "Rule \"missingRule\" is not defined",
+          "Rule \"duplicatedRule\" is already defined",
+          "Label \"duplicatedLabel\" is already defined",
+          "Possible infinite loop when parsing (left recursion: duplicatedRule -> start -> leftRecursion -> duplicatedRule)",
+        ]);
+      }
+    });
   });
 });

--- a/test/unit/compiler/passes/helpers.js
+++ b/test/unit/compiler/passes/helpers.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const parser = require("../../../../lib/parser");
+const Session = require("../../../../lib/compiler/session");
 
 module.exports = function(chai, utils) {
   const Assertion = chai.Assertion;
@@ -46,7 +47,7 @@ module.exports = function(chai, utils) {
 
     const ast = parser.parse(grammar);
 
-    utils.flag(this, "object")(ast, options);
+    utils.flag(this, "object")(ast, options, new Session());
 
     this.assert(
       matchProps(ast, props),
@@ -63,7 +64,7 @@ module.exports = function(chai, utils) {
     let passed, result;
 
     try {
-      utils.flag(this, "object")(ast);
+      utils.flag(this, "object")(ast, {}, new Session());
       passed = true;
     } catch (e) {
       result = e;

--- a/test/unit/compiler/passes/helpers.js
+++ b/test/unit/compiler/passes/helpers.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { GrammarError } = require("../../../../lib/peg");
 const parser = require("../../../../lib/parser");
 const Session = require("../../../../lib/compiler/session");
 
@@ -47,7 +48,9 @@ module.exports = function(chai, utils) {
 
     const ast = parser.parse(grammar);
 
-    utils.flag(this, "object")(ast, options, new Session());
+    utils.flag(this, "object")(ast, options, new Session({
+      error(stage, ...args) { throw new GrammarError(...args); }
+    }));
 
     this.assert(
       matchProps(ast, props),
@@ -64,7 +67,9 @@ module.exports = function(chai, utils) {
     let passed, result;
 
     try {
-      utils.flag(this, "object")(ast, {}, new Session());
+      utils.flag(this, "object")(ast, {}, new Session({
+        error(stage, ...args) { throw new GrammarError(...args); }
+      }));
       passed = true;
     } catch (e) {
       result = e;

--- a/test/unit/grammar-error.spec.js
+++ b/test/unit/grammar-error.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const chai = require("chai");
-const GrammarError = require("../../lib/grammar-error");
+const { GrammarError } = require("../../lib/peg");
 
 const expect = chai.expect;
 


### PR DESCRIPTION
Phew. Finally all necessary PRs are merged and I can provide this.

That is implementation of a Session API that I've [mentioned early](https://github.com/peggyjs/peggy/pull/116#discussion_r623355551) (well, couple of days turned into couple of weeks... but it worth it). Although I feared that a second commit could have to break backward compatibility, with the help of a small trick it was possible to avoid this. As a result, it turned out a little dirty, but without breaking changes.

The new API allows passes to register warnings, informational messages and errors and we can collect multiply errors in one compilation attempt -- as much as possible.

I've tried to explain everything in the README.md, so I will not repeat myself here. Just see the diff of the README.md.

Although it would be great to have this PR in the same version where we have [improved the errors](#116), it is possible that the changes here are too fundamental, so I don't rush you.