### PR TITLE
Fix a regression in the description of character classes in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Released: TBD
 
 - [#164](https://github.com/peggyjs/peggy/pull/164): Fix some errors in the typescript definitions
 - [#169](https://github.com/peggyjs/peggy/issues/169): Expose string escape functions
+- [#197](https://github.com/peggyjs/peggy/pull/197): Fix a regression of redundant commas in the
+  character classes in the error messages, introduced in fad4ab74d1de67ef1902cd22d479c81ccab73224
 
 1.2.0
 -----

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -554,7 +554,7 @@ function generateJS(ast, options) {
       "          : classEscape(part);",
       "      });",
       "",
-      "      return \"[\" + (expectation.inverted ? \"^\" : \"\") + escapedParts + \"]\";",
+      "      return \"[\" + (expectation.inverted ? \"^\" : \"\") + escapedParts.join(\"\") + \"]\";",
       "    },",
       "",
       "    any: function() {",

--- a/test/api/generated-parser-api.spec.js
+++ b/test/api/generated-parser-api.spec.js
@@ -20,6 +20,13 @@ describe("generated parser API", () => {
       expect(() => { parser.parse("b"); }).to.throw();
     });
 
+    // Regression: https://github.com/peggyjs/peggy/pull/197
+    it("correctly describe character class in syntax error", () => {
+      const parser = peg.generate("start = [123-5]");
+
+      expect(() => { parser.parse("0"); }).to.throw("[123-5]");
+    });
+
     describe("start rule", () => {
       const parser = peg.generate([
         "a = 'x' { return 'a'; }",


### PR DESCRIPTION
Regression was introduced in the fad4ab74d1de67ef1902cd22d479c81ccab73224 

Character class description contains redundant commas between class parts:

`[1,2,3-5]` instead of `[123-5]` for class `[123-5]`