### PR TITLE
experimental source maps / improved cache layout

### DIFF
--- a/lib/compiler/opcodes.js
+++ b/lib/compiler/opcodes.js
@@ -55,6 +55,11 @@ const opcodes = {
   SILENT_FAILS_ON:   28,   // SILENT_FAILS_ON
   SILENT_FAILS_OFF:  29,   // SILENT_FAILS_OFF
 
+  // The parser may write comments or emit trace calls with
+  // information about the source code. In the future this may
+  // be used to produce source maps.
+  SOURCE_MAP: 42,
+
   // Because the tests have hard-coded opcode numbers, don't renumber
   // existing opcodes.  New opcodes that have been put in the correct
   // sections above are repeated here in order to ensure we don't

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -249,8 +249,8 @@ function generateBytecode(ast, options) {
   }
 
   function addFunctionConst(predicate, params, code) {
-    if(code.trim() === 'default'){
-      code = 'return {' + params.map(m => m + ':' + m).join(',') + '};';
+    if (code.trim() === "default") {
+      code = "return {" + params.map(m => m + ":" + m).join(",") + "};";
     }
     const func = { predicate, params, body: code };
     const pattern = JSON.stringify(func);
@@ -303,7 +303,7 @@ function generateBytecode(ast, options) {
       generate(expression, {
         sp: context.sp + 1,
         env: cloneEnv(context.env),
-        action: null
+        action: null,
       }),
       [op.SILENT_FAILS_OFF],
       buildCondition(
@@ -353,20 +353,19 @@ function generateBytecode(ast, options) {
     );
   }
 
-  function buildSourceMap(location, byteCode){
-    if(options.sourceMap){
+  function buildSourceMap(location, byteCode) {
+    if (options.sourceMap) {
       return buildSequence(
         [
-          op.SOURCE_MAP, 
+          op.SOURCE_MAP,
           location.start.offset, location.start.line, location.start.column,
-          location.end.offset,   location.end.line,   location.end.column
+          location.end.offset,   location.end.line,   location.end.column,
         ],
-        byteCode,
-      )
-    }else{
+        byteCode
+      );
+    } else {
       return byteCode;
     }
-    
   }
 
   const generate = visitor.build({
@@ -384,17 +383,16 @@ function generateBytecode(ast, options) {
         sp: -1,        // Stack pointer
         env: {},       // Mapping of label names to stack positions
         pluck: [],     // Fields that have been picked
-        action: null   // Action nodes pass themselves to children here
+        action: null,   // Action nodes pass themselves to children here
       });
     },
 
     named(node, context) {
       const match = node.match | 0;
-      const nameIndex = (match === NEVER_MATCH) 
-      ? null
-      : addExpectedConst({ type: "rule", value: node.name });
+      const nameIndex = (match === NEVER_MATCH)
+        ? null
+        : addExpectedConst({ type: "rule", value: node.name });
 
-      
       // The code generated below is slightly suboptimal because |FAIL| pushes
       // to the stack, so we need to stick a |POP| in front of it. We lack a
       // dedicated instruction that would just report the failure and not touch
@@ -413,7 +411,7 @@ function generateBytecode(ast, options) {
         const first = generate(alternatives[0], {
           sp: context.sp,
           env: cloneEnv(context.env),
-          action: null
+          action: null,
         });
         // If an alternative always match, no need to generate code for the next
         // alternatives. Because their will never tried to match, any side-effects
@@ -430,14 +428,14 @@ function generateBytecode(ast, options) {
           first,
           alternatives.length > 1
             ? buildCondition(
-                SOMETIMES_MATCH,
-                [op.IF_ERROR],
-                buildSequence(
-                  [op.POP],
-                  buildAlternativesCode(alternatives.slice(1), context)
-                ),
-                []
-              )
+              SOMETIMES_MATCH,
+              [op.IF_ERROR],
+              buildSequence(
+                [op.POP],
+                buildAlternativesCode(alternatives.slice(1), context)
+              ),
+              []
+            )
             : []
         );
       }
@@ -450,9 +448,9 @@ function generateBytecode(ast, options) {
       const emitCall = node.expression.type !== "sequence"
                     || node.expression.elements.length === 0;
       const expressionCode = generate(node.expression, {
-            sp: context.sp + (emitCall ? 1 : 0),
-            env,
-            action: node
+        sp: context.sp + (emitCall ? 1 : 0),
+        env,
+        action: node,
       });
       const match = node.expression.match | 0;
       // Function only required if expression can match
@@ -462,33 +460,33 @@ function generateBytecode(ast, options) {
 
       return emitCall
         ? buildSequence(
-            [op.PUSH_CURR_POS],
-            expressionCode,
-            buildCondition(
-              match,
-              [op.IF_NOT_ERROR],
-              buildSequence(
-                [op.LOAD_SAVED_POS, 1],
-                buildCall(functionIndex, 1, env, context.sp + 2)
-              ),
-              []
+          [op.PUSH_CURR_POS],
+          expressionCode,
+          buildCondition(
+            match,
+            [op.IF_NOT_ERROR],
+            buildSequence(
+              [op.LOAD_SAVED_POS, 1],
+              buildCall(functionIndex, 1, env, context.sp + 2)
             ),
-            [op.NIP]
-          )
+            []
+          ),
+          [op.NIP]
+        )
         : expressionCode;
     },
 
     sequence(node, context) {
       function buildElementsCode(elements, context) {
         if (elements.length > 0) {
-        const processedCount = node.elements.length - elements.length + 1;
-        
+          const processedCount = node.elements.length - elements.length + 1;
+
           return buildSequence(
             generate(elements[0], {
               sp: context.sp,
               env: context.env,
               pluck: context.pluck,
-              action: null
+              action: null,
             }),
             buildCondition(
               elements[0].match | 0,
@@ -497,7 +495,7 @@ function generateBytecode(ast, options) {
                 sp: context.sp + 1,
                 env: context.env,
                 pluck: context.pluck,
-                action: context.action
+                action: context.action,
               }),
               buildSequence(
                 processedCount > 1 ? [op.POP_N, processedCount] : [op.POP],
@@ -506,11 +504,11 @@ function generateBytecode(ast, options) {
               )
             )
           );
-        } else {          
+        } else {
           if (context.pluck.length > 0) {
             return buildSequence(
-              [ op.PLUCK, node.elements.length + 1,
-                context.pluck.length ],
+              [op.PLUCK, node.elements.length + 1,
+                context.pluck.length],
               context.pluck.map(eSP => context.sp - eSP)
             );
           }
@@ -543,7 +541,7 @@ function generateBytecode(ast, options) {
           sp: context.sp + 1,
           env: context.env,
           pluck: [],
-          action: context.action
+          action: context.action,
         })
       );
     },
@@ -565,7 +563,7 @@ function generateBytecode(ast, options) {
       return generate(node.expression, {
         sp: context.sp,
         env,
-        action: null
+        action: null,
       });
     },
 
@@ -575,7 +573,7 @@ function generateBytecode(ast, options) {
         generate(node.expression, {
           sp: context.sp + 1,
           env: cloneEnv(context.env),
-          action: null
+          action: null,
         }),
         buildCondition(
           node.match | 0,
@@ -599,7 +597,7 @@ function generateBytecode(ast, options) {
         generate(node.expression, {
           sp: context.sp,
           env: cloneEnv(context.env),
-          action: null
+          action: null,
         }),
         buildCondition(
           // Check expression match, not the node match
@@ -617,7 +615,7 @@ function generateBytecode(ast, options) {
       const expressionCode = generate(node.expression, {
         sp: context.sp + 1,
         env: cloneEnv(context.env),
-        action: null
+        action: null,
       });
 
       return buildSequence(
@@ -632,7 +630,7 @@ function generateBytecode(ast, options) {
       const expressionCode = generate(node.expression, {
         sp: context.sp + 1,
         env: cloneEnv(context.env),
-        action: null
+        action: null,
       });
 
       return buildSequence(
@@ -652,49 +650,51 @@ function generateBytecode(ast, options) {
       return generate(node.expression, {
         sp: context.sp,
         env: cloneEnv(context.env),
-        action: null
+        action: null,
       });
     },
 
     semantic_and(node, context) {
-      return buildSourceMap(node.location, buildSemanticPredicate(node, false, context));
+      return buildSourceMap(node.location,
+        buildSemanticPredicate(node, false, context));
     },
 
     semantic_not(node, context) {
-      return buildSourceMap(node.location, buildSemanticPredicate(node, true, context));
+      return buildSourceMap(node.location,
+        buildSemanticPredicate(node, true, context));
     },
 
     rule_ref(node) {
-      return buildSourceMap(node.location, [op.RULE, asts.indexOfRule(ast, node.name)]);
+      return buildSourceMap(node.location,
+        [op.RULE, asts.indexOfRule(ast, node.name)]);
     },
 
     literal(node) {
-
       if (node.value.length > 0) {
         const match = node.match | 0;
-        // String only required if condition is generated or string is 
+        // String only required if condition is generated or string is
         // case-sensitive and node always match
         const needConst = match === SOMETIMES_MATCH
           || (match === ALWAYS_MATCH && !node.ignoreCase);
-        
+
         const stringIndex = needConst
-        ? addLiteralConst(
-          node.ignoreCase ? node.value.toLowerCase() : node.value
-        )
-        : null;
+          ? addLiteralConst(
+            node.ignoreCase ? node.value.toLowerCase() : node.value
+          )
+          : null;
         // Expectation not required if node always match
         const expectedIndex = (match !== ALWAYS_MATCH)
-        ? addExpectedConst({
-          type: "literal",
-          value: node.value,
-          ignoreCase: node.ignoreCase,
-        })
-        : null;
+          ? addExpectedConst({
+            type: "literal",
+            value: node.value,
+            ignoreCase: node.ignoreCase,
+          })
+          : null;
 
         // For case-sensitive strings the value must match the beginning of the
         // remaining input exactly. As a result, we can use |ACCEPT_STRING| and
         // save one |substr| call that would be needed if we used |ACCEPT_N|.
-        return buildSourceMap(node.location, 
+        return buildSourceMap(node.location,
           buildCondition(
             match,
             node.ignoreCase
@@ -704,8 +704,7 @@ function generateBytecode(ast, options) {
               ? [op.ACCEPT_N, node.value.length]
               : [op.ACCEPT_STRING, stringIndex],
             [op.FAIL, expectedIndex]
-          )
-        );
+          ));
       }
 
       return [op.PUSH_EMPTY_STRING];
@@ -714,18 +713,18 @@ function generateBytecode(ast, options) {
     class(node) {
       const match = node.match | 0;
       // Character class constant only required if condition is generated
-      
+
       const classIndex = match === SOMETIMES_MATCH ? addClassConst(node) : null;
       // Expectation not required if node always match
-      
+
       const expectedIndex = (match !== ALWAYS_MATCH)
-      ? addExpectedConst({
-        type: "class",
-        value: node.parts,
-        inverted: node.inverted,
-        ignoreCase: node.ignoreCase,
-      })
-      : null;
+        ? addExpectedConst({
+          type: "class",
+          value: node.parts,
+          inverted: node.inverted,
+          ignoreCase: node.ignoreCase,
+        })
+        : null;
 
       return buildCondition(
         match,
@@ -739,18 +738,18 @@ function generateBytecode(ast, options) {
       const match = node.match | 0;
       // Expectation not required if node always match
       const expectedIndex = (match !== ALWAYS_MATCH)
-      ? addExpectedConst({
-        type: "any"
-      })
-      : null;
-      
+        ? addExpectedConst({
+          type: "any",
+        })
+        : null;
+
       return buildCondition(
         match,
         [op.MATCH_ANY],
         [op.ACCEPT_N, 1],
         [op.FAIL, expectedIndex]
       );
-    }
+    },
   });
 
   generate(ast);

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -217,7 +217,7 @@ const { ALWAYS_MATCH, SOMETIMES_MATCH, NEVER_MATCH } = require("./inference-matc
 // that is equivalent of an unknown match result and signals the generator that
 // runtime check for the |FAILED| is required. Trick is explained on the
 // Wikipedia page (https://en.wikipedia.org/wiki/Asm.js#Code_generation)
-function generateBytecode(ast) {
+function generateBytecode(ast, options) {
   const literals = [];
   const classes = [];
   const expectations = [];
@@ -249,6 +249,9 @@ function generateBytecode(ast) {
   }
 
   function addFunctionConst(predicate, params, code) {
+    if(code.trim() === 'default'){
+      code = 'return {' + params.map(m => m + ':' + m).join(',') + '};';
+    }
     const func = { predicate, params, body: code };
     const pattern = JSON.stringify(func);
     const index = functions.findIndex(f => JSON.stringify(f) === pattern);
@@ -300,7 +303,7 @@ function generateBytecode(ast) {
       generate(expression, {
         sp: context.sp + 1,
         env: cloneEnv(context.env),
-        action: null,
+        action: null
       }),
       [op.SILENT_FAILS_OFF],
       buildCondition(
@@ -350,6 +353,22 @@ function generateBytecode(ast) {
     );
   }
 
+  function buildSourceMap(location, byteCode){
+    if(options.sourceMap){
+      return buildSequence(
+        [
+          op.SOURCE_MAP, 
+          location.start.offset, location.start.line, location.start.column,
+          location.end.offset,   location.end.line,   location.end.column
+        ],
+        byteCode,
+      )
+    }else{
+      return byteCode;
+    }
+    
+  }
+
   const generate = visitor.build({
     grammar(node) {
       node.rules.forEach(generate);
@@ -365,17 +384,17 @@ function generateBytecode(ast) {
         sp: -1,        // Stack pointer
         env: {},       // Mapping of label names to stack positions
         pluck: [],     // Fields that have been picked
-        action: null,  // Action nodes pass themselves to children here
+        action: null   // Action nodes pass themselves to children here
       });
     },
 
     named(node, context) {
       const match = node.match | 0;
-      // Expectation not required if node always fail
-      const nameIndex = (match === NEVER_MATCH)
-        ? null
-        : addExpectedConst({ type: "rule", value: node.name });
+      const nameIndex = (match === NEVER_MATCH) 
+      ? null
+      : addExpectedConst({ type: "rule", value: node.name });
 
+      
       // The code generated below is slightly suboptimal because |FAIL| pushes
       // to the stack, so we need to stick a |POP| in front of it. We lack a
       // dedicated instruction that would just report the failure and not touch
@@ -394,7 +413,7 @@ function generateBytecode(ast) {
         const first = generate(alternatives[0], {
           sp: context.sp,
           env: cloneEnv(context.env),
-          action: null,
+          action: null
         });
         // If an alternative always match, no need to generate code for the next
         // alternatives. Because their will never tried to match, any side-effects
@@ -411,14 +430,14 @@ function generateBytecode(ast) {
           first,
           alternatives.length > 1
             ? buildCondition(
-              SOMETIMES_MATCH,
-              [op.IF_ERROR],
-              buildSequence(
-                [op.POP],
-                buildAlternativesCode(alternatives.slice(1), context)
-              ),
-              []
-            )
+                SOMETIMES_MATCH,
+                [op.IF_ERROR],
+                buildSequence(
+                  [op.POP],
+                  buildAlternativesCode(alternatives.slice(1), context)
+                ),
+                []
+              )
             : []
         );
       }
@@ -431,9 +450,9 @@ function generateBytecode(ast) {
       const emitCall = node.expression.type !== "sequence"
                     || node.expression.elements.length === 0;
       const expressionCode = generate(node.expression, {
-        sp: context.sp + (emitCall ? 1 : 0),
-        env,
-        action: node,
+            sp: context.sp + (emitCall ? 1 : 0),
+            env,
+            action: node
       });
       const match = node.expression.match | 0;
       // Function only required if expression can match
@@ -443,33 +462,33 @@ function generateBytecode(ast) {
 
       return emitCall
         ? buildSequence(
-          [op.PUSH_CURR_POS],
-          expressionCode,
-          buildCondition(
-            match,
-            [op.IF_NOT_ERROR],
-            buildSequence(
-              [op.LOAD_SAVED_POS, 1],
-              buildCall(functionIndex, 1, env, context.sp + 2)
+            [op.PUSH_CURR_POS],
+            expressionCode,
+            buildCondition(
+              match,
+              [op.IF_NOT_ERROR],
+              buildSequence(
+                [op.LOAD_SAVED_POS, 1],
+                buildCall(functionIndex, 1, env, context.sp + 2)
+              ),
+              []
             ),
-            []
-          ),
-          [op.NIP]
-        )
+            [op.NIP]
+          )
         : expressionCode;
     },
 
     sequence(node, context) {
       function buildElementsCode(elements, context) {
         if (elements.length > 0) {
-          const processedCount = node.elements.length - elements.length + 1;
-
+        const processedCount = node.elements.length - elements.length + 1;
+        
           return buildSequence(
             generate(elements[0], {
               sp: context.sp,
               env: context.env,
               pluck: context.pluck,
-              action: null,
+              action: null
             }),
             buildCondition(
               elements[0].match | 0,
@@ -478,7 +497,7 @@ function generateBytecode(ast) {
                 sp: context.sp + 1,
                 env: context.env,
                 pluck: context.pluck,
-                action: context.action,
+                action: context.action
               }),
               buildSequence(
                 processedCount > 1 ? [op.POP_N, processedCount] : [op.POP],
@@ -487,10 +506,11 @@ function generateBytecode(ast) {
               )
             )
           );
-        } else {
+        } else {          
           if (context.pluck.length > 0) {
             return buildSequence(
-              [op.PLUCK, node.elements.length + 1, context.pluck.length],
+              [ op.PLUCK, node.elements.length + 1,
+                context.pluck.length ],
               context.pluck.map(eSP => context.sp - eSP)
             );
           }
@@ -523,7 +543,7 @@ function generateBytecode(ast) {
           sp: context.sp + 1,
           env: context.env,
           pluck: [],
-          action: context.action,
+          action: context.action
         })
       );
     },
@@ -545,7 +565,7 @@ function generateBytecode(ast) {
       return generate(node.expression, {
         sp: context.sp,
         env,
-        action: null,
+        action: null
       });
     },
 
@@ -555,7 +575,7 @@ function generateBytecode(ast) {
         generate(node.expression, {
           sp: context.sp + 1,
           env: cloneEnv(context.env),
-          action: null,
+          action: null
         }),
         buildCondition(
           node.match | 0,
@@ -579,7 +599,7 @@ function generateBytecode(ast) {
         generate(node.expression, {
           sp: context.sp,
           env: cloneEnv(context.env),
-          action: null,
+          action: null
         }),
         buildCondition(
           // Check expression match, not the node match
@@ -597,7 +617,7 @@ function generateBytecode(ast) {
       const expressionCode = generate(node.expression, {
         sp: context.sp + 1,
         env: cloneEnv(context.env),
-        action: null,
+        action: null
       });
 
       return buildSequence(
@@ -612,7 +632,7 @@ function generateBytecode(ast) {
       const expressionCode = generate(node.expression, {
         sp: context.sp + 1,
         env: cloneEnv(context.env),
-        action: null,
+        action: null
       });
 
       return buildSequence(
@@ -632,55 +652,59 @@ function generateBytecode(ast) {
       return generate(node.expression, {
         sp: context.sp,
         env: cloneEnv(context.env),
-        action: null,
+        action: null
       });
     },
 
     semantic_and(node, context) {
-      return buildSemanticPredicate(node, false, context);
+      return buildSourceMap(node.location, buildSemanticPredicate(node, false, context));
     },
 
     semantic_not(node, context) {
-      return buildSemanticPredicate(node, true, context);
+      return buildSourceMap(node.location, buildSemanticPredicate(node, true, context));
     },
 
     rule_ref(node) {
-      return [op.RULE, asts.indexOfRule(ast, node.name)];
+      return buildSourceMap(node.location, [op.RULE, asts.indexOfRule(ast, node.name)]);
     },
 
     literal(node) {
+
       if (node.value.length > 0) {
         const match = node.match | 0;
-        // String only required if condition is generated or string is
+        // String only required if condition is generated or string is 
         // case-sensitive and node always match
         const needConst = match === SOMETIMES_MATCH
-                      || (match === ALWAYS_MATCH && !node.ignoreCase);
+          || (match === ALWAYS_MATCH && !node.ignoreCase);
+        
         const stringIndex = needConst
-          ? addLiteralConst(
-            node.ignoreCase ? node.value.toLowerCase() : node.value
-          )
-          : null;
+        ? addLiteralConst(
+          node.ignoreCase ? node.value.toLowerCase() : node.value
+        )
+        : null;
         // Expectation not required if node always match
         const expectedIndex = (match !== ALWAYS_MATCH)
-          ? addExpectedConst({
-            type: "literal",
-            value: node.value,
-            ignoreCase: node.ignoreCase,
-          })
-          : null;
+        ? addExpectedConst({
+          type: "literal",
+          value: node.value,
+          ignoreCase: node.ignoreCase,
+        })
+        : null;
 
         // For case-sensitive strings the value must match the beginning of the
         // remaining input exactly. As a result, we can use |ACCEPT_STRING| and
         // save one |substr| call that would be needed if we used |ACCEPT_N|.
-        return buildCondition(
-          match,
-          node.ignoreCase
-            ? [op.MATCH_STRING_IC, stringIndex]
-            : [op.MATCH_STRING, stringIndex],
-          node.ignoreCase
-            ? [op.ACCEPT_N, node.value.length]
-            : [op.ACCEPT_STRING, stringIndex],
-          [op.FAIL, expectedIndex]
+        return buildSourceMap(node.location, 
+          buildCondition(
+            match,
+            node.ignoreCase
+              ? [op.MATCH_STRING_IC, stringIndex]
+              : [op.MATCH_STRING, stringIndex],
+            node.ignoreCase
+              ? [op.ACCEPT_N, node.value.length]
+              : [op.ACCEPT_STRING, stringIndex],
+            [op.FAIL, expectedIndex]
+          )
         );
       }
 
@@ -690,16 +714,18 @@ function generateBytecode(ast) {
     class(node) {
       const match = node.match | 0;
       // Character class constant only required if condition is generated
+      
       const classIndex = match === SOMETIMES_MATCH ? addClassConst(node) : null;
       // Expectation not required if node always match
+      
       const expectedIndex = (match !== ALWAYS_MATCH)
-        ? addExpectedConst({
-          type: "class",
-          value: node.parts,
-          inverted: node.inverted,
-          ignoreCase: node.ignoreCase,
-        })
-        : null;
+      ? addExpectedConst({
+        type: "class",
+        value: node.parts,
+        inverted: node.inverted,
+        ignoreCase: node.ignoreCase,
+      })
+      : null;
 
       return buildCondition(
         match,
@@ -713,18 +739,18 @@ function generateBytecode(ast) {
       const match = node.match | 0;
       // Expectation not required if node always match
       const expectedIndex = (match !== ALWAYS_MATCH)
-        ? addExpectedConst({
-          type: "any",
-        })
-        : null;
-
+      ? addExpectedConst({
+        type: "any"
+      })
+      : null;
+      
       return buildCondition(
         match,
         [op.MATCH_ANY],
         [op.ACCEPT_N, 1],
         [op.FAIL, expectedIndex]
       );
-    },
+    }
   });
 
   generate(ast);

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -67,7 +67,7 @@ function generateJS(ast, options) {
     function buildLiteral(literal) {
       return "\"" + stringEscape(literal) + "\"";
     }
-    
+
     function buildRegexp(cls) {
       return "/^["
         + (cls.inverted ? "^" : "")
@@ -125,7 +125,7 @@ function generateJS(ast, options) {
   }
 
   function generateRuleHeader(ruleNameCode, ruleIndexCode) {
-    var parts = [];
+    const parts = [];
 
     parts.push("");
 
@@ -186,7 +186,7 @@ function generateJS(ast, options) {
     if (options.cache) {
       parts.push([
         "",
-        "cacheRow[key] = {nextPos: peg$currPos, result: " + resultCode +"};"
+        "cacheRow[key] = {nextPos: peg$currPos, result: " + resultCode + "};",
       ].join("\n"));
     }
 
@@ -274,26 +274,30 @@ function generateJS(ast, options) {
         parts.push("}");
       }
 
-      function compileSourceMap(){
-        if(options.sourceMap){
-          var loc = {
+      function compileSourceMap() {
+        if (options.sourceMap) {
+          const loc = {
             type: "source-location",
             location:{
-              start: {offset: bc[ip+1], line: bc[ip+2], column: bc[ip+3]},
-              end: {offset: bc[ip+4], line: bc[ip+5], column: bc[ip+6]}
-            }
+              start: {
+                offset: bc[ip + 1],
+                line: bc[ip + 2],
+                column: bc[ip + 3],
+              },
+              end: { offset: bc[ip + 4], line: bc[ip + 5], column: bc[ip + 6] },
+            },
           };
-          if(options.trace) {
+          if (options.trace) {
             parts.push("peg$tracer.trace(" + JSON.stringify(loc) + ");");
-          }else{
+          } else {
             parts.push("/* source-location" + JSON.stringify(loc) + "*/");
           }
         }
         ip += 7;
       }
-      function traceInputPosition(){
-        if(options.trace && options.sourceMap){
-          parts.push("{")
+      function traceInputPosition() {
+        if (options.trace && options.sourceMap) {
+          parts.push("{");
           parts.push([
             "{",
             "  var loc = {",
@@ -303,8 +307,7 @@ function generateJS(ast, options) {
             "  peg$tracer.trance(loc);",
             "}",
             "",
-          ].join("\n"))
-          
+          ].join("\n"));
         }
       }
       function compileCall() {
@@ -322,9 +325,9 @@ function generateJS(ast, options) {
       }
 
       while (ip < end) {
-        for(var k in op){
-          if(op[k] === bc[ip]){
-            parts.push("\n/* " + k + " */")
+        for (const k in op) {
+          if (op[k] === bc[ip]) {
+            parts.push("\n/* " + k + " */");
             break;
           }
         }
@@ -365,7 +368,7 @@ function generateJS(ast, options) {
 
           case op.POP_CURR_POS:       // POP_CURR_POS
             parts.push("peg$currPos = " + stack.pop() + ";");
-            traceInputPosition()
+            traceInputPosition();
             ip++;
             break;
 
@@ -386,12 +389,12 @@ function generateJS(ast, options) {
             parts.push(stack.top() + ".push(" + value + ");");
             ip++;
             break;
-            
+
           case op.WRAP:               // WRAP n
-            if(options.noWrap){
+            if (options.noWrap) {
               stack.pop(bc[ip + 1]);
               stack.push(true);
-            }else{
+            } else {
               parts.push(
                 // @ts-expect-error  pop() returns array if argument is specified
                 stack.push("[" + stack.pop(bc[ip + 1]).join(", ") + "]")
@@ -406,7 +409,7 @@ function generateJS(ast, options) {
             );
             ip++;
             break;
-          
+
           case op.PLUCK: {            // PLUCK n, k, p1, ..., pK
             const baseLength = 3;
             const paramsLength = bc[ip + baseLength - 1];
@@ -461,7 +464,7 @@ function generateJS(ast, options) {
 
           case op.MATCH_STRING_IC:    // MATCH_STRING_IC s, a, f, ...
             compileCondition(
-              (options.saveLowerCase 
+              (options.saveLowerCase
                 ? "lowerInput.substr(peg$currPos, " + ast.literals[bc[ip + 1]].length + ")"
                 : "input.substr(peg$currPos, " + ast.literals[bc[ip + 1]].length + ").toLowerCase()"
               ) + " === " + l(bc[ip + 1]),
@@ -574,7 +577,7 @@ function generateJS(ast, options) {
 
   function generateToplevel() {
     const parts = [];
-    
+
     if (ast.topLevelInitializer) {
       parts.push(ast.topLevelInitializer.code);
       parts.push("");
@@ -819,8 +822,9 @@ function generateJS(ast, options) {
       "  var peg$numRules = " + ast.rules.length + ";",
       "  var peg$FAILED = {};",
       "  var peg$source = options.grammarSource;",
-      options.saveLowerCase ? 
-      "  var lowerInput = input.toLowerCase()," : "",
+      options.saveLowerCase
+        ? "  var lowerInput = input.toLowerCase(),"
+        : "",
       "  var peg$startRuleFunctions = " + startRuleFunctions + ";",
       "  var peg$startRuleFunction = " + startRuleFunction + ";",
       "",
@@ -851,18 +855,18 @@ function generateJS(ast, options) {
 
     if (options.cache === "forgettable") {
       parts.push([
-      "  function forgetBehind(pos){",
-      "    pos = pos || peg$currPos;",
-      "    for(var i in peg$resultsCache){",
-      "      if(+i < pos){",
-      "        delete peg$resultsCache[i];",
-      "      }else{",
-      "        break;",
-      "      }",
-      "    }",
-      "  }"
+        "  function forgetBehind(pos){",
+        "    pos = pos || peg$currPos;",
+        "    for(var i in peg$resultsCache){",
+        "      if(+i < pos){",
+        "        delete peg$resultsCache[i];",
+        "      }else{",
+        "        break;",
+        "      }",
+        "    }",
+        "  }",
       ].join("\n"));
-    }else{
+    } else {
       parts.push("function forgetBehind(){};");
     }
 
@@ -1017,9 +1021,9 @@ function generateJS(ast, options) {
       "",
     ].join("\n"));
 
-      ast.rules.forEach(rule => {
-        parts.push(indent2(generateRuleFunction(rule)));
-        parts.push("");
+    ast.rules.forEach(rule => {
+      parts.push(indent2(generateRuleFunction(rule)));
+      parts.push("");
     });
 
     if (ast.initializer) {
@@ -1094,34 +1098,34 @@ function generateJS(ast, options) {
           ].join("\n");
     }
 
-    var generators = {
-      web: function() {
+    const generators = {
+      web() {
         return [
           generateGeneratedByComment(),
           "document.currentScript.parser = (function() {",
           "  \"use strict\";",
-          "", indent2(toplevelCode), 
+          "", indent2(toplevelCode),
           "", indent2("return " + generateParserObject() + ";"),
-          "})()"
+          "})()",
         ].join("\n");
       },
-      bare: function() {
+      bare() {
         return [
           generateGeneratedByComment(),
           "(function() {",
           "  \"use strict\";",
           "",
-             indent2(toplevelCode),
+          indent2(toplevelCode),
           "",
-             indent2("return " + generateParserObject() + ";"),
-          "})()"
+          indent2("return " + generateParserObject() + ";"),
+          "})()",
         ].join("\n");
       },
 
-      commonjs: function() {
+      commonjs() {
         const parts          = [];
         const dependencyVars = Object.keys(options.dependencies);
-       
+
         parts.push([
           generateGeneratedByComment(),
           "",
@@ -1150,22 +1154,19 @@ function generateJS(ast, options) {
 
         return parts.join("\n");
       },
-      mixin: function() {
-        var parts          = [],
-            dependencyVars = Object.keys(options.dependencies),
-            requires       = dependencyVars.map(variable => {
-                return variable
+      mixin() {
+        const parts          = [];
+        const dependencyVars = Object.keys(options.dependencies);
+        const requires       = dependencyVars.map(variable => variable
                   + " = require(\""
-                  + js.stringEscape(options.dependencies[variable])
-                  + "\")";
-              }
-            );
+                  + stringEscape(options.dependencies[variable])
+                  + "\")");
 
         parts.push([
           generateGeneratedByComment(),
           "",
           "\"use strict\";",
-          ""
+          "",
         ].join("\n"));
 
         if (requires.length > 0) {
@@ -1178,13 +1179,13 @@ function generateJS(ast, options) {
           "",
           "module.exports = {",
           "  methods: ",
-            generateParserObject(),
-          "}"
+          generateParserObject(),
+          "}",
         ].join("\n"));
 
         return parts.join("\n");
       },
-      
+
       es() {
         const parts = [];
         const dependencyVars = Object.keys(options.dependencies);
@@ -1298,7 +1299,7 @@ function generateJS(ast, options) {
         return parts.join("\n");
       },
     };
-    
+
     return generators[options.format]();
   }
 

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -67,7 +67,7 @@ function generateJS(ast, options) {
     function buildLiteral(literal) {
       return "\"" + stringEscape(literal) + "\"";
     }
-
+    
     function buildRegexp(cls) {
       return "/^["
         + (cls.inverted ? "^" : "")
@@ -125,7 +125,7 @@ function generateJS(ast, options) {
   }
 
   function generateRuleHeader(ruleNameCode, ruleIndexCode) {
-    const parts = [];
+    var parts = [];
 
     parts.push("");
 
@@ -142,8 +142,8 @@ function generateJS(ast, options) {
 
     if (options.cache) {
       parts.push([
-        "var key = peg$currPos * " + ast.rules.length + " + " + ruleIndexCode + ";",
-        "var cached = peg$resultsCache[key];",
+        "var cacheRow = peg$resultsCache[peg$currPos] || (peg$resultsCache[peg$currPos] = {});",
+        "var key = " + ruleIndexCode + ", cached = cacheRow[key];",
         "",
         "if (cached) {",
         "  peg$currPos = cached.nextPos;",
@@ -186,7 +186,7 @@ function generateJS(ast, options) {
     if (options.cache) {
       parts.push([
         "",
-        "peg$resultsCache[key] = { nextPos: peg$currPos, result: " + resultCode + " };",
+        "cacheRow[key] = {nextPos: peg$currPos, result: " + resultCode +"};"
       ].join("\n"));
     }
 
@@ -274,6 +274,39 @@ function generateJS(ast, options) {
         parts.push("}");
       }
 
+      function compileSourceMap(){
+        if(options.sourceMap){
+          var loc = {
+            type: "source-location",
+            location:{
+              start: {offset: bc[ip+1], line: bc[ip+2], column: bc[ip+3]},
+              end: {offset: bc[ip+4], line: bc[ip+5], column: bc[ip+6]}
+            }
+          };
+          if(options.trace) {
+            parts.push("peg$tracer.trace(" + JSON.stringify(loc) + ");");
+          }else{
+            parts.push("/* source-location" + JSON.stringify(loc) + "*/");
+          }
+        }
+        ip += 7;
+      }
+      function traceInputPosition(){
+        if(options.trace && options.sourceMap){
+          parts.push("{")
+          parts.push([
+            "{",
+            "  var loc = {",
+            "    location: peg$computeLocation(peg$currPos, peg$savedPos),",
+            "    type: \"input-location\",",
+            "  };",
+            "  peg$tracer.trance(loc);",
+            "}",
+            "",
+          ].join("\n"))
+          
+        }
+      }
       function compileCall() {
         const baseLength = 4;
         const paramsLength = bc[ip + baseLength - 1];
@@ -289,19 +322,24 @@ function generateJS(ast, options) {
       }
 
       while (ip < end) {
+        for(var k in op){
+          if(op[k] === bc[ip]){
+            parts.push("\n/* " + k + " */")
+            break;
+          }
+        }
         switch (bc[ip]) {
           case op.PUSH_EMPTY_STRING:  // PUSH_EMPTY_STRING
             parts.push(stack.push("''"));
             ip++;
             break;
-
           case op.PUSH_CURR_POS:      // PUSH_CURR_POS
             parts.push(stack.push("peg$currPos"));
             ip++;
             break;
 
           case op.PUSH_UNDEFINED:     // PUSH_UNDEFINED
-            parts.push(stack.push("undefined"));
+            parts.push(stack.push("void 0"));
             ip++;
             break;
 
@@ -327,6 +365,7 @@ function generateJS(ast, options) {
 
           case op.POP_CURR_POS:       // POP_CURR_POS
             parts.push("peg$currPos = " + stack.pop() + ";");
+            traceInputPosition()
             ip++;
             break;
 
@@ -347,12 +386,17 @@ function generateJS(ast, options) {
             parts.push(stack.top() + ".push(" + value + ");");
             ip++;
             break;
-
+            
           case op.WRAP:               // WRAP n
-            parts.push(
-              // @ts-expect-error  pop() returns array if argument is specified
-              stack.push("[" + stack.pop(bc[ip + 1]).join(", ") + "]")
-            );
+            if(options.noWrap){
+              stack.pop(bc[ip + 1]);
+              stack.push(true);
+            }else{
+              parts.push(
+                // @ts-expect-error  pop() returns array if argument is specified
+                stack.push("[" + stack.pop(bc[ip + 1]).join(", ") + "]")
+              );
+            }
             ip += 2;
             break;
 
@@ -362,7 +406,7 @@ function generateJS(ast, options) {
             );
             ip++;
             break;
-
+          
           case op.PLUCK: {            // PLUCK n, k, p1, ..., pK
             const baseLength = 3;
             const paramsLength = bc[ip + baseLength - 1];
@@ -392,13 +436,16 @@ function generateJS(ast, options) {
             break;
 
           case op.WHILE_NOT_ERROR:    // WHILE_NOT_ERROR b
-            compileLoop(stack.top() + " !== peg$FAILED");
+            compileLoop(stack.top() + " !== peg$FAILED", 0);
             break;
 
           case op.MATCH_ANY:          // MATCH_ANY a, f, ...
             compileCondition("input.length > peg$currPos", 0);
             break;
 
+          case op.SOURCE_MAP:   // SOURCE_MAP startLine, startColumn, endLine, endColumn
+            compileSourceMap();
+            break;
           case op.MATCH_STRING:       // MATCH_STRING s, a, f, ...
             compileCondition(
               ast.literals[bc[ip + 1]].length > 1
@@ -414,10 +461,10 @@ function generateJS(ast, options) {
 
           case op.MATCH_STRING_IC:    // MATCH_STRING_IC s, a, f, ...
             compileCondition(
-              "input.substr(peg$currPos, "
-                + ast.literals[bc[ip + 1]].length
-                + ").toLowerCase() === "
-                + l(bc[ip + 1]),
+              (options.saveLowerCase 
+                ? "lowerInput.substr(peg$currPos, " + ast.literals[bc[ip + 1]].length + ")"
+                : "input.substr(peg$currPos, " + ast.literals[bc[ip + 1]].length + ").toLowerCase()"
+              ) + " === " + l(bc[ip + 1]),
               1
             );
             break;
@@ -440,6 +487,7 @@ function generateJS(ast, options) {
                 ? "peg$currPos += " + bc[ip + 1] + ";"
                 : "peg$currPos++;"
             );
+            traceInputPosition();
             ip += 2;
             break;
 
@@ -450,6 +498,7 @@ function generateJS(ast, options) {
                 ? "peg$currPos += " + ast.literals[bc[ip + 1]].length + ";"
                 : "peg$currPos++;"
             );
+            traceInputPosition();
             ip += 2;
             break;
 
@@ -461,11 +510,13 @@ function generateJS(ast, options) {
 
           case op.LOAD_SAVED_POS:     // LOAD_SAVED_POS p
             parts.push("peg$savedPos = " + stack.index(bc[ip + 1]) + ";");
+            traceInputPosition();
             ip += 2;
             break;
 
           case op.UPDATE_SAVED_POS:   // UPDATE_SAVED_POS
             parts.push("peg$savedPos = peg$currPos;");
+            traceInputPosition();
             ip++;
             break;
 
@@ -474,7 +525,7 @@ function generateJS(ast, options) {
             break;
 
           case op.RULE:               // RULE r
-            parts.push(stack.push("peg$parse" + ast.rules[bc[ip + 1]].name + "()"));
+            parts.push(stack.push(" /* MAP-TOKEN */ peg$parse" + ast.rules[bc[ip + 1]].name + "()"));
             ip += 2;
             break;
 
@@ -523,7 +574,7 @@ function generateJS(ast, options) {
 
   function generateToplevel() {
     const parts = [];
-
+    
     if (ast.topLevelInitializer) {
       parts.push(ast.topLevelInitializer.code);
       parts.push("");
@@ -715,12 +766,14 @@ function generateJS(ast, options) {
         "    }",
         "",
         "    if (typeof console === \"object\") {",   // IE 8-10
-        "      console.log(",
-        "        event.location.start.line + \":\" + event.location.start.column + \"-\"",
-        "          + event.location.end.line + \":\" + event.location.end.column + \" \"",
-        "          + pad(event.type, 10) + \" \"",
-        "          + repeat(\"  \", that.indentLevel) + event.rule",
-        "      );",
+        "      if(event.location){",
+        "        console.log(",
+        "          event.location.start.line + \":\" + event.location.start.column + \"-\"",
+        "            + event.location.end.line + \":\" + event.location.end.column + \" \"",
+        "            + pad(event.type, 10) + \" \"",
+        "            + repeat(\"  \", that.indentLevel) + event.rule",
+        "        );",
+        "      }",
         "    }",
         "  }",
         "",
@@ -737,6 +790,10 @@ function generateJS(ast, options) {
         "",
         "    case \"rule.fail\":",
         "      this.indentLevel--;",
+        "      log(event);",
+        "      break;",
+        "    case \"source-location\":",
+        "    case \"input-location\":",
         "      log(event);",
         "      break;",
         "",
@@ -757,11 +814,13 @@ function generateJS(ast, options) {
 
     parts.push([
       "function peg$parse(input, options) {",
-      "  options = options !== undefined ? options : {};",
+      "  options = options !== void 0 ? options : {};",
       "",
+      "  var peg$numRules = " + ast.rules.length + ";",
       "  var peg$FAILED = {};",
       "  var peg$source = options.grammarSource;",
-      "",
+      options.saveLowerCase ? 
+      "  var lowerInput = input.toLowerCase()," : "",
       "  var peg$startRuleFunctions = " + startRuleFunctions + ";",
       "  var peg$startRuleFunction = " + startRuleFunction + ";",
       "",
@@ -788,6 +847,23 @@ function generateJS(ast, options) {
         "  var peg$tracer = \"tracer\" in options ? options.tracer : new peg$DefaultTracer();",
         "",
       ].join("\n"));
+    }
+
+    if (options.cache === "forgettable") {
+      parts.push([
+      "  function forgetBehind(pos){",
+      "    pos = pos || peg$currPos;",
+      "    for(var i in peg$resultsCache){",
+      "      if(+i < pos){",
+      "        delete peg$resultsCache[i];",
+      "      }else{",
+      "        break;",
+      "      }",
+      "    }",
+      "  }"
+      ].join("\n"));
+    }else{
+      parts.push("function forgetBehind(){};");
     }
 
     parts.push([
@@ -822,7 +898,7 @@ function generateJS(ast, options) {
       "  }",
       "",
       "  function expected(description, location) {",
-      "    location = location !== undefined",
+      "    location = location !== void 0",
       "      ? location",
       "      : peg$computeLocation(peg$savedPos, peg$currPos);",
       "",
@@ -834,7 +910,7 @@ function generateJS(ast, options) {
       "  }",
       "",
       "  function error(message, location) {",
-      "    location = location !== undefined",
+      "    location = location !== void 0",
       "      ? location",
       "      : peg$computeLocation(peg$savedPos, peg$currPos);",
       "",
@@ -941,9 +1017,9 @@ function generateJS(ast, options) {
       "",
     ].join("\n"));
 
-    ast.rules.forEach(rule => {
-      parts.push(indent2(generateRuleFunction(rule)));
-      parts.push("");
+      ast.rules.forEach(rule => {
+        parts.push(indent2(generateRuleFunction(rule)));
+        parts.push("");
     });
 
     if (ast.initializer) {
@@ -1018,24 +1094,34 @@ function generateJS(ast, options) {
           ].join("\n");
     }
 
-    const generators = {
-      bare() {
+    var generators = {
+      web: function() {
+        return [
+          generateGeneratedByComment(),
+          "document.currentScript.parser = (function() {",
+          "  \"use strict\";",
+          "", indent2(toplevelCode), 
+          "", indent2("return " + generateParserObject() + ";"),
+          "})()"
+        ].join("\n");
+      },
+      bare: function() {
         return [
           generateGeneratedByComment(),
           "(function() {",
           "  \"use strict\";",
           "",
-          indent2(toplevelCode),
+             indent2(toplevelCode),
           "",
-          indent2("return " + generateParserObject() + ";"),
-          "})()",
+             indent2("return " + generateParserObject() + ";"),
+          "})()"
         ].join("\n");
       },
 
-      commonjs() {
-        const parts = [];
+      commonjs: function() {
+        const parts          = [];
         const dependencyVars = Object.keys(options.dependencies);
-
+       
         parts.push([
           generateGeneratedByComment(),
           "",
@@ -1064,7 +1150,41 @@ function generateJS(ast, options) {
 
         return parts.join("\n");
       },
+      mixin: function() {
+        var parts          = [],
+            dependencyVars = Object.keys(options.dependencies),
+            requires       = dependencyVars.map(variable => {
+                return variable
+                  + " = require(\""
+                  + js.stringEscape(options.dependencies[variable])
+                  + "\")";
+              }
+            );
 
+        parts.push([
+          generateGeneratedByComment(),
+          "",
+          "\"use strict\";",
+          ""
+        ].join("\n"));
+
+        if (requires.length > 0) {
+          parts.push("var " + requires.join(", ") + ";");
+          parts.push("");
+        }
+
+        parts.push([
+          toplevelCode,
+          "",
+          "module.exports = {",
+          "  methods: ",
+            generateParserObject(),
+          "}"
+        ].join("\n"));
+
+        return parts.join("\n");
+      },
+      
       es() {
         const parts = [];
         const dependencyVars = Object.keys(options.dependencies);
@@ -1178,7 +1298,7 @@ function generateJS(ast, options) {
         return parts.join("\n");
       },
     };
-
+    
     return generators[options.format]();
   }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bin": "bin/peggy",
   "scripts": {
     "clean": "rimraf -f build && rimraf -f browser && mkdir browser",
-    "parser": "node bin/peggy -o lib/parser.js --format commonjs src/parser.pegjs",
+    "parser": "node bin/peggy -o lib/parser.js --format commonjs src/parser.peggy",
     "set_version": "node ./tools/set_version",
     "lint": "eslint . --ext .js --ext .ts bin/peggy",
     "ts": "tsc --build tsconfig.json",

--- a/src/parser.peggy
+++ b/src/parser.peggy
@@ -56,6 +56,7 @@ Grammar
       };
     }
 
+
 TopLevelInitializer
   = "{" code:CodeBlock "}" EOS {
       return {


### PR DESCRIPTION
This is the first step in the direction of enabling more powerful debugging

With this code generation and enabled tracing I am able to record the execution and then debug it step by step showing simultaneously the grammar location and the input location.

![image](https://user-images.githubusercontent.com/19939799/124811244-283bf200-df5a-11eb-9c6e-353a8c68e41f.png)

The change in the cache layout gives a significant speedup with a big grammar. On the benchmark repeating 100 times with cache, it is 3 times faster than the main branch.

Comparing my _source-map_ and _main_ branches

 source-map --cache -n 100: 1417.90 kB/s
 main --cache -n 100: 488.41 kB/s
 source-map --cache -n 100:  2136.05 kB/s
 main -n 100: 2122.96 kB/s


## Next steps
There is some work to be done before we have proper source maps. But the idea is that the features on the page I use could be integrated in the code peggy language support. To allow step by step debugging, that would be a killer feature.
Also if it is interesting instead of recording the trace and replaying, to generate async rules, and traces calls that stop in endpoints and then can continue by resolving the promise returned by the trancer. With this approach we can have the debugging feature in the online demo page as well.

I also have a script that was an attempt to generate a javascript with a source map, however the source map is still buggy. Also for debugging in the browser step by step it is annoying because we have to give multiple steps to proceed to next step. If we have contribution of some guys with experience in generating source maps it will help.