### PR TITLE
Debug helpers - new output type `ast` / CLI option `-a/--ast`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Released: TBD
 - [#285](https://github.com/peggyjs/peggy/issues/285) Require that a non-empty
   string be given as a grammarSource if you are generating a source map, from
   @hildjj
+- [#206](https://github.com/peggyjs/peggy/pull/206): New output type `ast` and
+  an `--ast` flag for the CLI to get an internal grammar AST for investigation
+  (can be useful for plugin writers), from @Mingun
 
 ### Bug Fixes
 

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -171,6 +171,13 @@ override this using the <code>--format</code> option.</p>
   <dd>Comma-separated list of rules the parser will be allowed to start parsing
   from (default: only the first rule in the grammar).</dd>
 
+  <dt><code>--ast</code></dt>
+  <dd>Outputting an internal AST representation of the grammar after
+  all optimizations instead of the parser source code. Useful for plugin authors
+  to see how their plugin changes the AST. This option cannot be mixed with the
+  <code>-t/--test</code>, <code>-T/--test-file</code> and <code>-m/--source-map</code>
+  options.</dd>
+
   <dt><code>--cache</code></dt>
   <dd>Makes the parser cache results, avoiding exponential parsing time in
   pathological cases but making the parser slower.</dd>
@@ -227,21 +234,21 @@ override this using the <code>--format</code> option.</p>
   <dt><code>-t</code>, <code>--test &lt;text&gt;</code></dt>
   <dd>Test the parser with the given text, outputting the result of running
   the parser against this input.
-  If the input to be tested is not parsed, the CLI will exit with code 2</dd>
+  If the input to be tested is not parsed, the CLI will exit with code 2.</dd>
 
   <dt><code>-T</code>, <code>--test-file &lt;text&gt;</code></dt>
   <dd>Test the parser with the contents of the given file, outputting the
   result of running the parser against this input.
-  If the input to be tested is not parsed, the CLI will exit with code 2</dd>
+  If the input to be tested is not parsed, the CLI will exit with code 2.</dd>
 
   <dt><code>--trace</code></dt>
   <dd>Makes the parser trace its progress.</dd>
 
   <dt><code>-v</code>, <code>--version</code></dt>
-  <dd>Output the version number</dd>
+  <dd>Output the version number.</dd>
 
   <dt><code>-h</code>, <code>--help</code></dt>
-  <dd>Display help for the command</dd>
+  <dd>Display help for the command.</dd>
 
 </dl>
 
@@ -270,7 +277,7 @@ module.exports = {
 <p>
 You can test generated parser immediately if you specify the <code>-t/--test</code> or <code>-T/--test-file</code>
 option. This option conflicts with the option <code>-m/--source-map</code> unless <code>-o/--output</code> is
-also specified.
+also specified. This option conflicts with the <code>--ast</code> option.
 </p>
 
 <p>The CLI will exit with the code:</p>
@@ -411,6 +418,9 @@ supported:</p>
         with an embedded source map as a <code>data:</code> URI.  This option
         leads to a larger output string, but is the easiest to integrate with
         developer tooling.</li>
+        <li><code>"ast"</code> - return the internal AST of the grammar as a JSON
+          string. Useful for plugin authors to explore internals of Peggy and
+          for automation.</li>
     </ul>
     <p>(default: <code>"parser"</code>)</p>
     <blockquote>

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -141,6 +141,9 @@ const compiler = {
 `;
       }
 
+      case "ast":
+        return ast;
+
       default:
         throw new Error("Invalid output format: " + options.output + ".");
     }

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -258,7 +258,7 @@ function generateJS(ast, options) {
 
   function generateRuleFunction(rule) {
     const parts = [];
-    const stack = new Stack(rule.name, "s", "var");
+    const stack = new Stack(rule.name, "s", "var", rule.bytecode);
 
     function compile(bc) {
       let ip = 0;
@@ -528,7 +528,7 @@ function generateJS(ast, options) {
 
           // istanbul ignore next Because we never generate invalid bytecode we cannot reach this branch
           default:
-            throw new Error("Invalid opcode: " + bc[ip] + ".");
+            throw new Error("Invalid opcode: " + bc[ip] + ".", { rule: rule.name, bytecode: bc });
         }
       }
 

--- a/lib/compiler/stack.js
+++ b/lib/compiler/stack.js
@@ -8,8 +8,9 @@ class Stack {
    * @param {string} ruleName The name of rule that will be used in error messages
    * @param {string} varName The prefix for generated names of variables
    * @param {string} type The type of the variables. For JavaScript there are `var` or `let`
+   * @param {number[]} bytecode Bytecode for error messages
    */
-  constructor(ruleName, varName, type) {
+  constructor(ruleName, varName, type, bytecode) {
     /** Last used variable in the stack. */
     this.sp       = -1;
     /** Maximum stack size. */
@@ -17,6 +18,7 @@ class Stack {
     this.varName  = varName;
     this.ruleName = ruleName;
     this.type     = type;
+    this.bytecode = bytecode;
   }
 
   /**
@@ -30,7 +32,7 @@ class Stack {
   name(i) {
     if (i < 0) {
       throw new RangeError(
-        `Rule '${this.ruleName}': The variable stack underflow: attempt to use a variable '${this.varName}<x>' at an index ${i}`
+        `Rule '${this.ruleName}': The variable stack underflow: attempt to use a variable '${this.varName}<x>' at an index ${i}.\nBytecode: ${this.bytecode}`
       );
     }
 
@@ -90,7 +92,7 @@ class Stack {
   index(i) {
     if (i < 0) {
       throw new RangeError(
-        `Rule '${this.ruleName}': The variable stack overflow: attempt to get a variable at a negative index ${i}`
+        `Rule '${this.ruleName}': The variable stack overflow: attempt to get a variable at a negative index ${i}.\nBytecode: ${this.bytecode}`
       );
     }
 
@@ -107,7 +109,7 @@ class Stack {
   result() {
     if (this.maxSp < 0) {
       throw new RangeError(
-        `Rule '${this.ruleName}': The variable stack is empty, can't get the result'`
+        `Rule '${this.ruleName}': The variable stack is empty, can't get the result.\nBytecode: ${this.bytecode}`
       );
     }
 
@@ -154,7 +156,8 @@ class Stack {
         throw new Error(
           "Rule '" + this.ruleName + "', position " + pos + ": "
           + "Branches of a condition can't move the stack pointer differently "
-          + "(before: " + baseSp + ", after then: " + thenSp + ", after else: " + this.sp + ")."
+          + "(before: " + baseSp + ", after then: " + thenSp + ", after else: " + this.sp + "). "
+          + "Bytecode: " + this.bytecode
         );
       }
     }
@@ -178,7 +181,8 @@ class Stack {
       throw new Error(
         "Rule '" + this.ruleName + "', position " + pos + ": "
         + "Body of a loop can't move the stack pointer "
-        + "(before: " + baseSp + ", after: " + this.sp + ")."
+        + "(before: " + baseSp + ", after: " + this.sp + "). "
+        + "Bytecode: " + this.bytecode
       );
     }
   }

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -1079,7 +1079,7 @@ export type SourceOutputs =
   "source-with-inline-map";
 
 /** Base options for all source-generating formats. */
-interface SourceOptionsBase<Output extends SourceOutputs>
+interface SourceOptionsBase<Output>
   extends BuildOptionsBase {
   /**
    * If set to `"parser"`, the method will return generated parser object;
@@ -1245,6 +1245,27 @@ export function generate(
   grammar: string,
   options: SourceBuildOptions<SourceOutputs>
 ): string | SourceNode;
+
+/**
+ * Returns the generated AST for the grammar. Unlike result of the
+ * `peggy.compiler.compile(...)` an AST returned by this method is augmented
+ * with data from passes. In other words, the compiler gives you the raw AST,
+ * and this method provides the final AST after all optimizations and
+ * transformations.
+ *
+ * @param grammar String in the format described by the meta-grammar in the
+ *        `parser.pegjs` file
+ * @param options Options that allow you to customize returned AST
+ *
+ * @throws {SyntaxError}  If the grammar contains a syntax error, for example,
+ *         an unclosed brace
+ * @throws {GrammarError} If the grammar contains a semantic error, for example,
+ *         duplicated labels
+ */
+export function generate(
+  grammar: string,
+  options: SourceOptionsBase<"ast">
+): ast.Grammar;
 
 // Export all exported stuff under a global variable PEG in non-module environments
 export as namespace PEG;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peggy",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "peggy",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.3.0",
@@ -29,6 +29,7 @@
         "@typescript-eslint/parser": "^5.27.0",
         "browser-sync": "^2.27.10",
         "chai": "^4.3.6",
+        "chai-like": "^1.1.1",
         "copyfiles": "^2.4.1",
         "eslint": "^8.16.0",
         "express": "4.18.1",
@@ -2300,6 +2301,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chai-like": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chai-like/-/chai-like-1.1.1.tgz",
+      "integrity": "sha512-VKa9z/SnhXhkT1zIjtPACFWSoWsqVoaz1Vg+ecrKo5DCKVlgL30F/pEyEvXPBOVwCgLZcWUleCM/C1okaKdTTA==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "2 - 4"
       }
     },
     "node_modules/chalk": {
@@ -9600,6 +9610,13 @@
         "pathval": "^1.1.1",
         "type-detect": "^4.0.5"
       }
+    },
+    "chai-like": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chai-like/-/chai-like-1.1.1.tgz",
+      "integrity": "sha512-VKa9z/SnhXhkT1zIjtPACFWSoWsqVoaz1Vg+ecrKo5DCKVlgL30F/pEyEvXPBOVwCgLZcWUleCM/C1okaKdTTA==",
+      "dev": true,
+      "requires": {}
     },
     "chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@typescript-eslint/parser": "^5.27.0",
     "browser-sync": "^2.27.10",
     "chai": "^4.3.6",
+    "chai-like": "^1.1.1",
     "copyfiles": "^2.4.1",
     "eslint": "^8.16.0",
     "express": "4.18.1",

--- a/test/api/pegjs-api.spec.js
+++ b/test/api/pegjs-api.spec.js
@@ -10,6 +10,8 @@ exports.peggyVersion = function peggyVersion() {
   return peg.VERSION;
 };
 
+chai.use(require("chai-like"));
+
 beforeEach(() => {
   // In the browser, initialize SourceMapConsumer's wasm bits.
   // This is *async*, so make sure to return the promise to make
@@ -171,6 +173,15 @@ describe("Peggy API", () => {
 
           expect(source).to.be.a("string");
           expect(eval(source).parse("a")).to.equal("a");
+        });
+      });
+
+      describe("when |output| is set to |\"ast\"|", () => {
+        it("returns generated parser AST", () => {
+          const ast = peg.generate(grammar, { output: "ast" });
+
+          expect(ast).to.be.an("object");
+          expect(ast).to.be.like(peg.parser.parse(grammar));
         });
       });
     });

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -104,6 +104,9 @@ describe("peg.d.ts", () => {
 
     const p2 = peggy.generate(src, { output: "source", grammarSource: { foo: "src" } });
     expectType<string>(p2);
+
+    const p3 = peggy.generate(src, { output: "ast", grammarSource: { foo: "src" } });
+    expectType<peggy.ast.Grammar>(p3);
   });
 
   it("generates a source map", () => {

--- a/test/unit/compiler/passes/generate-bytecode.spec.js
+++ b/test/unit/compiler/passes/generate-bytecode.spec.js
@@ -151,7 +151,7 @@ describe("compiler pass |generateBytecode|", () => {
           5,                           // PUSH_CURR_POS
           18, 0, 2, 2, 22, 0, 23, 0,   // <expression>
           15, 6, 0,                    // IF_NOT_ERROR
-          24, 1,                       //   * LOAD_SAVED_POS
+          24, 1,                       //   * LOAD_SAVED_POS <1>
           26, 0, 1, 0,                 //     CALL <0>
           9,                            // NIP
         ]));
@@ -184,7 +184,7 @@ describe("compiler pass |generateBytecode|", () => {
           5,                           // PUSH_CURR_POS
           18, 0, 2, 2, 22, 0, 23, 0,   // <expression>
           15, 7, 0,                    // IF_NOT_ERROR
-          24, 1,                       //   * LOAD_SAVED_POS
+          24, 1,                       //   * LOAD_SAVED_POS <1>
           26, 0, 1, 1, 0,              //     CALL <0>
           9,                            // NIP
         ]));
@@ -221,7 +221,7 @@ describe("compiler pass |generateBytecode|", () => {
           15, 24, 4,                   //     IF_NOT_ERROR
           18, 2, 2, 2, 22, 2, 23, 2,   //       * <elements[2]>
           15, 9, 4,                    //         IF_NOT_ERROR
-          24, 3,                       //           * LOAD_SAVED_POS
+          24, 3,                       //           * LOAD_SAVED_POS <3>
           26, 0, 4, 3, 2, 1, 0,        //             CALL <0>
           8, 3,                        //           * POP_N <3>
           7,                           //             POP_CURR_POS

--- a/test/unit/compiler/passes/helpers.js
+++ b/test/unit/compiler/passes/helpers.js
@@ -7,44 +7,10 @@ const Session = require("../../../../lib/compiler/session");
 module.exports = function(chai, utils) {
   const Assertion = chai.Assertion;
 
+  chai.use(require("chai-like"));
+
   Assertion.addMethod("changeAST", function(grammar, props, options) {
     options = options !== undefined ? options : {};
-
-    function matchProps(value, props) {
-      function isArray(value) {
-        return Object.prototype.toString.apply(value) === "[object Array]";
-      }
-
-      function isObject(value) {
-        return value !== null && typeof value === "object";
-      }
-
-      if (isArray(props)) {
-        if (!isArray(value)) { return false; }
-
-        if (value.length !== props.length) { return false; }
-        for (let i = 0; i < props.length; i++) {
-          if (!matchProps(value[i], props[i])) { return false; }
-        }
-
-        return true;
-      } else if (isObject(props)) {
-        if (!isObject(value)) { return false; }
-
-        const keys = Object.keys(props);
-        for (let i = 0; i < keys.length; i++) {
-          const key = keys[i];
-
-          if (!(key in value)) { return false; }
-
-          if (!matchProps(value[key], props[key])) { return false; }
-        }
-
-        return true;
-      } else {
-        return value === props;
-      }
-    }
 
     const ast = parser.parse(grammar);
 
@@ -52,13 +18,7 @@ module.exports = function(chai, utils) {
       error(stage, ...args) { throw new GrammarError(...args); },
     }));
 
-    this.assert(
-      matchProps(ast, props),
-      "expected #{this} to change the AST to match #{exp}",
-      "expected #{this} to not change the AST to match #{exp}",
-      props,
-      ast
-    );
+    new Assertion(ast).like(props);
   });
 
   Assertion.addMethod("reportError", function(grammar, props) {

--- a/test/unit/compiler/stack.spec.js
+++ b/test/unit/compiler/stack.spec.js
@@ -9,20 +9,20 @@ describe("utility class Stack", () => {
   describe("for an empty stack", () => {
     let stack;
 
-    beforeEach(() => { stack = new Stack("rule", "v", "let"); });
+    beforeEach(() => { stack = new Stack("rule", "v", "let", [42]); });
 
     describe("throws an error when attempting", () => {
       it("`pop`", () => {
         expect(() => stack.pop()).to.throw(
           RangeError,
-          "Rule 'rule': The variable stack underflow: attempt to use a variable 'v<x>' at an index -1"
+          "Rule 'rule': The variable stack underflow: attempt to use a variable 'v<x>' at an index -1.\nBytecode: 42"
         );
       });
 
       it("`top`", () => {
         expect(() => stack.top()).to.throw(
           RangeError,
-          "Rule 'rule': The variable stack underflow: attempt to use a variable 'v<x>' at an index -1"
+          "Rule 'rule': The variable stack underflow: attempt to use a variable 'v<x>' at an index -1.\nBytecode: 42"
         );
       });
 
@@ -36,15 +36,15 @@ describe("utility class Stack", () => {
       it("`index`", () => {
         expect(() => stack.index(-2)).to.throw(
           RangeError,
-          "Rule 'rule': The variable stack overflow: attempt to get a variable at a negative index -2"
+          "Rule 'rule': The variable stack overflow: attempt to get a variable at a negative index -2.\nBytecode: 42"
         );
         expect(() => stack.index(0)).to.throw(
           RangeError,
-          "Rule 'rule': The variable stack underflow: attempt to use a variable 'v<x>' at an index -1"
+          "Rule 'rule': The variable stack underflow: attempt to use a variable 'v<x>' at an index -1.\nBytecode: 42"
         );
         expect(() => stack.index(2)).to.throw(
           RangeError,
-          "Rule 'rule': The variable stack underflow: attempt to use a variable 'v<x>' at an index -3"
+          "Rule 'rule': The variable stack underflow: attempt to use a variable 'v<x>' at an index -3.\nBytecode: 42"
         );
       });
     });
@@ -55,18 +55,18 @@ describe("utility class Stack", () => {
   });
 
   it("throws an error when attempting `pop` more than `push`", () => {
-    const stack = new Stack("rule", "v", "let");
+    const stack = new Stack("rule", "v", "let", [42]);
 
     stack.push("1");
 
     expect(() => stack.pop(3)).to.throw(
       RangeError,
-      "Rule 'rule': The variable stack underflow: attempt to use a variable 'v<x>' at an index -2"
+      "Rule 'rule': The variable stack underflow: attempt to use a variable 'v<x>' at an index -2.\nBytecode: 42"
     );
   });
 
   it("returns a variable with an index 0 for `result`", () => {
-    const stack = new Stack("rule", "v", "let");
+    const stack = new Stack("rule", "v", "let", []);
 
     stack.push("1");
 
@@ -74,7 +74,7 @@ describe("utility class Stack", () => {
   });
 
   it("`defines` returns a define expression for all used variables", () => {
-    const stack = new Stack("rule", "v", "let");
+    const stack = new Stack("rule", "v", "let", []);
 
     stack.push("1");
     stack.push("2");
@@ -88,7 +88,7 @@ describe("utility class Stack", () => {
     let stack;
 
     beforeEach(() => {
-      stack = new Stack("rule", "v", "let");
+      stack = new Stack("rule", "v", "let", [42]);
       stack.push("1");
     });
 
@@ -152,7 +152,8 @@ describe("utility class Stack", () => {
           Error,
           "Rule 'rule', position 0: "
           + "Branches of a condition can't move the stack pointer differently "
-          + "(before: 0, after then: 0, after else: -1)."
+          + "(before: 0, after then: 0, after else: -1). "
+          + "Bytecode: 42"
         );
       });
       it("decreases in `if` and was not moving in `then`", () => {
@@ -162,7 +163,8 @@ describe("utility class Stack", () => {
           Error,
           "Rule 'rule', position 0: "
           + "Branches of a condition can't move the stack pointer differently "
-          + "(before: 0, after then: -1, after else: 0)."
+          + "(before: 0, after then: -1, after else: 0). "
+          + "Bytecode: 42"
         );
       });
 
@@ -173,7 +175,8 @@ describe("utility class Stack", () => {
           Error,
           "Rule 'rule', position 0: "
           + "Branches of a condition can't move the stack pointer differently "
-          + "(before: 0, after then: 0, after else: 1)."
+          + "(before: 0, after then: 0, after else: 1). "
+          + "Bytecode: 42"
         );
       });
       it("increases in `if` and was not moving in `then`", () => {
@@ -183,7 +186,8 @@ describe("utility class Stack", () => {
           Error,
           "Rule 'rule', position 0: "
           + "Branches of a condition can't move the stack pointer differently "
-          + "(before: 0, after then: 1, after else: 0)."
+          + "(before: 0, after then: 1, after else: 0). "
+          + "Bytecode: 42"
         );
       });
 
@@ -194,7 +198,8 @@ describe("utility class Stack", () => {
           Error,
           "Rule 'rule', position 0: "
           + "Branches of a condition can't move the stack pointer differently "
-          + "(before: 0, after then: -1, after else: 1)."
+          + "(before: 0, after then: -1, after else: 1). "
+          + "Bytecode: 42"
         );
       });
       it("increases in `if` and decreases in `then`", () => {
@@ -204,7 +209,8 @@ describe("utility class Stack", () => {
           Error,
           "Rule 'rule', position 0: "
           + "Branches of a condition can't move the stack pointer differently "
-          + "(before: 0, after then: 1, after else: -1)."
+          + "(before: 0, after then: 1, after else: -1). "
+          + "Bytecode: 42"
         );
       });
     });
@@ -214,7 +220,7 @@ describe("utility class Stack", () => {
     let stack;
 
     beforeEach(() => {
-      stack = new Stack("rule", "v", "let");
+      stack = new Stack("rule", "v", "let", [42]);
       stack.push("1");
     });
 
@@ -247,7 +253,8 @@ describe("utility class Stack", () => {
         Error,
         "Rule 'rule', position 0: "
         + "Body of a loop can't move the stack pointer "
-        + "(before: 0, after: 1)."
+        + "(before: 0, after: 1). "
+        + "Bytecode: 42"
       );
     });
 
@@ -256,7 +263,8 @@ describe("utility class Stack", () => {
         Error,
         "Rule 'rule', position 0: "
         + "Body of a loop can't move the stack pointer "
-        + "(before: 0, after: -1)."
+        + "(before: 0, after: -1). "
+        + "Bytecode: 42"
       );
     });
   });


### PR DESCRIPTION
Working on my next PR I realized that I need a way to get the AST generated, so I've added a new output type `ast`. It also can be useful for plugin writers to check how their plugin changes AST.