### PR TITLE
Fix some tests and definition of `dependencies` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Released: TBD
   - New -t/--test and -T/--testfile flags to directly test the generated grammar
 - Check allowedStartRules for validity [@hildjj](https://github.com/peggyjs/peggy/pull/175)
 
+### Bug fixes
+
+- [#164](https://github.com/peggyjs/peggy/pull/164): Fix some errors in the typescript definitions
+
 1.2.0
 -----
 

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -285,11 +285,11 @@ supported:</p>
 
   <dt><code>output</code></dt>
   <dd>If set to <code>"parser"</code>, the method will return generated parser
-  object; if set to <opde>"source"</code>, it will return parser source code as
+  object; if set to <code>"source"</code>, it will return parser source code as
   a string (default: <code>"parser"</code>).</dd>
 
   <dt><code>plugins</code></dt>
-  <dd>Plugins to use. See the [Plugins API](#plugins-api) section.</dd>
+  <dd>Plugins to use. See the <a href="#plugins-api">Plugins API</a> section.</dd>
 
   <dt><code>trace</code></dt>
   <dd>Makes the parser trace its progress (default: <code>false</code>).</dd>

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -917,9 +917,12 @@ export interface OutputFormatUmd extends BuildOptionsBase {
    * (default: `{}`)
    */
   dependencies?: Dependencies;
-
-  /** Name of a global variable into which the parser object is assigned to when no module loader is detected; valid only when `format` is set to `"globals"` or `"umd"` (default: `null`) */
-  exportVar?: any;
+  /**
+   * Name of a global variable into which the parser object is assigned to when
+   * no module loader is detected; valid only when `format` is set to `"globals"`
+   * (and in that case it should be defined) or `"umd"` (default: `null`)
+   */
+  exportVar?: string;
 }
 
 export interface OutputFormatGlobals extends BuildOptionsBase {
@@ -928,9 +931,12 @@ export interface OutputFormatGlobals extends BuildOptionsBase {
 
   /** Format of the generated parser (`"amd"`, `"bare"`, `"commonjs"`, `"es"`, `"globals"`, or `"umd"`); valid only when `output` is set to `"source"` (default: `"bare"`) */
   format: "globals";
-
-  /** Name of a global variable into which the parser object is assigned to when no module loader is detected; valid only when `format` is set to `"globals"` or `"umd"` (default: `null`) */
-  exportVar?: any;
+  /**
+   * Name of a global variable into which the parser object is assigned to when
+   * no module loader is detected; valid only when `format` is set to `"globals"`
+   * (and in that case it should be defined) or `"umd"` (default: `null`)
+   */
+  exportVar: string;
 }
 
 export interface OutputFormatBare extends BuildOptionsBase {

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -845,6 +845,14 @@ export interface Plugin {
   use(config: Config, options: ParserBuildOptions): void;
 }
 
+/**
+ * Parser dependencies, is an object which maps variables used to access the
+ * dependencies in the parser to module IDs used to load them
+ */
+export interface Dependencies {
+  [variable: string]: string;
+}
+
 export interface BuildOptionsBase {
   /** Rules the parser will be allowed to start parsing from (default: the first rule in the grammar) */
   allowedStartRules?: string[];
@@ -887,9 +895,13 @@ export interface OutputFormatAmdCommonjsEs extends BuildOptionsBase {
 
   /** Format of the generated parser (`"amd"`, `"bare"`, `"commonjs"`, `"es"`, `"globals"`, or `"umd"`); valid only when `output` is set to `"source"` (default: `"bare"`) */
   format: "amd" | "commonjs" | "es";
-
-  /** Parser dependencies, the value is an object which maps variables used to access the dependencies in the parser to module IDs used to load them; valid only when `format` is set to `"amd"`, `"commonjs"`, `"es"`, or `"umd"` (default: `{}`) */
-  dependencies?: any;
+  /**
+   * Parser dependencies, the value is an object which maps variables used to
+   * access the dependencies in the parser to module IDs used to load them;
+   * valid only when `format` is set to `"amd"`, `"commonjs"`, `"es"`, or `"umd"`
+   * (default: `{}`)
+   */
+  dependencies?: Dependencies;
 }
 
 export interface OutputFormatUmd extends BuildOptionsBase {
@@ -898,9 +910,13 @@ export interface OutputFormatUmd extends BuildOptionsBase {
 
   /** Format of the generated parser (`"amd"`, `"bare"`, `"commonjs"`, `"es"`, `"globals"`, or `"umd"`); valid only when `output` is set to `"source"` (default: `"bare"`) */
   format: "umd";
-
-  /** Parser dependencies, the value is an object which maps variables used to access the dependencies in the parser to module IDs used to load them; valid only when `format` is set to `"amd"`, `"commonjs"`, `"es"`, or `"umd"` (default: `{}`) */
-  dependencies?: any;
+  /**
+   * Parser dependencies, the value is an object which maps variables used to
+   * access the dependencies in the parser to module IDs used to load them;
+   * valid only when `format` is set to `"amd"`, `"commonjs"`, `"es"`, or `"umd"`
+   * (default: `{}`)
+   */
+  dependencies?: Dependencies;
 
   /** Name of a global variable into which the parser object is assigned to when no module loader is detected; valid only when `format` is set to `"globals"` or `"umd"` (default: `null`) */
   exportVar?: any;

--- a/test/behavior/generated-parser-behavior.spec.js
+++ b/test/behavior/generated-parser-behavior.spec.js
@@ -159,13 +159,13 @@ describe("generated parser behavior", () => {
         describe("without display name", () => {
           describe("returns its match result", () => {
             it("when expression may match", () => {
-              const parser = peg.generate("start = 'a'");
+              const parser = peg.generate("start = 'a'", options);
 
               expect(parser).to.parse("a", "a");
             });
 
             it("when expression always match", () => {
-              const parser = peg.generate("start = 'a'*");
+              const parser = peg.generate("start = 'a'*", options);
 
               expect(parser).to.parse("", []);
             });
@@ -175,13 +175,13 @@ describe("generated parser behavior", () => {
         describe("with display name", () => {
           describe("returns its match result", () => {
             it("when expression may match", () => {
-              const parser = peg.generate("start 'start' = 'a'");
+              const parser = peg.generate("start 'start' = 'a'", options);
 
               expect(parser).to.parse("a", "a");
             });
 
             it("when expression always match", () => {
-              const parser = peg.generate("start 'start' = 'a'*");
+              const parser = peg.generate("start 'start' = 'a'*", options);
 
               expect(parser).to.parse("", []);
             });
@@ -193,7 +193,7 @@ describe("generated parser behavior", () => {
         describe("without display name", () => {
           describe("reports match failure and records an expectation", () => {
             it("when expression may match", () => {
-              const parser = peg.generate("start = 'a'");
+              const parser = peg.generate("start = 'a'", options);
 
               expect(parser).to.failToParse("b", {
                 expected: [{ type: "literal", text: "a", ignoreCase: false }],
@@ -201,7 +201,7 @@ describe("generated parser behavior", () => {
             });
 
             it("when expression never match", () => {
-              const parser = peg.generate("start = []");
+              const parser = peg.generate("start = []", options);
 
               expect(parser).to.failToParse("b", {
                 expected: [{ type: "class", parts: [], inverted: false, ignoreCase: false }],
@@ -212,7 +212,7 @@ describe("generated parser behavior", () => {
 
         describe("with display name", () => {
           it("reports match failure and records an expectation of type \"other\" when expression may match", () => {
-            const parser = peg.generate("start 'start' = 'a'");
+            const parser = peg.generate("start 'start' = 'a'", options);
 
             expect(parser).to.failToParse("b", {
               expected: [{ type: "other", description: "start" }],
@@ -220,7 +220,7 @@ describe("generated parser behavior", () => {
           });
 
           it("reports match failure and doesn't records any expectations when expression never match", () => {
-            const parser = peg.generate("start 'start' = []");
+            const parser = peg.generate("start 'start' = []", options);
 
             expect(parser).to.failToParse("b", {
               expected: [],
@@ -228,7 +228,7 @@ describe("generated parser behavior", () => {
           });
 
           it("discards any expectations recorded when matching the expression", () => {
-            const parser = peg.generate("start 'start' = 'a'");
+            const parser = peg.generate("start 'start' = 'a'", options);
 
             expect(parser).to.failToParse("b", {
               expected: [{ type: "other", description: "start" }],
@@ -1070,8 +1070,8 @@ describe("generated parser behavior", () => {
         });
 
         it("prevents \"@\" on a semantic predicate", () => {
-          expect(() => peg.generate("start1 = 'a' @&{ /* semantic_and */ } 'c'")).to.throw();
-          expect(() => peg.generate("start2 = 'a' @!{ /* semantic_not */ } 'c'")).to.throw();
+          expect(() => peg.generate("start1 = 'a' @&{ /* semantic_and */ } 'c'"), options).to.throw();
+          expect(() => peg.generate("start2 = 'a' @!{ /* semantic_not */ } 'c'"), options).to.throw();
         });
       });
 


### PR DESCRIPTION
This PR fixes three things:
- some new behavior tests did not use the options, so not all variants were tested
- `options.definitions` was declared with type `any` instead of `object`
- `options.exportVar` was declared with type `any` instead of `string`; for `globals` format it is required