### PR TITLE
Expose string escape functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Released: TBD
 ### Bug fixes
 
 - [#164](https://github.com/peggyjs/peggy/pull/164): Fix some errors in the typescript definitions
+- [#169](https://github.com/peggyjs/peggy/issues/169): Expose string escape functions
 
 1.2.0
 -----

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -4,54 +4,7 @@ const asts = require("../asts");
 const op = require("../opcodes");
 const Stack = require("../stack");
 const VERSION = require("../../version");
-
-function hex(ch) { return ch.charCodeAt(0).toString(16).toUpperCase(); }
-
-function stringEscape(s) {
-  // ECMA-262, 5th ed., 7.8.4: All characters may appear literally in a string
-  // literal except for the closing quote character, backslash, carriage
-  // return, line separator, paragraph separator, and line feed. Any character
-  // may appear in the form of an escape sequence.
-  //
-  // For portability, we also escape all control and non-ASCII characters.
-  return s
-    .replace(/\\/g,   "\\\\")   // Backslash
-    .replace(/"/g,    "\\\"")   // Closing double quote
-    .replace(/\0/g,   "\\0")    // Null
-    .replace(/\x08/g, "\\b")    // Backspace
-    .replace(/\t/g,   "\\t")    // Horizontal tab
-    .replace(/\n/g,   "\\n")    // Line feed
-    .replace(/\v/g,   "\\v")    // Vertical tab
-    .replace(/\f/g,   "\\f")    // Form feed
-    .replace(/\r/g,   "\\r")    // Carriage return
-    .replace(/[\x00-\x0F]/g,          ch => "\\x0" + hex(ch))
-    .replace(/[\x10-\x1F\x7F-\xFF]/g, ch => "\\x"  + hex(ch))
-    .replace(/[\u0100-\u0FFF]/g,      ch => "\\u0" + hex(ch))
-    .replace(/[\u1000-\uFFFF]/g,      ch => "\\u"  + hex(ch));
-}
-
-function regexpClassEscape(s) {
-  // Based on ECMA-262, 5th ed., 7.8.5 & 15.10.1.
-  //
-  // For portability, we also escape all control and non-ASCII characters.
-  return s
-    .replace(/\\/g,   "\\\\")   // Backslash
-    .replace(/\//g,   "\\/")    // Closing slash
-    .replace(/]/g,    "\\]")    // Closing bracket
-    .replace(/\^/g,   "\\^")    // Caret
-    .replace(/-/g,    "\\-")    // Dash
-    .replace(/\0/g,   "\\0")    // Null
-    .replace(/\x08/g, "\\b")    // Backspace
-    .replace(/\t/g,   "\\t")    // Horizontal tab
-    .replace(/\n/g,   "\\n")    // Line feed
-    .replace(/\v/g,   "\\v")    // Vertical tab
-    .replace(/\f/g,   "\\f")    // Form feed
-    .replace(/\r/g,   "\\r")    // Carriage return
-    .replace(/[\x00-\x0F]/g,          ch => "\\x0" + hex(ch))
-    .replace(/[\x10-\x1F\x7F-\xFF]/g, ch => "\\x"  + hex(ch))
-    .replace(/[\u0100-\u0FFF]/g,      ch => "\\u0" + hex(ch))
-    .replace(/[\u1000-\uFFFF]/g,      ch => "\\u"  + hex(ch));
-}
+const { stringEscape, regexpClassEscape } = require("../utils");
 
 // Generates parser JavaScript code.
 function generateJS(ast, options) {

--- a/lib/compiler/utils.js
+++ b/lib/compiler/utils.js
@@ -1,0 +1,52 @@
+"use strict";
+
+function hex(ch) { return ch.charCodeAt(0).toString(16).toUpperCase(); }
+exports.hex = hex;
+
+function stringEscape(s) {
+  // ECMA-262, 5th ed., 7.8.4: All characters may appear literally in a string
+  // literal except for the closing quote character, backslash, carriage
+  // return, line separator, paragraph separator, and line feed. Any character
+  // may appear in the form of an escape sequence.
+  //
+  // For portability, we also escape all control and non-ASCII characters.
+  return s
+    .replace(/\\/g,   "\\\\")   // Backslash
+    .replace(/"/g,    "\\\"")   // Closing double quote
+    .replace(/\0/g,   "\\0")    // Null
+    .replace(/\x08/g, "\\b")    // Backspace
+    .replace(/\t/g,   "\\t")    // Horizontal tab
+    .replace(/\n/g,   "\\n")    // Line feed
+    .replace(/\v/g,   "\\v")    // Vertical tab
+    .replace(/\f/g,   "\\f")    // Form feed
+    .replace(/\r/g,   "\\r")    // Carriage return
+    .replace(/[\x00-\x0F]/g,          ch => "\\x0" + hex(ch))
+    .replace(/[\x10-\x1F\x7F-\xFF]/g, ch => "\\x"  + hex(ch))
+    .replace(/[\u0100-\u0FFF]/g,      ch => "\\u0" + hex(ch))
+    .replace(/[\u1000-\uFFFF]/g,      ch => "\\u"  + hex(ch));
+}
+exports.stringEscape = stringEscape;
+
+function regexpClassEscape(s) {
+  // Based on ECMA-262, 5th ed., 7.8.5 & 15.10.1.
+  //
+  // For portability, we also escape all control and non-ASCII characters.
+  return s
+    .replace(/\\/g,   "\\\\")   // Backslash
+    .replace(/\//g,   "\\/")    // Closing slash
+    .replace(/]/g,    "\\]")    // Closing bracket
+    .replace(/\^/g,   "\\^")    // Caret
+    .replace(/-/g,    "\\-")    // Dash
+    .replace(/\0/g,   "\\0")    // Null
+    .replace(/\x08/g, "\\b")    // Backspace
+    .replace(/\t/g,   "\\t")    // Horizontal tab
+    .replace(/\n/g,   "\\n")    // Line feed
+    .replace(/\v/g,   "\\v")    // Vertical tab
+    .replace(/\f/g,   "\\f")    // Form feed
+    .replace(/\r/g,   "\\r")    // Carriage return
+    .replace(/[\x00-\x0F]/g,          ch => "\\x0" + hex(ch))
+    .replace(/[\x10-\x1F\x7F-\xFF]/g, ch => "\\x"  + hex(ch))
+    .replace(/[\u0100-\u0FFF]/g,      ch => "\\u0" + hex(ch))
+    .replace(/[\u1000-\uFFFF]/g,      ch => "\\u"  + hex(ch));
+}
+exports.regexpClassEscape = regexpClassEscape;

--- a/test/unit/compiler/utils.spec.js
+++ b/test/unit/compiler/utils.spec.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const chai = require("chai");
+const { hex, stringEscape, regexpClassEscape } = require("../../../lib/compiler/utils");
+
+const expect = chai.expect;
+
+describe("utility functions", () => {
+  it("hex", () => {
+    expect(hex("0")).to.equal("30");
+    expect(hex("\0")).to.equal("0");
+    expect(hex("\n")).to.equal("A");
+    expect(hex("\ufeff")).to.equal("FEFF");
+  });
+  it("stringEscape", () => {
+    expect(stringEscape("abc")).to.equal("abc");
+    expect(stringEscape("\\\"\0\b\t\n\v\f\r")).to.equal("\\\\\\\"\\0\\b\\t\\n\\v\\f\\r");
+    expect(stringEscape("\x01\x0f")).to.equal("\\x01\\x0F");
+    expect(stringEscape("\x10\x1f\x7f")).to.equal("\\x10\\x1F\\x7F");
+    expect(stringEscape("\u0100\u0fff")).to.equal("\\u0100\\u0FFF");
+    expect(stringEscape("\u1000\uffff")).to.equal("\\u1000\\uFFFF");
+  });
+  it("regexpClassEscape", () => {
+    expect(regexpClassEscape("\\\0\b\t\n\v\f\r")).to.equal("\\\\\\0\\b\\t\\n\\v\\f\\r");
+    expect(regexpClassEscape("/]^-")).to.equal("\\/\\]\\^\\-");
+    expect(regexpClassEscape("\x01\x0f")).to.equal("\\x01\\x0F");
+    expect(regexpClassEscape("\x10\x1f\x7f")).to.equal("\\x10\\x1F\\x7F");
+    expect(regexpClassEscape("\u0100\u0fff")).to.equal("\\u0100\\u0FFF");
+    expect(regexpClassEscape("\u1000\uffff")).to.equal("\\u1000\\uFFFF");
+  });
+});


### PR DESCRIPTION
Fixes #169.

to use:

```js
const {hex, stringEscape, regexpClassEscape} = require("peggy/lib/compiler/utils");
```

I wish we were prouder of these implementations. :(
Do any other utility functions need to be exposed?