### PR TITLE
back reference syntax for rules

### DIFF
--- a/lib/compiler/asts.js
+++ b/lib/compiler/asts.js
@@ -44,6 +44,10 @@ const asts = {
       semantic_and: consumesFalse,
       semantic_not: consumesFalse,
 
+      back_ref(node) {
+        return consumes(asts.findRule(ast, node.name));
+      },
+
       rule_ref(node) {
         return consumes(asts.findRule(ast, node.name));
       },

--- a/lib/compiler/visitor.js
+++ b/lib/compiler/visitor.js
@@ -50,6 +50,7 @@ const visitor = {
       text: visitExpression,
       simple_and: visitExpression,
       simple_not: visitExpression,
+      back_ref: visitExpression,
       optional: visitExpression,
       zero_or_more: visitExpression,
       one_or_more: visitExpression,

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -25,7 +25,8 @@
   const OPS_TO_PREFIXED_TYPES = {
     "$": "text",
     "&": "simple_and",
-    "!": "simple_not"
+    "!": "simple_not",
+    "#": "back_ref"
   };
 
   const OPS_TO_SUFFIXED_TYPES = {
@@ -188,6 +189,7 @@ PrefixedOperator
   = "$"
   / "&"
   / "!"
+  / "#"
 
 SuffixedExpression
   = expression:PrimaryExpression __ operator:SuffixedOperator {


### PR DESCRIPTION
This is working in progress. Because I will need some help on how I can reference another pattern in the rule.
Right now I've added `"#"` where `name:#foo` works the same `name:rule`

I didn't modify the lib/parser.js so there would be no conflicts since this file is generated.