### PR TITLE
Implementation of the ranges (with delimiters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Released: TBD
   results checking after each compilation stage.
   [@Mingun](https://github.com/peggyjs/peggy/pull/160)
 
+- Add support for repetition operator `expression|min .. max, delimiter|`
+  [@Mingun](https://github.com/peggyjs/peggy/pull/208)
+
 ### Minor Changes
 
 - New CLI [@hildjj](https://github.com/peggyjs/peggy/pull/167)

--- a/README.md
+++ b/README.md
@@ -517,6 +517,39 @@ Try to match the expression. If the match succeeds, return its match result,
 otherwise return `null`. Unlike in regular expressions, there is no
 backtracking.
 
+#### _expression_ |count|<br> _expression_ |min..max|<br> _expression_ |count, delimiter|<br> _expression_ |min..max, delimiter|
+
+Match exact `count` repetitions of `expression`. If the match succeeds, return
+their match results in an array.
+
+-or-
+
+Match expression at least `min` but not more then `max` times. If the match
+succeeds, return their match results in an array. Both `min` and `max` may
+be omitted. If `min` is omitted, then it is assumed to be `0`. If `max` is
+omitted, then it is assumed to be infinity. Hence `expression |..|` is an
+equivalent of `expression |0..|` and `expression *`. `expression |1..|` is
+equivalent of `expression +`.
+
+Optionally, `delimiter` expression can be specified. Delimiter must appear
+between expressions exactly once and it is not included in the final array.
+
+`count`, `min` and `max` can be represented as:
+- positive integers:
+  ```peggy
+  start = "a"|2|;
+  ```
+- name of the preceding label:
+  ```peggy
+  start = count:n1 "a"|count|;
+  n1 = n:$[0-9] { parseInt(n); };
+  ```
+- code block:
+  ```peggy
+  start = 'a'|{ return options.count; }|;
+  ```
+  Any non-number values will be interpreted as `0`.
+
 #### & _expression_
 
 Try to match the expression. If the match succeeds, just return `undefined` and

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -649,6 +649,40 @@ subexpressions and thus forming a recursive structure:</p>
     result, otherwise return <code>null</code>. Unlike in regular expressions,
     there is no backtracking.</p>
   </dd>
+  <dt><code><em>expression</em> |count|<br> <em>expression</em> |min..max|<br> <em>expression</em> |count, delimiter|<br> <em>expression</em> |min..max, delimiter|</code></dt>
+
+  <dd>
+    <p>Match exact <code>count</code> repetitions of <code>expression</code>. If the match succeeds, return
+    their match results in an array.</p>
+
+    <p>-or-</p>
+
+    <p>Match expression at least <code>min</code> but not more then <code>max</code> times. If the match
+    succeeds, return their match results in an array. Both <code>min</code> and <code>max</code> may
+    be omitted. If <code>min</code> is omitted, then it is assumed to be <code>0</code>. If <code>max</code> is
+    omitted, then it is assumed to be infinity. Hence <code>expression |..|</code> is an
+    equivalent of <code>expression |0..|</code> and <code>expression *</code>. <code>expression |1..|</code> is
+    equivalent of <code>expression +</code>.</p>
+
+    <p>Optionally, <code>delimiter</code> expression can be specified. Delimiter must appear
+    between expressions exactly once and it is not included in the final array.</p>
+
+    <p><code>count</code>, <code>min</code> and <code>max</code> can be represented as:</p>
+
+    <ul>
+      <li>positive integers:
+        <pre><code class="language-peggy">start = "a"|2|;</code></pre>
+      </li>
+      <li>name of the preceding label:
+        <pre><code class="language-peggy">start = count:n1 "a"|count|;
+n1 = n:$[0-9] { parseInt(n); };</code></pre>
+      </li>
+      <li>code block:
+        <pre><code class="language-peggy">start = "a"|{ return options.count; }|;</code></pre>
+      </li>
+      Any non-number values will be interpreted as <code>0</code>.
+    </ul>
+  </dd>
 
   <dt><code>&amp; <em>expression</em></code></dt>
 

--- a/examples/fizzbuzz.peggy
+++ b/examples/fizzbuzz.peggy
@@ -10,7 +10,7 @@ const NUMS = [3, 5];
 let currentNumber = (options.start == null) ? 1 : options.start|0;
 }
 
-top = c:count* { return c.filter(fb => fb) }
+top = c:count|..| { return c.filter(fb => fb) }
 
 count
   = end_comment "\n" { return }

--- a/lib/compiler/asts.js
+++ b/lib/compiler/asts.js
@@ -53,8 +53,17 @@ const asts = {
         if (min.type !== "constant" || min.value === 0) {
           return false;
         }
+        if (consumes(node.expression)) {
+          return true;
+        }
+        // |node.delimiter| used only when |node.expression| match at least two times
+        // The first `if` filtered out all non-constant minimums, so at this point
+        // |min.value| is always a constant
+        if (min.value > 1 && node.delimiter && consumes(node.delimiter)) {
+          return true;
+        }
 
-        return consumes(node.expression);
+        return false;
       },
       semantic_and: consumesFalse,
       semantic_not: consumesFalse,

--- a/lib/compiler/asts.js
+++ b/lib/compiler/asts.js
@@ -43,6 +43,12 @@ const asts = {
       simple_not: consumesFalse,
       optional: consumesFalse,
       zero_or_more: consumesFalse,
+      repeated(node) {
+        // Handle exact case
+        const min = node.min ? node.min : node.max;
+
+        return min.value > 0 ? consumes(node.expression) : false;
+      },
       semantic_and: consumesFalse,
       semantic_not: consumesFalse,
 

--- a/lib/compiler/asts.js
+++ b/lib/compiler/asts.js
@@ -44,10 +44,17 @@ const asts = {
       optional: consumesFalse,
       zero_or_more: consumesFalse,
       repeated(node) {
-        // Handle exact case
+        // If minimum is `null` it is equals to maximum (parsed from `|exact|` syntax)
         const min = node.min ? node.min : node.max;
 
-        return min.value > 0 ? consumes(node.expression) : false;
+        // If the low boundary is variable then it can be zero.
+        // Expression, repeated zero times, does not consume any input
+        // but always matched - so it does not always consumes on success
+        if (min.type !== "constant" || min.value === 0) {
+          return false;
+        }
+
+        return consumes(node.expression);
       },
       semantic_and: consumesFalse,
       semantic_not: consumesFalse,

--- a/lib/compiler/opcodes.js
+++ b/lib/compiler/opcodes.js
@@ -26,6 +26,8 @@ const opcodes = {
   IF:                13,   // IF t, f
   IF_ERROR:          14,   // IF_ERROR t, f
   IF_NOT_ERROR:      15,   // IF_NOT_ERROR t, f
+  IF_LT:             30,   // IF_LT min, t, f
+  IF_GE:             31,   // IF_GE max, t, f
   WHILE_NOT_ERROR:   16,   // WHILE_NOT_ERROR b
 
   // Matching
@@ -60,7 +62,9 @@ const opcodes = {
   // sections above are repeated here in order to ensure we don't
   // reuse them.
   //
-  // 30-34 reserved for @mingun
+  // IF_LT: 30
+  // IF_GE: 31
+  // 32-34 reserved for @mingun
   // PUSH_EMPTY_STRING: 35
   // PLUCK: 36
 };

--- a/lib/compiler/opcodes.js
+++ b/lib/compiler/opcodes.js
@@ -28,6 +28,8 @@ const opcodes = {
   IF_NOT_ERROR:      15,   // IF_NOT_ERROR t, f
   IF_LT:             30,   // IF_LT min, t, f
   IF_GE:             31,   // IF_GE max, t, f
+  IF_LT_DYNAMIC:     32,   // IF_LT_DYNAMIC min, t, f
+  IF_GE_DYNAMIC:     33,   // IF_GE_DYNAMIC max, t, f
   WHILE_NOT_ERROR:   16,   // WHILE_NOT_ERROR b
 
   // Matching
@@ -64,7 +66,9 @@ const opcodes = {
   //
   // IF_LT: 30
   // IF_GE: 31
-  // 32-34 reserved for @mingun
+  // IF_LT_DYNAMIC: 32
+  // IF_GE_DYNAMIC: 33
+  // 34 reserved for @mingun
   // PUSH_EMPTY_STRING: 35
   // PLUCK: 36
 };

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -480,6 +480,49 @@ function generateBytecode(ast) {
     );
   }
 
+  function buildRangeBody(
+    delimiterNode,
+    expressionMatch,
+    expressionCode,
+    context
+  ) {
+    if (delimiterNode) {
+      return buildSequence(           //                          stack:[  ]
+        [op.PUSH_CURR_POS],           // pos = peg$currPos;       stack:[ pos ]
+        generate(delimiterNode, {     // item = delim();          stack:[ pos, delim ]
+          // +1 for the saved offset
+          sp: context.sp + 1,
+          env: cloneEnv(context.env),
+          action: null,
+        }),
+        buildCondition(
+          delimiterNode.match | 0,
+          [op.IF_NOT_ERROR],          // if (item !== peg$FAILED) {
+          buildSequence(
+            [op.POP],                 //                          stack:[ pos ]
+            expressionCode,           //   item = expr();         stack:[ pos, item ]
+            buildCondition(
+              -expressionMatch,
+              [op.IF_ERROR],          //   if (item === peg$FAILED) {
+              // If element FAILED, rollback currPos to saved value.
+              /* eslint-disable indent */
+              [op.POP,                //                          stack:[ pos ]
+               op.POP_CURR_POS,       //     peg$currPos = pos;   stack:[  ]
+               op.PUSH_FAILED],       //     item = peg$FAILED;   stack:[ peg$FAILED ]
+              /* eslint-enable indent */
+              // Else, just drop saved currPos.
+              [op.NIP]                //   }                      stack:[ item ]
+            )
+          ),                          // }
+          // If delimiter FAILED, currPos not changed, so just drop it.
+          [op.NIP]                    //                          stack:[ peg$FAILED ]
+        )                             //                          stack:[ <?> ]
+      );
+    }
+
+    return expressionCode;
+  }
+
   const generate = visitor.build({
     grammar(node) {
       node.rules.forEach(generate);
@@ -788,12 +831,18 @@ function generateBytecode(ast) {
         env: cloneEnv(context.env),
         action: null,
       });
+      const bodyCode = buildRangeBody(
+        node.delimiter,
+        node.expression.match | 0,
+        expressionCode,
+        context
+      );
       // Check the high boundary, if it is defined.
-      const checkMaxCode = buildCheckMax(expressionCode, node.max);
+      const checkMaxCode = buildCheckMax(bodyCode, node.max);
       // For dynamic high boundary we need check the first iteration, because the result can be
       // empty. Constant boundaries does not require that check, because they are always >=1
       const firstElemCode = hasBoundedMax
-        ? checkMaxCode
+        ? buildCheckMax(expressionCode, node.max)
         : expressionCode;
       const mainLoopCode = buildSequence(
         // If the low boundary present, then backtracking is possible, so save the current pos

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -106,6 +106,22 @@ const { ALWAYS_MATCH, SOMETIMES_MATCH, NEVER_MATCH } = require("./inference-matc
 //          interpret(ip + 3 + t, ip + 3 + t + f);
 //        }
 //
+// [30] IF_LT min, t, f
+//
+//        if (stack.top().length < min) {
+//          interpret(ip + 3, ip + 3 + t);
+//        } else {
+//          interpret(ip + 3 + t, ip + 3 + t + f);
+//        }
+//
+// [31] IF_GE max, t, f
+//
+//        if (stack.top().length >= max) {
+//          interpret(ip + 3, ip + 3 + t);
+//        } else {
+//          interpret(ip + 3 + t, ip + 3 + t + f);
+//        }
+//
 // [16] WHILE_NOT_ERROR b
 //
 //        while(stack.top() !== FAILED) {
@@ -352,6 +368,51 @@ function generateBytecode(ast) {
     return buildLoop(
       [op.WHILE_NOT_ERROR],
       buildSequence([op.APPEND], expressionCode)
+    );
+  }
+
+  /* eslint capitalized-comments: "off" */
+  /**
+   * @param {number[]} expressionCode Bytecode for parsing repetitions
+   * @param {import("../../peg").ast.RepeatedBoundary} max Maximum boundary of repetitions.
+   *        If `null`, the maximum boundary is unlimited
+   *
+   * @returns {number[]} Bytecode that performs check of the maximum boundary
+   */
+  function buildCheckMax(expressionCode, max) {
+    if (max.value !== null) {
+      // Push `peg$FAILED` - this break loop on next iteration, so |result|
+      // will contains not more then |max| elements.
+      return buildCondition(
+        SOMETIMES_MATCH,
+        [op.IF_GE, max.value], // if (r.length >= max)   stack:[ [elem...] ]
+        [op.PUSH_FAILED],      //   elem = peg$FAILED;   stack:[ [elem...], peg$FAILED ]
+        expressionCode         // else
+      );                       //   elem = expr();       stack:[ [elem...], elem ]
+    }
+
+    return expressionCode;
+  }
+
+  /* eslint capitalized-comments: "off" */
+  /**
+   * @param {number[]} expressionCode Bytecode for parsing repeated elements
+   * @param {import("../../peg").ast.RepeatedBoundary} min Minimum boundary of repetitions.
+   *        If `null`, the minimum boundary is zero
+   *
+   * @returns {number[]} Bytecode that performs check of the minimum boundary
+   */
+  function buildCheckMin(expressionCode, min) {
+    return buildSequence(
+      expressionCode,             // result = [elem...];      stack:[ pos, [elem...] ]
+      buildCondition(
+        SOMETIMES_MATCH,
+        [op.IF_LT, min.value],    // if (result.length < min) {
+        [op.POP, op.POP_CURR_POS, //   currPos = savedPos;    stack:[  ]
+        // eslint-disable-next-line indent
+         op.PUSH_FAILED],         //   result = peg$FAILED;   stack:[ peg$FAILED ]
+        [op.NIP]                  // }                        stack:[ [elem...] ]
+      )
     );
   }
 
@@ -631,6 +692,30 @@ function generateBytecode(ast) {
           buildSequence([op.POP], [op.POP], [op.PUSH_FAILED])
         )
       );
+    },
+
+    repeated(node, context) {
+      // Handle case when minimum was literally equals to maximum
+      const min = node.min ? node.min : node.max;
+      const hasMin = min.value > 0;
+      const expressionCode = generate(node.expression, {
+        sp: context.sp + (hasMin ? 2 : 1),
+        env: cloneEnv(context.env),
+        action: null,
+      });
+      // Check the high boundary, if it is defined.
+      const checkMaxCode = buildCheckMax(expressionCode, node.max);
+      const mainLoopCode = buildSequence(
+        // If the low boundary present, then backtracking is possible, so save the current pos
+        hasMin ? [op.PUSH_CURR_POS] : [], // var savedPos = curPos;   stack:[ pos ]
+        [op.PUSH_EMPTY_ARRAY],            // var result = [];         stack:[ pos, [] ]
+        expressionCode,                   // var elem = expr();       stack:[ pos, [], elem ]
+        buildAppendLoop(checkMaxCode),    // while(...)r.push(elem);  stack:[ pos, [...], elem|peg$FAILED ]
+        [op.POP]                          //                          stack:[ pos, [elem...] ] (pop elem===`peg$FAILED`)
+      );
+
+      // Check the low boundary, if it is defined and not |0|.
+      return hasMin ? buildCheckMin(mainLoopCode, min) : mainLoopCode;
     },
 
     group(node, context) {

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -122,6 +122,22 @@ const { ALWAYS_MATCH, SOMETIMES_MATCH, NEVER_MATCH } = require("./inference-matc
 //          interpret(ip + 3 + t, ip + 3 + t + f);
 //        }
 //
+// [32] IF_LT_DYNAMIC min, t, f
+//
+//        if (stack.top().length < stack[min]) {
+//          interpret(ip + 3, ip + 3 + t);
+//        } else {
+//          interpret(ip + 3 + t, ip + 3 + t + f);
+//        }
+//
+// [33] IF_GE_DYNAMIC max, t, f
+//
+//        if (stack.top().length >= stack[max]) {
+//          interpret(ip + 3, ip + 3 + t);
+//        } else {
+//          interpret(ip + 3 + t, ip + 3 + t + f);
+//        }
+//
 // [16] WHILE_NOT_ERROR b
 //
 //        while(stack.top() !== FAILED) {
@@ -376,16 +392,22 @@ function generateBytecode(ast) {
    * @param {number[]} expressionCode Bytecode for parsing repetitions
    * @param {import("../../peg").ast.RepeatedBoundary} max Maximum boundary of repetitions.
    *        If `null`, the maximum boundary is unlimited
+   * @param {object} context
+   * @param {number} sp Pointer to the top of the variable stack
    *
    * @returns {number[]} Bytecode that performs check of the maximum boundary
    */
-  function buildCheckMax(expressionCode, max) {
+  function buildCheckMax(expressionCode, max, context, sp) {
     if (max.value !== null) {
+      const checkCode = max.type === "constant"
+        ? [op.IF_GE, max.value]
+        : [op.IF_GE_DYNAMIC, sp - context.env[max.value]];
+
       // Push `peg$FAILED` - this break loop on next iteration, so |result|
       // will contains not more then |max| elements.
       return buildCondition(
         SOMETIMES_MATCH,
-        [op.IF_GE, max.value], // if (r.length >= max)   stack:[ [elem...] ]
+        checkCode,             // if (r.length >= max)   stack:[ [elem...] ]
         [op.PUSH_FAILED],      //   elem = peg$FAILED;   stack:[ [elem...], peg$FAILED ]
         expressionCode         // else
       );                       //   elem = expr();       stack:[ [elem...], elem ]
@@ -402,12 +424,16 @@ function generateBytecode(ast) {
    *
    * @returns {number[]} Bytecode that performs check of the minimum boundary
    */
-  function buildCheckMin(expressionCode, min) {
+  function buildCheckMin(expressionCode, min, context) {
+    const checkCode = min.type === "constant"
+      ? [op.IF_LT, min.value]
+      : [op.IF_LT_DYNAMIC, context.sp + 2 - context.env[min.value]];
+
     return buildSequence(
       expressionCode,             // result = [elem...];      stack:[ pos, [elem...] ]
       buildCondition(
         SOMETIMES_MATCH,
-        [op.IF_LT, min.value],    // if (result.length < min) {
+        checkCode,                // if (result.length < min) {
         [op.POP, op.POP_CURR_POS, //   currPos = savedPos;    stack:[  ]
         // eslint-disable-next-line indent
          op.PUSH_FAILED],         //   result = peg$FAILED;   stack:[ peg$FAILED ]
@@ -697,25 +723,37 @@ function generateBytecode(ast) {
     repeated(node, context) {
       // Handle case when minimum was literally equals to maximum
       const min = node.min ? node.min : node.max;
-      const hasMin = min.value > 0;
+      const hasMin = min.type !== "constant" || min.value > 0;
+      const hasBoundedMax = node.max.type !== "constant" && node.max.value !== null;
+      const sp = context.sp + (hasMin ? 2 : 1);
+
       const expressionCode = generate(node.expression, {
-        sp: context.sp + (hasMin ? 2 : 1),
+        sp,
         env: cloneEnv(context.env),
         action: null,
       });
       // Check the high boundary, if it is defined.
-      const checkMaxCode = buildCheckMax(expressionCode, node.max);
+      const checkMaxCode = buildCheckMax(
+        expressionCode, node.max, context, sp
+      );
+      // For dynamic high boundary we need check the first iteration, because the result can be
+      // empty. Constant boundaries does not require that check, because they are always >=1
+      const firstElemCode = hasBoundedMax
+        ? checkMaxCode
+        : expressionCode;
       const mainLoopCode = buildSequence(
         // If the low boundary present, then backtracking is possible, so save the current pos
         hasMin ? [op.PUSH_CURR_POS] : [], // var savedPos = curPos;   stack:[ pos ]
         [op.PUSH_EMPTY_ARRAY],            // var result = [];         stack:[ pos, [] ]
-        expressionCode,                   // var elem = expr();       stack:[ pos, [], elem ]
+        firstElemCode,                    // var elem = expr();       stack:[ pos, [], elem ]
         buildAppendLoop(checkMaxCode),    // while(...)r.push(elem);  stack:[ pos, [...], elem|peg$FAILED ]
-        [op.POP]                          //                          stack:[ pos, [elem...] ] (pop elem===`peg$FAILED`)
+        [op.POP]                          //                          stack:[ pos, [...] ] (pop elem===`peg$FAILED`)
       );
 
       // Check the low boundary, if it is defined and not |0|.
-      return hasMin ? buildCheckMin(mainLoopCode, min) : mainLoopCode;
+      return hasMin
+        ? buildCheckMin(mainLoopCode, min, context)
+        : mainLoopCode;
     },
 
     group(node, context) {

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -387,21 +387,59 @@ function generateBytecode(ast) {
     );
   }
 
+  /**
+   *
+   * @param {import("../../peg").ast.RepeatedBoundary} boundary
+   * @param {{ [label: string]: number}} env Mapping of label names to stack positions
+   * @param {number} sp Number of the first free slot in the stack
+   *
+   * @returns {{ pre: number[], post: number[], sp: number}}
+   *          Bytecode that should be added before and after parsing and new
+   *          first free slot in the stack
+   */
+  function buildRangeCall(boundary, env, sp, offset) {
+    switch (boundary.type) {
+      case "constant":
+        return { pre: [], post: [], sp };
+      case "variable":
+        boundary.sp = offset + sp - env[boundary.value];
+        return { pre: [], post: [], sp };
+      case "function": {
+        boundary.sp = offset;
+
+        const functionIndex = addFunctionConst(
+          true,
+          Object.keys(env),
+          { code: boundary.value, codeLocation: boundary.codeLocation }
+        );
+
+        return {
+          pre: buildCall(functionIndex, 0, env, sp),
+          post: [op.NIP],
+          // +1 for the function result
+          sp: sp + 1,
+        };
+      }
+
+      // istanbul ignore next Because we never generate invalid boundary type we cannot reach this branch
+      default:
+        throw new Error(`Unknown boundary type "${boundary.type}" for the "repeated" node`);
+    }
+  }
+
   /* eslint capitalized-comments: "off" */
   /**
    * @param {number[]} expressionCode Bytecode for parsing repetitions
    * @param {import("../../peg").ast.RepeatedBoundary} max Maximum boundary of repetitions.
    *        If `null`, the maximum boundary is unlimited
-   * @param {object} context
-   * @param {number} sp Pointer to the top of the variable stack
    *
    * @returns {number[]} Bytecode that performs check of the maximum boundary
    */
-  function buildCheckMax(expressionCode, max, context, sp) {
+  function buildCheckMax(expressionCode, max) {
     if (max.value !== null) {
       const checkCode = max.type === "constant"
         ? [op.IF_GE, max.value]
-        : [op.IF_GE_DYNAMIC, sp - context.env[max.value]];
+        : [op.IF_GE_DYNAMIC, max.sp];
 
       // Push `peg$FAILED` - this break loop on next iteration, so |result|
       // will contains not more then |max| elements.
@@ -424,10 +462,10 @@ function generateBytecode(ast) {
    *
    * @returns {number[]} Bytecode that performs check of the minimum boundary
    */
-  function buildCheckMin(expressionCode, min, context) {
+  function buildCheckMin(expressionCode, min) {
     const checkCode = min.type === "constant"
       ? [op.IF_LT, min.value]
-      : [op.IF_LT_DYNAMIC, context.sp + 2 - context.env[min.value]];
+      : [op.IF_LT_DYNAMIC, min.sp];
 
     return buildSequence(
       expressionCode,             // result = [elem...];      stack:[ pos, [elem...] ]
@@ -725,17 +763,33 @@ function generateBytecode(ast) {
       const min = node.min ? node.min : node.max;
       const hasMin = min.type !== "constant" || min.value > 0;
       const hasBoundedMax = node.max.type !== "constant" && node.max.value !== null;
-      const sp = context.sp + (hasMin ? 2 : 1);
+
+      // +1 for the result slot with an array
+      // +1 if we have non-constant (i.e. potentially non-zero) or non-zero minimum
+      //    for the position before match for backtracking
+      const offset = hasMin ? 2 : 1;
+
+      // Do not generate function for "minimum" if grammar used `exact` syntax
+      const minCode = node.min
+        ? buildRangeCall(
+          node.min,
+          context.env,
+          context.sp,
+          // +1 for the result slot with an array
+          // +1 for the saved position
+          // +1 if we have a "function" maximum it occupies an additional slot in the stack
+          2 + (node.max.type === "function" ? 1 : 0)
+        )
+        : { pre: [], post: [], sp: context.sp };
+      const maxCode = buildRangeCall(node.max, context.env, minCode.sp, offset);
 
       const expressionCode = generate(node.expression, {
-        sp,
+        sp: maxCode.sp + offset,
         env: cloneEnv(context.env),
         action: null,
       });
       // Check the high boundary, if it is defined.
-      const checkMaxCode = buildCheckMax(
-        expressionCode, node.max, context, sp
-      );
+      const checkMaxCode = buildCheckMax(expressionCode, node.max);
       // For dynamic high boundary we need check the first iteration, because the result can be
       // empty. Constant boundaries does not require that check, because they are always >=1
       const firstElemCode = hasBoundedMax
@@ -750,10 +804,16 @@ function generateBytecode(ast) {
         [op.POP]                          //                          stack:[ pos, [...] ] (pop elem===`peg$FAILED`)
       );
 
-      // Check the low boundary, if it is defined and not |0|.
-      return hasMin
-        ? buildCheckMin(mainLoopCode, min, context)
-        : mainLoopCode;
+      return buildSequence(
+        minCode.pre,
+        maxCode.pre,
+        // Check the low boundary, if it is defined and not |0|.
+        hasMin
+          ? buildCheckMin(mainLoopCode, min)
+          : mainLoopCode,
+        maxCode.post,
+        minCode.post
+      );
     },
 
     group(node, context) {

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -429,6 +429,14 @@ function generateJS(ast, options) {
             compileCondition(stack.top() + " !== peg$FAILED", 0);
             break;
 
+          case op.IF_LT:              // IF_LT min, t, f
+            compileCondition(stack.top() + ".length < " + bc[ip + 1], 1);
+            break;
+
+          case op.IF_GE:              // IF_GE max, t, f
+            compileCondition(stack.top() + ".length >= " + bc[ip + 1], 1);
+            break;
+
           case op.WHILE_NOT_ERROR:    // WHILE_NOT_ERROR b
             compileLoop(stack.top() + " !== peg$FAILED");
             break;

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -437,6 +437,14 @@ function generateJS(ast, options) {
             compileCondition(stack.top() + ".length >= " + bc[ip + 1], 1);
             break;
 
+          case op.IF_LT_DYNAMIC:      // IF_LT_DYNAMIC min, t, f
+            compileCondition(stack.top() + ".length < " + stack.index(bc[ip + 1]) + "|0", 1);
+            break;
+
+          case op.IF_GE_DYNAMIC:      // IF_GE_DYNAMIC max, t, f
+            compileCondition(stack.top() + ".length >= " + stack.index(bc[ip + 1]) + "|0", 1);
+            break;
+
           case op.WHILE_NOT_ERROR:    // WHILE_NOT_ERROR b
             compileLoop(stack.top() + " !== peg$FAILED");
             break;

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -312,18 +312,14 @@ function generateJS(ast, options) {
         parts.push("}");
       }
 
-      function compileCall() {
-        const baseLength = 4;
+      function compileCall(baseLength) {
         const paramsLength = bc[ip + baseLength - 1];
 
-        const value = f(bc[ip + 1]) + "("
+        return f(bc[ip + 1]) + "("
           + bc.slice(ip + baseLength, ip + baseLength + paramsLength).map(
             p => stack.index(p)
           ).join(", ")
           + ")";
-        stack.pop(bc[ip + 2]);
-        parts.push(stack.push(value));
-        ip += baseLength + paramsLength;
       }
 
       while (ip < end) {
@@ -524,7 +520,10 @@ function generateJS(ast, options) {
             break;
 
           case op.CALL:               // CALL f, n, pc, p1, p2, ..., pN
-            compileCall();
+            value = compileCall(4);
+            stack.pop(bc[ip + 2]);
+            parts.push(stack.push(value));
+            ip += 4 + bc[ip + 3];
             break;
 
           case op.RULE:               // RULE r

--- a/lib/compiler/passes/inference-match-result.js
+++ b/lib/compiler/passes/inference-match-result.js
@@ -98,10 +98,37 @@ function inferenceMatchResult(ast) {
     one_or_more:  inferenceExpression,
     repeated(node) {
       const match = inference(node.expression);
-      // Handle exact case
+      // If minimum is `null` it is equals to maximum (parsed from `|exact|` syntax)
       const min = node.min ? node.min : node.max;
 
-      return (node.match = min.value > 0 ? match : ALWAYS_MATCH);
+      // If any boundary are variable - it can be negative, and it that case
+      // node does not match, but it may be match with some other values
+      if (min.type !== "constant" || node.max.type !== "constant") {
+        return (node.match = SOMETIMES_MATCH);
+      }
+      // Now both boundaries is constants
+      // If the upper boundary is zero or minimum exceeds maximum,
+      // matching is impossible
+      if (node.max.value === 0
+       || node.max.value !== null && min.value > node.max.value
+      ) {
+        return (node.match = NEVER_MATCH);
+      }
+
+      if (match === NEVER_MATCH) {
+        // If an expression always fails, a range will also always fail
+        // (with the one exception - never matched expression repeated
+        //  zero times always match and returns an empty array).
+        return (node.match = min.value === 0 ? ALWAYS_MATCH : NEVER_MATCH);
+      }
+      if (match === ALWAYS_MATCH) {
+        return (node.match = ALWAYS_MATCH);
+      }
+
+      // Here an expression sometimes match. If it should be repeated at least once
+      // the whole range sometimes match, otherwise it will always succeeds (at least
+      // an empty array guaranteed)
+      return (node.match = min.value === 0 ? ALWAYS_MATCH : SOMETIMES_MATCH);
     },
     group:        inferenceExpression,
     semantic_and: sometimesMatch,

--- a/lib/compiler/passes/inference-match-result.js
+++ b/lib/compiler/passes/inference-match-result.js
@@ -98,6 +98,7 @@ function inferenceMatchResult(ast) {
     one_or_more:  inferenceExpression,
     repeated(node) {
       const match = inference(node.expression);
+      const dMatch = node.delimiter ? inference(node.delimiter) : NEVER_MATCH;
       // If minimum is `null` it is equals to maximum (parsed from `|exact|` syntax)
       const min = node.min ? node.min : node.max;
 
@@ -122,12 +123,28 @@ function inferenceMatchResult(ast) {
         return (node.match = min.value === 0 ? ALWAYS_MATCH : NEVER_MATCH);
       }
       if (match === ALWAYS_MATCH) {
+        if (node.delimiter && min.value >= 2) {
+          // If an expression always match the final result determined only
+          // by the delimiter, but delimiter used only when count of elements
+          // two and more
+          return (node.match = dMatch);
+        }
+
         return (node.match = ALWAYS_MATCH);
       }
 
-      // Here an expression sometimes match. If it should be repeated at least once
-      // the whole range sometimes match, otherwise it will always succeeds (at least
-      // an empty array guaranteed)
+      // Here `match === SOMETIMES_MATCH`
+      if (node.delimiter && min.value >= 2) {
+        // If an expression always match the final result determined only
+        // by the delimiter, but delimiter used only when count of elements
+        // two and more
+        return (
+          // If a delimiter never match then the range also never match (because
+          // there at least one delimiter)
+          node.match = dMatch === NEVER_MATCH ? NEVER_MATCH : SOMETIMES_MATCH
+        );
+      }
+
       return (node.match = min.value === 0 ? ALWAYS_MATCH : SOMETIMES_MATCH);
     },
     group:        inferenceExpression,

--- a/lib/compiler/passes/inference-match-result.js
+++ b/lib/compiler/passes/inference-match-result.js
@@ -96,6 +96,13 @@ function inferenceMatchResult(ast) {
     optional:     alwaysMatch,
     zero_or_more: alwaysMatch,
     one_or_more:  inferenceExpression,
+    repeated(node) {
+      const match = inference(node.expression);
+      // Handle exact case
+      const min = node.min ? node.min : node.max;
+
+      return (node.match = min.value > 0 ? match : ALWAYS_MATCH);
+    },
     group:        inferenceExpression,
     semantic_and: sometimesMatch,
     semantic_not: sometimesMatch,

--- a/lib/compiler/passes/report-duplicate-labels.js
+++ b/lib/compiler/passes/report-duplicate-labels.js
@@ -55,7 +55,13 @@ function reportDuplicateLabels(ast, options, session) {
     optional: checkExpressionWithClonedEnv,
     zero_or_more: checkExpressionWithClonedEnv,
     one_or_more: checkExpressionWithClonedEnv,
-    repeated: checkExpressionWithClonedEnv,
+    repeated(node, env) {
+      if (node.delimiter) {
+        check(node.delimiter, cloneEnv(env));
+      }
+
+      check(node.expression, cloneEnv(env));
+    },
     group: checkExpressionWithClonedEnv,
   });
 

--- a/lib/compiler/passes/report-duplicate-labels.js
+++ b/lib/compiler/passes/report-duplicate-labels.js
@@ -55,6 +55,7 @@ function reportDuplicateLabels(ast, options, session) {
     optional: checkExpressionWithClonedEnv,
     zero_or_more: checkExpressionWithClonedEnv,
     one_or_more: checkExpressionWithClonedEnv,
+    repeated: checkExpressionWithClonedEnv,
     group: checkExpressionWithClonedEnv,
   });
 

--- a/lib/compiler/passes/report-infinite-recursion.js
+++ b/lib/compiler/passes/report-infinite-recursion.js
@@ -34,6 +34,18 @@ function reportInfiniteRecursion(ast, options, session) {
       });
     },
 
+    repeated(node) {
+      check(node.expression);
+
+      // If an expression does not consume input then recursion
+      // over delimiter is possible
+      if (node.delimiter
+       && !asts.alwaysConsumesOnSuccess(ast, node.expression)
+      ) {
+        check(node.delimiter);
+      }
+    },
+
     rule_ref(node) {
       backtraceRefs.push(node);
 

--- a/lib/compiler/passes/report-infinite-repetition.js
+++ b/lib/compiler/passes/report-infinite-repetition.js
@@ -3,7 +3,7 @@
 const asts = require("../asts");
 const visitor = require("../visitor");
 
-// Reports expressions that don't consume any input inside |*| or |+| in the
+// Reports expressions that don't consume any input inside |*|, |+| or repeated in the
 // grammar, which prevents infinite loops in the generated parser.
 function reportInfiniteRepetition(ast, options, session) {
   const check = visitor.build({
@@ -20,6 +20,23 @@ function reportInfiniteRepetition(ast, options, session) {
       if (!asts.alwaysConsumesOnSuccess(ast, node.expression)) {
         session.error(
           "Possible infinite loop when parsing (repetition used with an expression that may not consume any input)",
+          node.location
+        );
+      }
+    },
+
+    repeated(node) {
+      if (asts.alwaysConsumesOnSuccess(ast, node.expression)) {
+        return;
+      }
+      if (node.max.value === null) {
+        session.error(
+          "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          node.location
+        );
+      } else {
+        session.warning(
+          `An expression always match ${node.max.value} times, because it does not consume any input`,
           node.location
         );
       }

--- a/lib/compiler/passes/report-infinite-repetition.js
+++ b/lib/compiler/passes/report-infinite-repetition.js
@@ -26,7 +26,9 @@ function reportInfiniteRepetition(ast, options, session) {
     },
 
     repeated(node) {
-      if (asts.alwaysConsumesOnSuccess(ast, node.expression)) {
+      if (asts.alwaysConsumesOnSuccess(ast, node.expression)
+       || node.delimiter && asts.alwaysConsumesOnSuccess(ast, node.delimiter)
+      ) {
         return;
       }
       if (node.max.value === null) {

--- a/lib/compiler/passes/report-infinite-repetition.js
+++ b/lib/compiler/passes/report-infinite-repetition.js
@@ -35,8 +35,15 @@ function reportInfiniteRepetition(ast, options, session) {
           node.location
         );
       } else {
+        // If minimum is `null` it is equals to maximum (parsed from `|exact|` syntax)
+        const min = node.min ? node.min : node.max;
+
+        // Because the high boundary is defined, infinity repetition is not possible
+        // but the grammar will waste of CPU
         session.warning(
-          `An expression always match ${node.max.value} times, because it does not consume any input`,
+          min.type === "constant" && node.max.type === "constant"
+            ? `An expression may not consume any input and may always match ${node.max.value} times`
+            : "An expression may not consume any input and may always match with a maximum repetition count",
           node.location
         );
       }

--- a/lib/compiler/visitor.js
+++ b/lib/compiler/visitor.js
@@ -53,7 +53,13 @@ const visitor = {
       optional: visitExpression,
       zero_or_more: visitExpression,
       one_or_more: visitExpression,
-      repeated: visitExpression,
+      repeated(node, ...args) {
+        if (node.delimiter) {
+          visit(node.delimiter, ...args);
+        }
+
+        return visit(node.expression, ...args);
+      },
       group: visitExpression,
       semantic_and: visitNop,
       semantic_not: visitNop,

--- a/lib/compiler/visitor.js
+++ b/lib/compiler/visitor.js
@@ -53,6 +53,7 @@ const visitor = {
       optional: visitExpression,
       zero_or_more: visitExpression,
       one_or_more: visitExpression,
+      repeated: visitExpression,
       group: visitExpression,
       semantic_and: visitNop,
       semantic_not: visitNop,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -203,45 +203,46 @@ function peg$parse(input, options) {
   var peg$c10 = "*";
   var peg$c11 = "+";
   var peg$c12 = "|";
-  var peg$c13 = "..";
-  var peg$c14 = "(";
-  var peg$c15 = ")";
-  var peg$c16 = "\t";
-  var peg$c17 = "\v";
-  var peg$c18 = "\f";
-  var peg$c19 = " ";
-  var peg$c20 = "\xA0";
-  var peg$c21 = "\uFEFF";
-  var peg$c22 = "\n";
-  var peg$c23 = "\r\n";
-  var peg$c24 = "\r";
-  var peg$c25 = "\u2028";
-  var peg$c26 = "\u2029";
-  var peg$c27 = "/*";
-  var peg$c28 = "*/";
-  var peg$c29 = "//";
-  var peg$c30 = "_";
-  var peg$c31 = "\\";
-  var peg$c32 = "\u200C";
-  var peg$c33 = "\u200D";
-  var peg$c34 = "i";
-  var peg$c35 = "\"";
-  var peg$c36 = "'";
-  var peg$c37 = "[";
-  var peg$c38 = "^";
-  var peg$c39 = "]";
-  var peg$c40 = "-";
-  var peg$c41 = "0";
-  var peg$c42 = "b";
-  var peg$c43 = "f";
-  var peg$c44 = "n";
-  var peg$c45 = "r";
-  var peg$c46 = "t";
-  var peg$c47 = "v";
-  var peg$c48 = "x";
-  var peg$c49 = "u";
-  var peg$c50 = ".";
-  var peg$c51 = ";";
+  var peg$c13 = ",";
+  var peg$c14 = "..";
+  var peg$c15 = "(";
+  var peg$c16 = ")";
+  var peg$c17 = "\t";
+  var peg$c18 = "\v";
+  var peg$c19 = "\f";
+  var peg$c20 = " ";
+  var peg$c21 = "\xA0";
+  var peg$c22 = "\uFEFF";
+  var peg$c23 = "\n";
+  var peg$c24 = "\r\n";
+  var peg$c25 = "\r";
+  var peg$c26 = "\u2028";
+  var peg$c27 = "\u2029";
+  var peg$c28 = "/*";
+  var peg$c29 = "*/";
+  var peg$c30 = "//";
+  var peg$c31 = "_";
+  var peg$c32 = "\\";
+  var peg$c33 = "\u200C";
+  var peg$c34 = "\u200D";
+  var peg$c35 = "i";
+  var peg$c36 = "\"";
+  var peg$c37 = "'";
+  var peg$c38 = "[";
+  var peg$c39 = "^";
+  var peg$c40 = "]";
+  var peg$c41 = "-";
+  var peg$c42 = "0";
+  var peg$c43 = "b";
+  var peg$c44 = "f";
+  var peg$c45 = "n";
+  var peg$c46 = "r";
+  var peg$c47 = "t";
+  var peg$c48 = "v";
+  var peg$c49 = "x";
+  var peg$c50 = "u";
+  var peg$c51 = ".";
+  var peg$c52 = ";";
 
   var peg$r0 = /^[\n\r\u2028\u2029]/;
   var peg$r1 = /^[0-9]/;
@@ -272,69 +273,70 @@ function peg$parse(input, options) {
   var peg$e10 = peg$literalExpectation("*", false);
   var peg$e11 = peg$literalExpectation("+", false);
   var peg$e12 = peg$literalExpectation("|", false);
-  var peg$e13 = peg$literalExpectation("..", false);
-  var peg$e14 = peg$literalExpectation("(", false);
-  var peg$e15 = peg$literalExpectation(")", false);
-  var peg$e16 = peg$anyExpectation();
-  var peg$e17 = peg$otherExpectation("whitespace");
-  var peg$e18 = peg$literalExpectation("\t", false);
-  var peg$e19 = peg$literalExpectation("\v", false);
-  var peg$e20 = peg$literalExpectation("\f", false);
-  var peg$e21 = peg$literalExpectation(" ", false);
-  var peg$e22 = peg$literalExpectation("\xA0", false);
-  var peg$e23 = peg$literalExpectation("\uFEFF", false);
-  var peg$e24 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false);
-  var peg$e25 = peg$otherExpectation("end of line");
-  var peg$e26 = peg$literalExpectation("\n", false);
-  var peg$e27 = peg$literalExpectation("\r\n", false);
-  var peg$e28 = peg$literalExpectation("\r", false);
-  var peg$e29 = peg$literalExpectation("\u2028", false);
-  var peg$e30 = peg$literalExpectation("\u2029", false);
-  var peg$e31 = peg$otherExpectation("comment");
-  var peg$e32 = peg$literalExpectation("/*", false);
-  var peg$e33 = peg$literalExpectation("*/", false);
-  var peg$e34 = peg$literalExpectation("//", false);
-  var peg$e35 = peg$otherExpectation("identifier");
-  var peg$e36 = peg$literalExpectation("_", false);
-  var peg$e37 = peg$literalExpectation("\\", false);
-  var peg$e38 = peg$literalExpectation("\u200C", false);
-  var peg$e39 = peg$literalExpectation("\u200D", false);
-  var peg$e40 = peg$otherExpectation("literal");
-  var peg$e41 = peg$literalExpectation("i", false);
-  var peg$e42 = peg$otherExpectation("string");
-  var peg$e43 = peg$literalExpectation("\"", false);
-  var peg$e44 = peg$literalExpectation("'", false);
-  var peg$e45 = peg$otherExpectation("character class");
-  var peg$e46 = peg$literalExpectation("[", false);
-  var peg$e47 = peg$literalExpectation("^", false);
-  var peg$e48 = peg$literalExpectation("]", false);
-  var peg$e49 = peg$literalExpectation("-", false);
-  var peg$e50 = peg$literalExpectation("0", false);
-  var peg$e51 = peg$literalExpectation("b", false);
-  var peg$e52 = peg$literalExpectation("f", false);
-  var peg$e53 = peg$literalExpectation("n", false);
-  var peg$e54 = peg$literalExpectation("r", false);
-  var peg$e55 = peg$literalExpectation("t", false);
-  var peg$e56 = peg$literalExpectation("v", false);
-  var peg$e57 = peg$literalExpectation("x", false);
-  var peg$e58 = peg$literalExpectation("u", false);
-  var peg$e59 = peg$classExpectation([["0", "9"]], false, false);
-  var peg$e60 = peg$classExpectation([["0", "9"], ["a", "f"]], false, true);
-  var peg$e61 = peg$literalExpectation(".", false);
-  var peg$e62 = peg$otherExpectation("code block");
-  var peg$e63 = peg$classExpectation(["{", "}"], false, false);
-  var peg$e64 = peg$classExpectation([["a", "z"], "\xB5", ["\xDF", "\xF6"], ["\xF8", "\xFF"], "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", ["\u0137", "\u0138"], "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", ["\u0148", "\u0149"], "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", ["\u017E", "\u0180"], "\u0183", "\u0185", "\u0188", ["\u018C", "\u018D"], "\u0192", "\u0195", ["\u0199", "\u019B"], "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", ["\u01AA", "\u01AB"], "\u01AD", "\u01B0", "\u01B4", "\u01B6", ["\u01B9", "\u01BA"], ["\u01BD", "\u01BF"], "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", ["\u01DC", "\u01DD"], "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", ["\u01EF", "\u01F0"], "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", ["\u0233", "\u0239"], "\u023C", ["\u023F", "\u0240"], "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", ["\u024F", "\u0293"], ["\u0295", "\u02AF"], "\u0371", "\u0373", "\u0377", ["\u037B", "\u037D"], "\u0390", ["\u03AC", "\u03CE"], ["\u03D0", "\u03D1"], ["\u03D5", "\u03D7"], "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", ["\u03EF", "\u03F3"], "\u03F5", "\u03F8", ["\u03FB", "\u03FC"], ["\u0430", "\u045F"], "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", ["\u04CE", "\u04CF"], "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0525", "\u0527", "\u0529", "\u052B", "\u052D", "\u052F", ["\u0561", "\u0587"], ["\u13F8", "\u13FD"], ["\u1D00", "\u1D2B"], ["\u1D6B", "\u1D77"], ["\u1D79", "\u1D9A"], "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", ["\u1E95", "\u1E9D"], "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", ["\u1EFF", "\u1F07"], ["\u1F10", "\u1F15"], ["\u1F20", "\u1F27"], ["\u1F30", "\u1F37"], ["\u1F40", "\u1F45"], ["\u1F50", "\u1F57"], ["\u1F60", "\u1F67"], ["\u1F70", "\u1F7D"], ["\u1F80", "\u1F87"], ["\u1F90", "\u1F97"], ["\u1FA0", "\u1FA7"], ["\u1FB0", "\u1FB4"], ["\u1FB6", "\u1FB7"], "\u1FBE", ["\u1FC2", "\u1FC4"], ["\u1FC6", "\u1FC7"], ["\u1FD0", "\u1FD3"], ["\u1FD6", "\u1FD7"], ["\u1FE0", "\u1FE7"], ["\u1FF2", "\u1FF4"], ["\u1FF6", "\u1FF7"], "\u210A", ["\u210E", "\u210F"], "\u2113", "\u212F", "\u2134", "\u2139", ["\u213C", "\u213D"], ["\u2146", "\u2149"], "\u214E", "\u2184", ["\u2C30", "\u2C5E"], "\u2C61", ["\u2C65", "\u2C66"], "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", ["\u2C73", "\u2C74"], ["\u2C76", "\u2C7B"], "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", ["\u2CE3", "\u2CE4"], "\u2CEC", "\u2CEE", "\u2CF3", ["\u2D00", "\u2D25"], "\u2D27", "\u2D2D", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA661", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA699", "\uA69B", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", ["\uA72F", "\uA731"], "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", ["\uA771", "\uA778"], "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uA78E", "\uA791", ["\uA793", "\uA795"], "\uA797", "\uA799", "\uA79B", "\uA79D", "\uA79F", "\uA7A1", "\uA7A3", "\uA7A5", "\uA7A7", "\uA7A9", "\uA7B5", "\uA7B7", "\uA7FA", ["\uAB30", "\uAB5A"], ["\uAB60", "\uAB65"], ["\uAB70", "\uABBF"], ["\uFB00", "\uFB06"], ["\uFB13", "\uFB17"], ["\uFF41", "\uFF5A"]], false, false);
-  var peg$e65 = peg$classExpectation([["\u02B0", "\u02C1"], ["\u02C6", "\u02D1"], ["\u02E0", "\u02E4"], "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", ["\u06E5", "\u06E6"], ["\u07F4", "\u07F5"], "\u07FA", "\u081A", "\u0824", "\u0828", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1AA7", ["\u1C78", "\u1C7D"], ["\u1D2C", "\u1D6A"], "\u1D78", ["\u1D9B", "\u1DBF"], "\u2071", "\u207F", ["\u2090", "\u209C"], ["\u2C7C", "\u2C7D"], "\u2D6F", "\u2E2F", "\u3005", ["\u3031", "\u3035"], "\u303B", ["\u309D", "\u309E"], ["\u30FC", "\u30FE"], "\uA015", ["\uA4F8", "\uA4FD"], "\uA60C", "\uA67F", ["\uA69C", "\uA69D"], ["\uA717", "\uA71F"], "\uA770", "\uA788", ["\uA7F8", "\uA7F9"], "\uA9CF", "\uA9E6", "\uAA70", "\uAADD", ["\uAAF3", "\uAAF4"], ["\uAB5C", "\uAB5F"], "\uFF70", ["\uFF9E", "\uFF9F"]], false, false);
-  var peg$e66 = peg$classExpectation(["\xAA", "\xBA", "\u01BB", ["\u01C0", "\u01C3"], "\u0294", ["\u05D0", "\u05EA"], ["\u05F0", "\u05F2"], ["\u0620", "\u063F"], ["\u0641", "\u064A"], ["\u066E", "\u066F"], ["\u0671", "\u06D3"], "\u06D5", ["\u06EE", "\u06EF"], ["\u06FA", "\u06FC"], "\u06FF", "\u0710", ["\u0712", "\u072F"], ["\u074D", "\u07A5"], "\u07B1", ["\u07CA", "\u07EA"], ["\u0800", "\u0815"], ["\u0840", "\u0858"], ["\u08A0", "\u08B4"], ["\u0904", "\u0939"], "\u093D", "\u0950", ["\u0958", "\u0961"], ["\u0972", "\u0980"], ["\u0985", "\u098C"], ["\u098F", "\u0990"], ["\u0993", "\u09A8"], ["\u09AA", "\u09B0"], "\u09B2", ["\u09B6", "\u09B9"], "\u09BD", "\u09CE", ["\u09DC", "\u09DD"], ["\u09DF", "\u09E1"], ["\u09F0", "\u09F1"], ["\u0A05", "\u0A0A"], ["\u0A0F", "\u0A10"], ["\u0A13", "\u0A28"], ["\u0A2A", "\u0A30"], ["\u0A32", "\u0A33"], ["\u0A35", "\u0A36"], ["\u0A38", "\u0A39"], ["\u0A59", "\u0A5C"], "\u0A5E", ["\u0A72", "\u0A74"], ["\u0A85", "\u0A8D"], ["\u0A8F", "\u0A91"], ["\u0A93", "\u0AA8"], ["\u0AAA", "\u0AB0"], ["\u0AB2", "\u0AB3"], ["\u0AB5", "\u0AB9"], "\u0ABD", "\u0AD0", ["\u0AE0", "\u0AE1"], "\u0AF9", ["\u0B05", "\u0B0C"], ["\u0B0F", "\u0B10"], ["\u0B13", "\u0B28"], ["\u0B2A", "\u0B30"], ["\u0B32", "\u0B33"], ["\u0B35", "\u0B39"], "\u0B3D", ["\u0B5C", "\u0B5D"], ["\u0B5F", "\u0B61"], "\u0B71", "\u0B83", ["\u0B85", "\u0B8A"], ["\u0B8E", "\u0B90"], ["\u0B92", "\u0B95"], ["\u0B99", "\u0B9A"], "\u0B9C", ["\u0B9E", "\u0B9F"], ["\u0BA3", "\u0BA4"], ["\u0BA8", "\u0BAA"], ["\u0BAE", "\u0BB9"], "\u0BD0", ["\u0C05", "\u0C0C"], ["\u0C0E", "\u0C10"], ["\u0C12", "\u0C28"], ["\u0C2A", "\u0C39"], "\u0C3D", ["\u0C58", "\u0C5A"], ["\u0C60", "\u0C61"], ["\u0C85", "\u0C8C"], ["\u0C8E", "\u0C90"], ["\u0C92", "\u0CA8"], ["\u0CAA", "\u0CB3"], ["\u0CB5", "\u0CB9"], "\u0CBD", "\u0CDE", ["\u0CE0", "\u0CE1"], ["\u0CF1", "\u0CF2"], ["\u0D05", "\u0D0C"], ["\u0D0E", "\u0D10"], ["\u0D12", "\u0D3A"], "\u0D3D", "\u0D4E", ["\u0D5F", "\u0D61"], ["\u0D7A", "\u0D7F"], ["\u0D85", "\u0D96"], ["\u0D9A", "\u0DB1"], ["\u0DB3", "\u0DBB"], "\u0DBD", ["\u0DC0", "\u0DC6"], ["\u0E01", "\u0E30"], ["\u0E32", "\u0E33"], ["\u0E40", "\u0E45"], ["\u0E81", "\u0E82"], "\u0E84", ["\u0E87", "\u0E88"], "\u0E8A", "\u0E8D", ["\u0E94", "\u0E97"], ["\u0E99", "\u0E9F"], ["\u0EA1", "\u0EA3"], "\u0EA5", "\u0EA7", ["\u0EAA", "\u0EAB"], ["\u0EAD", "\u0EB0"], ["\u0EB2", "\u0EB3"], "\u0EBD", ["\u0EC0", "\u0EC4"], ["\u0EDC", "\u0EDF"], "\u0F00", ["\u0F40", "\u0F47"], ["\u0F49", "\u0F6C"], ["\u0F88", "\u0F8C"], ["\u1000", "\u102A"], "\u103F", ["\u1050", "\u1055"], ["\u105A", "\u105D"], "\u1061", ["\u1065", "\u1066"], ["\u106E", "\u1070"], ["\u1075", "\u1081"], "\u108E", ["\u10D0", "\u10FA"], ["\u10FD", "\u1248"], ["\u124A", "\u124D"], ["\u1250", "\u1256"], "\u1258", ["\u125A", "\u125D"], ["\u1260", "\u1288"], ["\u128A", "\u128D"], ["\u1290", "\u12B0"], ["\u12B2", "\u12B5"], ["\u12B8", "\u12BE"], "\u12C0", ["\u12C2", "\u12C5"], ["\u12C8", "\u12D6"], ["\u12D8", "\u1310"], ["\u1312", "\u1315"], ["\u1318", "\u135A"], ["\u1380", "\u138F"], ["\u1401", "\u166C"], ["\u166F", "\u167F"], ["\u1681", "\u169A"], ["\u16A0", "\u16EA"], ["\u16F1", "\u16F8"], ["\u1700", "\u170C"], ["\u170E", "\u1711"], ["\u1720", "\u1731"], ["\u1740", "\u1751"], ["\u1760", "\u176C"], ["\u176E", "\u1770"], ["\u1780", "\u17B3"], "\u17DC", ["\u1820", "\u1842"], ["\u1844", "\u1877"], ["\u1880", "\u18A8"], "\u18AA", ["\u18B0", "\u18F5"], ["\u1900", "\u191E"], ["\u1950", "\u196D"], ["\u1970", "\u1974"], ["\u1980", "\u19AB"], ["\u19B0", "\u19C9"], ["\u1A00", "\u1A16"], ["\u1A20", "\u1A54"], ["\u1B05", "\u1B33"], ["\u1B45", "\u1B4B"], ["\u1B83", "\u1BA0"], ["\u1BAE", "\u1BAF"], ["\u1BBA", "\u1BE5"], ["\u1C00", "\u1C23"], ["\u1C4D", "\u1C4F"], ["\u1C5A", "\u1C77"], ["\u1CE9", "\u1CEC"], ["\u1CEE", "\u1CF1"], ["\u1CF5", "\u1CF6"], ["\u2135", "\u2138"], ["\u2D30", "\u2D67"], ["\u2D80", "\u2D96"], ["\u2DA0", "\u2DA6"], ["\u2DA8", "\u2DAE"], ["\u2DB0", "\u2DB6"], ["\u2DB8", "\u2DBE"], ["\u2DC0", "\u2DC6"], ["\u2DC8", "\u2DCE"], ["\u2DD0", "\u2DD6"], ["\u2DD8", "\u2DDE"], "\u3006", "\u303C", ["\u3041", "\u3096"], "\u309F", ["\u30A1", "\u30FA"], "\u30FF", ["\u3105", "\u312D"], ["\u3131", "\u318E"], ["\u31A0", "\u31BA"], ["\u31F0", "\u31FF"], ["\u3400", "\u4DB5"], ["\u4E00", "\u9FD5"], ["\uA000", "\uA014"], ["\uA016", "\uA48C"], ["\uA4D0", "\uA4F7"], ["\uA500", "\uA60B"], ["\uA610", "\uA61F"], ["\uA62A", "\uA62B"], "\uA66E", ["\uA6A0", "\uA6E5"], "\uA78F", "\uA7F7", ["\uA7FB", "\uA801"], ["\uA803", "\uA805"], ["\uA807", "\uA80A"], ["\uA80C", "\uA822"], ["\uA840", "\uA873"], ["\uA882", "\uA8B3"], ["\uA8F2", "\uA8F7"], "\uA8FB", "\uA8FD", ["\uA90A", "\uA925"], ["\uA930", "\uA946"], ["\uA960", "\uA97C"], ["\uA984", "\uA9B2"], ["\uA9E0", "\uA9E4"], ["\uA9E7", "\uA9EF"], ["\uA9FA", "\uA9FE"], ["\uAA00", "\uAA28"], ["\uAA40", "\uAA42"], ["\uAA44", "\uAA4B"], ["\uAA60", "\uAA6F"], ["\uAA71", "\uAA76"], "\uAA7A", ["\uAA7E", "\uAAAF"], "\uAAB1", ["\uAAB5", "\uAAB6"], ["\uAAB9", "\uAABD"], "\uAAC0", "\uAAC2", ["\uAADB", "\uAADC"], ["\uAAE0", "\uAAEA"], "\uAAF2", ["\uAB01", "\uAB06"], ["\uAB09", "\uAB0E"], ["\uAB11", "\uAB16"], ["\uAB20", "\uAB26"], ["\uAB28", "\uAB2E"], ["\uABC0", "\uABE2"], ["\uAC00", "\uD7A3"], ["\uD7B0", "\uD7C6"], ["\uD7CB", "\uD7FB"], ["\uF900", "\uFA6D"], ["\uFA70", "\uFAD9"], "\uFB1D", ["\uFB1F", "\uFB28"], ["\uFB2A", "\uFB36"], ["\uFB38", "\uFB3C"], "\uFB3E", ["\uFB40", "\uFB41"], ["\uFB43", "\uFB44"], ["\uFB46", "\uFBB1"], ["\uFBD3", "\uFD3D"], ["\uFD50", "\uFD8F"], ["\uFD92", "\uFDC7"], ["\uFDF0", "\uFDFB"], ["\uFE70", "\uFE74"], ["\uFE76", "\uFEFC"], ["\uFF66", "\uFF6F"], ["\uFF71", "\uFF9D"], ["\uFFA0", "\uFFBE"], ["\uFFC2", "\uFFC7"], ["\uFFCA", "\uFFCF"], ["\uFFD2", "\uFFD7"], ["\uFFDA", "\uFFDC"]], false, false);
-  var peg$e67 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", ["\u1F88", "\u1F8F"], ["\u1F98", "\u1F9F"], ["\u1FA8", "\u1FAF"], "\u1FBC", "\u1FCC", "\u1FFC"], false, false);
-  var peg$e68 = peg$classExpectation([["A", "Z"], ["\xC0", "\xD6"], ["\xD8", "\xDE"], "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", ["\u0178", "\u0179"], "\u017B", "\u017D", ["\u0181", "\u0182"], "\u0184", ["\u0186", "\u0187"], ["\u0189", "\u018B"], ["\u018E", "\u0191"], ["\u0193", "\u0194"], ["\u0196", "\u0198"], ["\u019C", "\u019D"], ["\u019F", "\u01A0"], "\u01A2", "\u01A4", ["\u01A6", "\u01A7"], "\u01A9", "\u01AC", ["\u01AE", "\u01AF"], ["\u01B1", "\u01B3"], "\u01B5", ["\u01B7", "\u01B8"], "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", ["\u01F6", "\u01F8"], "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", ["\u023A", "\u023B"], ["\u023D", "\u023E"], "\u0241", ["\u0243", "\u0246"], "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u037F", "\u0386", ["\u0388", "\u038A"], "\u038C", ["\u038E", "\u038F"], ["\u0391", "\u03A1"], ["\u03A3", "\u03AB"], "\u03CF", ["\u03D2", "\u03D4"], "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", ["\u03F9", "\u03FA"], ["\u03FD", "\u042F"], "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", ["\u04C0", "\u04C1"], "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0524", "\u0526", "\u0528", "\u052A", "\u052C", "\u052E", ["\u0531", "\u0556"], ["\u10A0", "\u10C5"], "\u10C7", "\u10CD", ["\u13A0", "\u13F5"], "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", ["\u1F08", "\u1F0F"], ["\u1F18", "\u1F1D"], ["\u1F28", "\u1F2F"], ["\u1F38", "\u1F3F"], ["\u1F48", "\u1F4D"], "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", ["\u1F68", "\u1F6F"], ["\u1FB8", "\u1FBB"], ["\u1FC8", "\u1FCB"], ["\u1FD8", "\u1FDB"], ["\u1FE8", "\u1FEC"], ["\u1FF8", "\u1FFB"], "\u2102", "\u2107", ["\u210B", "\u210D"], ["\u2110", "\u2112"], "\u2115", ["\u2119", "\u211D"], "\u2124", "\u2126", "\u2128", ["\u212A", "\u212D"], ["\u2130", "\u2133"], ["\u213E", "\u213F"], "\u2145", "\u2183", ["\u2C00", "\u2C2E"], "\u2C60", ["\u2C62", "\u2C64"], "\u2C67", "\u2C69", "\u2C6B", ["\u2C6D", "\u2C70"], "\u2C72", "\u2C75", ["\u2C7E", "\u2C80"], "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\u2CEB", "\u2CED", "\u2CF2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA660", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA698", "\uA69A", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", ["\uA77D", "\uA77E"], "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uA78D", "\uA790", "\uA792", "\uA796", "\uA798", "\uA79A", "\uA79C", "\uA79E", "\uA7A0", "\uA7A2", "\uA7A4", "\uA7A6", "\uA7A8", ["\uA7AA", "\uA7AD"], ["\uA7B0", "\uA7B4"], "\uA7B6", ["\uFF21", "\uFF3A"]], false, false);
-  var peg$e69 = peg$classExpectation(["\u0903", "\u093B", ["\u093E", "\u0940"], ["\u0949", "\u094C"], ["\u094E", "\u094F"], ["\u0982", "\u0983"], ["\u09BE", "\u09C0"], ["\u09C7", "\u09C8"], ["\u09CB", "\u09CC"], "\u09D7", "\u0A03", ["\u0A3E", "\u0A40"], "\u0A83", ["\u0ABE", "\u0AC0"], "\u0AC9", ["\u0ACB", "\u0ACC"], ["\u0B02", "\u0B03"], "\u0B3E", "\u0B40", ["\u0B47", "\u0B48"], ["\u0B4B", "\u0B4C"], "\u0B57", ["\u0BBE", "\u0BBF"], ["\u0BC1", "\u0BC2"], ["\u0BC6", "\u0BC8"], ["\u0BCA", "\u0BCC"], "\u0BD7", ["\u0C01", "\u0C03"], ["\u0C41", "\u0C44"], ["\u0C82", "\u0C83"], "\u0CBE", ["\u0CC0", "\u0CC4"], ["\u0CC7", "\u0CC8"], ["\u0CCA", "\u0CCB"], ["\u0CD5", "\u0CD6"], ["\u0D02", "\u0D03"], ["\u0D3E", "\u0D40"], ["\u0D46", "\u0D48"], ["\u0D4A", "\u0D4C"], "\u0D57", ["\u0D82", "\u0D83"], ["\u0DCF", "\u0DD1"], ["\u0DD8", "\u0DDF"], ["\u0DF2", "\u0DF3"], ["\u0F3E", "\u0F3F"], "\u0F7F", ["\u102B", "\u102C"], "\u1031", "\u1038", ["\u103B", "\u103C"], ["\u1056", "\u1057"], ["\u1062", "\u1064"], ["\u1067", "\u106D"], ["\u1083", "\u1084"], ["\u1087", "\u108C"], "\u108F", ["\u109A", "\u109C"], "\u17B6", ["\u17BE", "\u17C5"], ["\u17C7", "\u17C8"], ["\u1923", "\u1926"], ["\u1929", "\u192B"], ["\u1930", "\u1931"], ["\u1933", "\u1938"], ["\u1A19", "\u1A1A"], "\u1A55", "\u1A57", "\u1A61", ["\u1A63", "\u1A64"], ["\u1A6D", "\u1A72"], "\u1B04", "\u1B35", "\u1B3B", ["\u1B3D", "\u1B41"], ["\u1B43", "\u1B44"], "\u1B82", "\u1BA1", ["\u1BA6", "\u1BA7"], "\u1BAA", "\u1BE7", ["\u1BEA", "\u1BEC"], "\u1BEE", ["\u1BF2", "\u1BF3"], ["\u1C24", "\u1C2B"], ["\u1C34", "\u1C35"], "\u1CE1", ["\u1CF2", "\u1CF3"], ["\u302E", "\u302F"], ["\uA823", "\uA824"], "\uA827", ["\uA880", "\uA881"], ["\uA8B4", "\uA8C3"], ["\uA952", "\uA953"], "\uA983", ["\uA9B4", "\uA9B5"], ["\uA9BA", "\uA9BB"], ["\uA9BD", "\uA9C0"], ["\uAA2F", "\uAA30"], ["\uAA33", "\uAA34"], "\uAA4D", "\uAA7B", "\uAA7D", "\uAAEB", ["\uAAEE", "\uAAEF"], "\uAAF5", ["\uABE3", "\uABE4"], ["\uABE6", "\uABE7"], ["\uABE9", "\uABEA"], "\uABEC"], false, false);
-  var peg$e70 = peg$classExpectation([["\u0300", "\u036F"], ["\u0483", "\u0487"], ["\u0591", "\u05BD"], "\u05BF", ["\u05C1", "\u05C2"], ["\u05C4", "\u05C5"], "\u05C7", ["\u0610", "\u061A"], ["\u064B", "\u065F"], "\u0670", ["\u06D6", "\u06DC"], ["\u06DF", "\u06E4"], ["\u06E7", "\u06E8"], ["\u06EA", "\u06ED"], "\u0711", ["\u0730", "\u074A"], ["\u07A6", "\u07B0"], ["\u07EB", "\u07F3"], ["\u0816", "\u0819"], ["\u081B", "\u0823"], ["\u0825", "\u0827"], ["\u0829", "\u082D"], ["\u0859", "\u085B"], ["\u08E3", "\u0902"], "\u093A", "\u093C", ["\u0941", "\u0948"], "\u094D", ["\u0951", "\u0957"], ["\u0962", "\u0963"], "\u0981", "\u09BC", ["\u09C1", "\u09C4"], "\u09CD", ["\u09E2", "\u09E3"], ["\u0A01", "\u0A02"], "\u0A3C", ["\u0A41", "\u0A42"], ["\u0A47", "\u0A48"], ["\u0A4B", "\u0A4D"], "\u0A51", ["\u0A70", "\u0A71"], "\u0A75", ["\u0A81", "\u0A82"], "\u0ABC", ["\u0AC1", "\u0AC5"], ["\u0AC7", "\u0AC8"], "\u0ACD", ["\u0AE2", "\u0AE3"], "\u0B01", "\u0B3C", "\u0B3F", ["\u0B41", "\u0B44"], "\u0B4D", "\u0B56", ["\u0B62", "\u0B63"], "\u0B82", "\u0BC0", "\u0BCD", "\u0C00", ["\u0C3E", "\u0C40"], ["\u0C46", "\u0C48"], ["\u0C4A", "\u0C4D"], ["\u0C55", "\u0C56"], ["\u0C62", "\u0C63"], "\u0C81", "\u0CBC", "\u0CBF", "\u0CC6", ["\u0CCC", "\u0CCD"], ["\u0CE2", "\u0CE3"], "\u0D01", ["\u0D41", "\u0D44"], "\u0D4D", ["\u0D62", "\u0D63"], "\u0DCA", ["\u0DD2", "\u0DD4"], "\u0DD6", "\u0E31", ["\u0E34", "\u0E3A"], ["\u0E47", "\u0E4E"], "\u0EB1", ["\u0EB4", "\u0EB9"], ["\u0EBB", "\u0EBC"], ["\u0EC8", "\u0ECD"], ["\u0F18", "\u0F19"], "\u0F35", "\u0F37", "\u0F39", ["\u0F71", "\u0F7E"], ["\u0F80", "\u0F84"], ["\u0F86", "\u0F87"], ["\u0F8D", "\u0F97"], ["\u0F99", "\u0FBC"], "\u0FC6", ["\u102D", "\u1030"], ["\u1032", "\u1037"], ["\u1039", "\u103A"], ["\u103D", "\u103E"], ["\u1058", "\u1059"], ["\u105E", "\u1060"], ["\u1071", "\u1074"], "\u1082", ["\u1085", "\u1086"], "\u108D", "\u109D", ["\u135D", "\u135F"], ["\u1712", "\u1714"], ["\u1732", "\u1734"], ["\u1752", "\u1753"], ["\u1772", "\u1773"], ["\u17B4", "\u17B5"], ["\u17B7", "\u17BD"], "\u17C6", ["\u17C9", "\u17D3"], "\u17DD", ["\u180B", "\u180D"], "\u18A9", ["\u1920", "\u1922"], ["\u1927", "\u1928"], "\u1932", ["\u1939", "\u193B"], ["\u1A17", "\u1A18"], "\u1A1B", "\u1A56", ["\u1A58", "\u1A5E"], "\u1A60", "\u1A62", ["\u1A65", "\u1A6C"], ["\u1A73", "\u1A7C"], "\u1A7F", ["\u1AB0", "\u1ABD"], ["\u1B00", "\u1B03"], "\u1B34", ["\u1B36", "\u1B3A"], "\u1B3C", "\u1B42", ["\u1B6B", "\u1B73"], ["\u1B80", "\u1B81"], ["\u1BA2", "\u1BA5"], ["\u1BA8", "\u1BA9"], ["\u1BAB", "\u1BAD"], "\u1BE6", ["\u1BE8", "\u1BE9"], "\u1BED", ["\u1BEF", "\u1BF1"], ["\u1C2C", "\u1C33"], ["\u1C36", "\u1C37"], ["\u1CD0", "\u1CD2"], ["\u1CD4", "\u1CE0"], ["\u1CE2", "\u1CE8"], "\u1CED", "\u1CF4", ["\u1CF8", "\u1CF9"], ["\u1DC0", "\u1DF5"], ["\u1DFC", "\u1DFF"], ["\u20D0", "\u20DC"], "\u20E1", ["\u20E5", "\u20F0"], ["\u2CEF", "\u2CF1"], "\u2D7F", ["\u2DE0", "\u2DFF"], ["\u302A", "\u302D"], ["\u3099", "\u309A"], "\uA66F", ["\uA674", "\uA67D"], ["\uA69E", "\uA69F"], ["\uA6F0", "\uA6F1"], "\uA802", "\uA806", "\uA80B", ["\uA825", "\uA826"], "\uA8C4", ["\uA8E0", "\uA8F1"], ["\uA926", "\uA92D"], ["\uA947", "\uA951"], ["\uA980", "\uA982"], "\uA9B3", ["\uA9B6", "\uA9B9"], "\uA9BC", "\uA9E5", ["\uAA29", "\uAA2E"], ["\uAA31", "\uAA32"], ["\uAA35", "\uAA36"], "\uAA43", "\uAA4C", "\uAA7C", "\uAAB0", ["\uAAB2", "\uAAB4"], ["\uAAB7", "\uAAB8"], ["\uAABE", "\uAABF"], "\uAAC1", ["\uAAEC", "\uAAED"], "\uAAF6", "\uABE5", "\uABE8", "\uABED", "\uFB1E", ["\uFE00", "\uFE0F"], ["\uFE20", "\uFE2F"]], false, false);
-  var peg$e71 = peg$classExpectation([["0", "9"], ["\u0660", "\u0669"], ["\u06F0", "\u06F9"], ["\u07C0", "\u07C9"], ["\u0966", "\u096F"], ["\u09E6", "\u09EF"], ["\u0A66", "\u0A6F"], ["\u0AE6", "\u0AEF"], ["\u0B66", "\u0B6F"], ["\u0BE6", "\u0BEF"], ["\u0C66", "\u0C6F"], ["\u0CE6", "\u0CEF"], ["\u0D66", "\u0D6F"], ["\u0DE6", "\u0DEF"], ["\u0E50", "\u0E59"], ["\u0ED0", "\u0ED9"], ["\u0F20", "\u0F29"], ["\u1040", "\u1049"], ["\u1090", "\u1099"], ["\u17E0", "\u17E9"], ["\u1810", "\u1819"], ["\u1946", "\u194F"], ["\u19D0", "\u19D9"], ["\u1A80", "\u1A89"], ["\u1A90", "\u1A99"], ["\u1B50", "\u1B59"], ["\u1BB0", "\u1BB9"], ["\u1C40", "\u1C49"], ["\u1C50", "\u1C59"], ["\uA620", "\uA629"], ["\uA8D0", "\uA8D9"], ["\uA900", "\uA909"], ["\uA9D0", "\uA9D9"], ["\uA9F0", "\uA9F9"], ["\uAA50", "\uAA59"], ["\uABF0", "\uABF9"], ["\uFF10", "\uFF19"]], false, false);
-  var peg$e72 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false);
-  var peg$e73 = peg$classExpectation(["_", ["\u203F", "\u2040"], "\u2054", ["\uFE33", "\uFE34"], ["\uFE4D", "\uFE4F"], "\uFF3F"], false, false);
-  var peg$e74 = peg$classExpectation([" ", "\xA0", "\u1680", ["\u2000", "\u200A"], "\u202F", "\u205F", "\u3000"], false, false);
-  var peg$e75 = peg$literalExpectation(";", false);
+  var peg$e13 = peg$literalExpectation(",", false);
+  var peg$e14 = peg$literalExpectation("..", false);
+  var peg$e15 = peg$literalExpectation("(", false);
+  var peg$e16 = peg$literalExpectation(")", false);
+  var peg$e17 = peg$anyExpectation();
+  var peg$e18 = peg$otherExpectation("whitespace");
+  var peg$e19 = peg$literalExpectation("\t", false);
+  var peg$e20 = peg$literalExpectation("\v", false);
+  var peg$e21 = peg$literalExpectation("\f", false);
+  var peg$e22 = peg$literalExpectation(" ", false);
+  var peg$e23 = peg$literalExpectation("\xA0", false);
+  var peg$e24 = peg$literalExpectation("\uFEFF", false);
+  var peg$e25 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false);
+  var peg$e26 = peg$otherExpectation("end of line");
+  var peg$e27 = peg$literalExpectation("\n", false);
+  var peg$e28 = peg$literalExpectation("\r\n", false);
+  var peg$e29 = peg$literalExpectation("\r", false);
+  var peg$e30 = peg$literalExpectation("\u2028", false);
+  var peg$e31 = peg$literalExpectation("\u2029", false);
+  var peg$e32 = peg$otherExpectation("comment");
+  var peg$e33 = peg$literalExpectation("/*", false);
+  var peg$e34 = peg$literalExpectation("*/", false);
+  var peg$e35 = peg$literalExpectation("//", false);
+  var peg$e36 = peg$otherExpectation("identifier");
+  var peg$e37 = peg$literalExpectation("_", false);
+  var peg$e38 = peg$literalExpectation("\\", false);
+  var peg$e39 = peg$literalExpectation("\u200C", false);
+  var peg$e40 = peg$literalExpectation("\u200D", false);
+  var peg$e41 = peg$otherExpectation("literal");
+  var peg$e42 = peg$literalExpectation("i", false);
+  var peg$e43 = peg$otherExpectation("string");
+  var peg$e44 = peg$literalExpectation("\"", false);
+  var peg$e45 = peg$literalExpectation("'", false);
+  var peg$e46 = peg$otherExpectation("character class");
+  var peg$e47 = peg$literalExpectation("[", false);
+  var peg$e48 = peg$literalExpectation("^", false);
+  var peg$e49 = peg$literalExpectation("]", false);
+  var peg$e50 = peg$literalExpectation("-", false);
+  var peg$e51 = peg$literalExpectation("0", false);
+  var peg$e52 = peg$literalExpectation("b", false);
+  var peg$e53 = peg$literalExpectation("f", false);
+  var peg$e54 = peg$literalExpectation("n", false);
+  var peg$e55 = peg$literalExpectation("r", false);
+  var peg$e56 = peg$literalExpectation("t", false);
+  var peg$e57 = peg$literalExpectation("v", false);
+  var peg$e58 = peg$literalExpectation("x", false);
+  var peg$e59 = peg$literalExpectation("u", false);
+  var peg$e60 = peg$classExpectation([["0", "9"]], false, false);
+  var peg$e61 = peg$classExpectation([["0", "9"], ["a", "f"]], false, true);
+  var peg$e62 = peg$literalExpectation(".", false);
+  var peg$e63 = peg$otherExpectation("code block");
+  var peg$e64 = peg$classExpectation(["{", "}"], false, false);
+  var peg$e65 = peg$classExpectation([["a", "z"], "\xB5", ["\xDF", "\xF6"], ["\xF8", "\xFF"], "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", ["\u0137", "\u0138"], "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", ["\u0148", "\u0149"], "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", ["\u017E", "\u0180"], "\u0183", "\u0185", "\u0188", ["\u018C", "\u018D"], "\u0192", "\u0195", ["\u0199", "\u019B"], "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", ["\u01AA", "\u01AB"], "\u01AD", "\u01B0", "\u01B4", "\u01B6", ["\u01B9", "\u01BA"], ["\u01BD", "\u01BF"], "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", ["\u01DC", "\u01DD"], "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", ["\u01EF", "\u01F0"], "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", ["\u0233", "\u0239"], "\u023C", ["\u023F", "\u0240"], "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", ["\u024F", "\u0293"], ["\u0295", "\u02AF"], "\u0371", "\u0373", "\u0377", ["\u037B", "\u037D"], "\u0390", ["\u03AC", "\u03CE"], ["\u03D0", "\u03D1"], ["\u03D5", "\u03D7"], "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", ["\u03EF", "\u03F3"], "\u03F5", "\u03F8", ["\u03FB", "\u03FC"], ["\u0430", "\u045F"], "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", ["\u04CE", "\u04CF"], "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0525", "\u0527", "\u0529", "\u052B", "\u052D", "\u052F", ["\u0561", "\u0587"], ["\u13F8", "\u13FD"], ["\u1D00", "\u1D2B"], ["\u1D6B", "\u1D77"], ["\u1D79", "\u1D9A"], "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", ["\u1E95", "\u1E9D"], "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", ["\u1EFF", "\u1F07"], ["\u1F10", "\u1F15"], ["\u1F20", "\u1F27"], ["\u1F30", "\u1F37"], ["\u1F40", "\u1F45"], ["\u1F50", "\u1F57"], ["\u1F60", "\u1F67"], ["\u1F70", "\u1F7D"], ["\u1F80", "\u1F87"], ["\u1F90", "\u1F97"], ["\u1FA0", "\u1FA7"], ["\u1FB0", "\u1FB4"], ["\u1FB6", "\u1FB7"], "\u1FBE", ["\u1FC2", "\u1FC4"], ["\u1FC6", "\u1FC7"], ["\u1FD0", "\u1FD3"], ["\u1FD6", "\u1FD7"], ["\u1FE0", "\u1FE7"], ["\u1FF2", "\u1FF4"], ["\u1FF6", "\u1FF7"], "\u210A", ["\u210E", "\u210F"], "\u2113", "\u212F", "\u2134", "\u2139", ["\u213C", "\u213D"], ["\u2146", "\u2149"], "\u214E", "\u2184", ["\u2C30", "\u2C5E"], "\u2C61", ["\u2C65", "\u2C66"], "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", ["\u2C73", "\u2C74"], ["\u2C76", "\u2C7B"], "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", ["\u2CE3", "\u2CE4"], "\u2CEC", "\u2CEE", "\u2CF3", ["\u2D00", "\u2D25"], "\u2D27", "\u2D2D", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA661", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA699", "\uA69B", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", ["\uA72F", "\uA731"], "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", ["\uA771", "\uA778"], "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uA78E", "\uA791", ["\uA793", "\uA795"], "\uA797", "\uA799", "\uA79B", "\uA79D", "\uA79F", "\uA7A1", "\uA7A3", "\uA7A5", "\uA7A7", "\uA7A9", "\uA7B5", "\uA7B7", "\uA7FA", ["\uAB30", "\uAB5A"], ["\uAB60", "\uAB65"], ["\uAB70", "\uABBF"], ["\uFB00", "\uFB06"], ["\uFB13", "\uFB17"], ["\uFF41", "\uFF5A"]], false, false);
+  var peg$e66 = peg$classExpectation([["\u02B0", "\u02C1"], ["\u02C6", "\u02D1"], ["\u02E0", "\u02E4"], "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", ["\u06E5", "\u06E6"], ["\u07F4", "\u07F5"], "\u07FA", "\u081A", "\u0824", "\u0828", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1AA7", ["\u1C78", "\u1C7D"], ["\u1D2C", "\u1D6A"], "\u1D78", ["\u1D9B", "\u1DBF"], "\u2071", "\u207F", ["\u2090", "\u209C"], ["\u2C7C", "\u2C7D"], "\u2D6F", "\u2E2F", "\u3005", ["\u3031", "\u3035"], "\u303B", ["\u309D", "\u309E"], ["\u30FC", "\u30FE"], "\uA015", ["\uA4F8", "\uA4FD"], "\uA60C", "\uA67F", ["\uA69C", "\uA69D"], ["\uA717", "\uA71F"], "\uA770", "\uA788", ["\uA7F8", "\uA7F9"], "\uA9CF", "\uA9E6", "\uAA70", "\uAADD", ["\uAAF3", "\uAAF4"], ["\uAB5C", "\uAB5F"], "\uFF70", ["\uFF9E", "\uFF9F"]], false, false);
+  var peg$e67 = peg$classExpectation(["\xAA", "\xBA", "\u01BB", ["\u01C0", "\u01C3"], "\u0294", ["\u05D0", "\u05EA"], ["\u05F0", "\u05F2"], ["\u0620", "\u063F"], ["\u0641", "\u064A"], ["\u066E", "\u066F"], ["\u0671", "\u06D3"], "\u06D5", ["\u06EE", "\u06EF"], ["\u06FA", "\u06FC"], "\u06FF", "\u0710", ["\u0712", "\u072F"], ["\u074D", "\u07A5"], "\u07B1", ["\u07CA", "\u07EA"], ["\u0800", "\u0815"], ["\u0840", "\u0858"], ["\u08A0", "\u08B4"], ["\u0904", "\u0939"], "\u093D", "\u0950", ["\u0958", "\u0961"], ["\u0972", "\u0980"], ["\u0985", "\u098C"], ["\u098F", "\u0990"], ["\u0993", "\u09A8"], ["\u09AA", "\u09B0"], "\u09B2", ["\u09B6", "\u09B9"], "\u09BD", "\u09CE", ["\u09DC", "\u09DD"], ["\u09DF", "\u09E1"], ["\u09F0", "\u09F1"], ["\u0A05", "\u0A0A"], ["\u0A0F", "\u0A10"], ["\u0A13", "\u0A28"], ["\u0A2A", "\u0A30"], ["\u0A32", "\u0A33"], ["\u0A35", "\u0A36"], ["\u0A38", "\u0A39"], ["\u0A59", "\u0A5C"], "\u0A5E", ["\u0A72", "\u0A74"], ["\u0A85", "\u0A8D"], ["\u0A8F", "\u0A91"], ["\u0A93", "\u0AA8"], ["\u0AAA", "\u0AB0"], ["\u0AB2", "\u0AB3"], ["\u0AB5", "\u0AB9"], "\u0ABD", "\u0AD0", ["\u0AE0", "\u0AE1"], "\u0AF9", ["\u0B05", "\u0B0C"], ["\u0B0F", "\u0B10"], ["\u0B13", "\u0B28"], ["\u0B2A", "\u0B30"], ["\u0B32", "\u0B33"], ["\u0B35", "\u0B39"], "\u0B3D", ["\u0B5C", "\u0B5D"], ["\u0B5F", "\u0B61"], "\u0B71", "\u0B83", ["\u0B85", "\u0B8A"], ["\u0B8E", "\u0B90"], ["\u0B92", "\u0B95"], ["\u0B99", "\u0B9A"], "\u0B9C", ["\u0B9E", "\u0B9F"], ["\u0BA3", "\u0BA4"], ["\u0BA8", "\u0BAA"], ["\u0BAE", "\u0BB9"], "\u0BD0", ["\u0C05", "\u0C0C"], ["\u0C0E", "\u0C10"], ["\u0C12", "\u0C28"], ["\u0C2A", "\u0C39"], "\u0C3D", ["\u0C58", "\u0C5A"], ["\u0C60", "\u0C61"], ["\u0C85", "\u0C8C"], ["\u0C8E", "\u0C90"], ["\u0C92", "\u0CA8"], ["\u0CAA", "\u0CB3"], ["\u0CB5", "\u0CB9"], "\u0CBD", "\u0CDE", ["\u0CE0", "\u0CE1"], ["\u0CF1", "\u0CF2"], ["\u0D05", "\u0D0C"], ["\u0D0E", "\u0D10"], ["\u0D12", "\u0D3A"], "\u0D3D", "\u0D4E", ["\u0D5F", "\u0D61"], ["\u0D7A", "\u0D7F"], ["\u0D85", "\u0D96"], ["\u0D9A", "\u0DB1"], ["\u0DB3", "\u0DBB"], "\u0DBD", ["\u0DC0", "\u0DC6"], ["\u0E01", "\u0E30"], ["\u0E32", "\u0E33"], ["\u0E40", "\u0E45"], ["\u0E81", "\u0E82"], "\u0E84", ["\u0E87", "\u0E88"], "\u0E8A", "\u0E8D", ["\u0E94", "\u0E97"], ["\u0E99", "\u0E9F"], ["\u0EA1", "\u0EA3"], "\u0EA5", "\u0EA7", ["\u0EAA", "\u0EAB"], ["\u0EAD", "\u0EB0"], ["\u0EB2", "\u0EB3"], "\u0EBD", ["\u0EC0", "\u0EC4"], ["\u0EDC", "\u0EDF"], "\u0F00", ["\u0F40", "\u0F47"], ["\u0F49", "\u0F6C"], ["\u0F88", "\u0F8C"], ["\u1000", "\u102A"], "\u103F", ["\u1050", "\u1055"], ["\u105A", "\u105D"], "\u1061", ["\u1065", "\u1066"], ["\u106E", "\u1070"], ["\u1075", "\u1081"], "\u108E", ["\u10D0", "\u10FA"], ["\u10FD", "\u1248"], ["\u124A", "\u124D"], ["\u1250", "\u1256"], "\u1258", ["\u125A", "\u125D"], ["\u1260", "\u1288"], ["\u128A", "\u128D"], ["\u1290", "\u12B0"], ["\u12B2", "\u12B5"], ["\u12B8", "\u12BE"], "\u12C0", ["\u12C2", "\u12C5"], ["\u12C8", "\u12D6"], ["\u12D8", "\u1310"], ["\u1312", "\u1315"], ["\u1318", "\u135A"], ["\u1380", "\u138F"], ["\u1401", "\u166C"], ["\u166F", "\u167F"], ["\u1681", "\u169A"], ["\u16A0", "\u16EA"], ["\u16F1", "\u16F8"], ["\u1700", "\u170C"], ["\u170E", "\u1711"], ["\u1720", "\u1731"], ["\u1740", "\u1751"], ["\u1760", "\u176C"], ["\u176E", "\u1770"], ["\u1780", "\u17B3"], "\u17DC", ["\u1820", "\u1842"], ["\u1844", "\u1877"], ["\u1880", "\u18A8"], "\u18AA", ["\u18B0", "\u18F5"], ["\u1900", "\u191E"], ["\u1950", "\u196D"], ["\u1970", "\u1974"], ["\u1980", "\u19AB"], ["\u19B0", "\u19C9"], ["\u1A00", "\u1A16"], ["\u1A20", "\u1A54"], ["\u1B05", "\u1B33"], ["\u1B45", "\u1B4B"], ["\u1B83", "\u1BA0"], ["\u1BAE", "\u1BAF"], ["\u1BBA", "\u1BE5"], ["\u1C00", "\u1C23"], ["\u1C4D", "\u1C4F"], ["\u1C5A", "\u1C77"], ["\u1CE9", "\u1CEC"], ["\u1CEE", "\u1CF1"], ["\u1CF5", "\u1CF6"], ["\u2135", "\u2138"], ["\u2D30", "\u2D67"], ["\u2D80", "\u2D96"], ["\u2DA0", "\u2DA6"], ["\u2DA8", "\u2DAE"], ["\u2DB0", "\u2DB6"], ["\u2DB8", "\u2DBE"], ["\u2DC0", "\u2DC6"], ["\u2DC8", "\u2DCE"], ["\u2DD0", "\u2DD6"], ["\u2DD8", "\u2DDE"], "\u3006", "\u303C", ["\u3041", "\u3096"], "\u309F", ["\u30A1", "\u30FA"], "\u30FF", ["\u3105", "\u312D"], ["\u3131", "\u318E"], ["\u31A0", "\u31BA"], ["\u31F0", "\u31FF"], ["\u3400", "\u4DB5"], ["\u4E00", "\u9FD5"], ["\uA000", "\uA014"], ["\uA016", "\uA48C"], ["\uA4D0", "\uA4F7"], ["\uA500", "\uA60B"], ["\uA610", "\uA61F"], ["\uA62A", "\uA62B"], "\uA66E", ["\uA6A0", "\uA6E5"], "\uA78F", "\uA7F7", ["\uA7FB", "\uA801"], ["\uA803", "\uA805"], ["\uA807", "\uA80A"], ["\uA80C", "\uA822"], ["\uA840", "\uA873"], ["\uA882", "\uA8B3"], ["\uA8F2", "\uA8F7"], "\uA8FB", "\uA8FD", ["\uA90A", "\uA925"], ["\uA930", "\uA946"], ["\uA960", "\uA97C"], ["\uA984", "\uA9B2"], ["\uA9E0", "\uA9E4"], ["\uA9E7", "\uA9EF"], ["\uA9FA", "\uA9FE"], ["\uAA00", "\uAA28"], ["\uAA40", "\uAA42"], ["\uAA44", "\uAA4B"], ["\uAA60", "\uAA6F"], ["\uAA71", "\uAA76"], "\uAA7A", ["\uAA7E", "\uAAAF"], "\uAAB1", ["\uAAB5", "\uAAB6"], ["\uAAB9", "\uAABD"], "\uAAC0", "\uAAC2", ["\uAADB", "\uAADC"], ["\uAAE0", "\uAAEA"], "\uAAF2", ["\uAB01", "\uAB06"], ["\uAB09", "\uAB0E"], ["\uAB11", "\uAB16"], ["\uAB20", "\uAB26"], ["\uAB28", "\uAB2E"], ["\uABC0", "\uABE2"], ["\uAC00", "\uD7A3"], ["\uD7B0", "\uD7C6"], ["\uD7CB", "\uD7FB"], ["\uF900", "\uFA6D"], ["\uFA70", "\uFAD9"], "\uFB1D", ["\uFB1F", "\uFB28"], ["\uFB2A", "\uFB36"], ["\uFB38", "\uFB3C"], "\uFB3E", ["\uFB40", "\uFB41"], ["\uFB43", "\uFB44"], ["\uFB46", "\uFBB1"], ["\uFBD3", "\uFD3D"], ["\uFD50", "\uFD8F"], ["\uFD92", "\uFDC7"], ["\uFDF0", "\uFDFB"], ["\uFE70", "\uFE74"], ["\uFE76", "\uFEFC"], ["\uFF66", "\uFF6F"], ["\uFF71", "\uFF9D"], ["\uFFA0", "\uFFBE"], ["\uFFC2", "\uFFC7"], ["\uFFCA", "\uFFCF"], ["\uFFD2", "\uFFD7"], ["\uFFDA", "\uFFDC"]], false, false);
+  var peg$e68 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", ["\u1F88", "\u1F8F"], ["\u1F98", "\u1F9F"], ["\u1FA8", "\u1FAF"], "\u1FBC", "\u1FCC", "\u1FFC"], false, false);
+  var peg$e69 = peg$classExpectation([["A", "Z"], ["\xC0", "\xD6"], ["\xD8", "\xDE"], "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", ["\u0178", "\u0179"], "\u017B", "\u017D", ["\u0181", "\u0182"], "\u0184", ["\u0186", "\u0187"], ["\u0189", "\u018B"], ["\u018E", "\u0191"], ["\u0193", "\u0194"], ["\u0196", "\u0198"], ["\u019C", "\u019D"], ["\u019F", "\u01A0"], "\u01A2", "\u01A4", ["\u01A6", "\u01A7"], "\u01A9", "\u01AC", ["\u01AE", "\u01AF"], ["\u01B1", "\u01B3"], "\u01B5", ["\u01B7", "\u01B8"], "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", ["\u01F6", "\u01F8"], "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", ["\u023A", "\u023B"], ["\u023D", "\u023E"], "\u0241", ["\u0243", "\u0246"], "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u037F", "\u0386", ["\u0388", "\u038A"], "\u038C", ["\u038E", "\u038F"], ["\u0391", "\u03A1"], ["\u03A3", "\u03AB"], "\u03CF", ["\u03D2", "\u03D4"], "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", ["\u03F9", "\u03FA"], ["\u03FD", "\u042F"], "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", ["\u04C0", "\u04C1"], "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0524", "\u0526", "\u0528", "\u052A", "\u052C", "\u052E", ["\u0531", "\u0556"], ["\u10A0", "\u10C5"], "\u10C7", "\u10CD", ["\u13A0", "\u13F5"], "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", ["\u1F08", "\u1F0F"], ["\u1F18", "\u1F1D"], ["\u1F28", "\u1F2F"], ["\u1F38", "\u1F3F"], ["\u1F48", "\u1F4D"], "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", ["\u1F68", "\u1F6F"], ["\u1FB8", "\u1FBB"], ["\u1FC8", "\u1FCB"], ["\u1FD8", "\u1FDB"], ["\u1FE8", "\u1FEC"], ["\u1FF8", "\u1FFB"], "\u2102", "\u2107", ["\u210B", "\u210D"], ["\u2110", "\u2112"], "\u2115", ["\u2119", "\u211D"], "\u2124", "\u2126", "\u2128", ["\u212A", "\u212D"], ["\u2130", "\u2133"], ["\u213E", "\u213F"], "\u2145", "\u2183", ["\u2C00", "\u2C2E"], "\u2C60", ["\u2C62", "\u2C64"], "\u2C67", "\u2C69", "\u2C6B", ["\u2C6D", "\u2C70"], "\u2C72", "\u2C75", ["\u2C7E", "\u2C80"], "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\u2CEB", "\u2CED", "\u2CF2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA660", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA698", "\uA69A", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", ["\uA77D", "\uA77E"], "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uA78D", "\uA790", "\uA792", "\uA796", "\uA798", "\uA79A", "\uA79C", "\uA79E", "\uA7A0", "\uA7A2", "\uA7A4", "\uA7A6", "\uA7A8", ["\uA7AA", "\uA7AD"], ["\uA7B0", "\uA7B4"], "\uA7B6", ["\uFF21", "\uFF3A"]], false, false);
+  var peg$e70 = peg$classExpectation(["\u0903", "\u093B", ["\u093E", "\u0940"], ["\u0949", "\u094C"], ["\u094E", "\u094F"], ["\u0982", "\u0983"], ["\u09BE", "\u09C0"], ["\u09C7", "\u09C8"], ["\u09CB", "\u09CC"], "\u09D7", "\u0A03", ["\u0A3E", "\u0A40"], "\u0A83", ["\u0ABE", "\u0AC0"], "\u0AC9", ["\u0ACB", "\u0ACC"], ["\u0B02", "\u0B03"], "\u0B3E", "\u0B40", ["\u0B47", "\u0B48"], ["\u0B4B", "\u0B4C"], "\u0B57", ["\u0BBE", "\u0BBF"], ["\u0BC1", "\u0BC2"], ["\u0BC6", "\u0BC8"], ["\u0BCA", "\u0BCC"], "\u0BD7", ["\u0C01", "\u0C03"], ["\u0C41", "\u0C44"], ["\u0C82", "\u0C83"], "\u0CBE", ["\u0CC0", "\u0CC4"], ["\u0CC7", "\u0CC8"], ["\u0CCA", "\u0CCB"], ["\u0CD5", "\u0CD6"], ["\u0D02", "\u0D03"], ["\u0D3E", "\u0D40"], ["\u0D46", "\u0D48"], ["\u0D4A", "\u0D4C"], "\u0D57", ["\u0D82", "\u0D83"], ["\u0DCF", "\u0DD1"], ["\u0DD8", "\u0DDF"], ["\u0DF2", "\u0DF3"], ["\u0F3E", "\u0F3F"], "\u0F7F", ["\u102B", "\u102C"], "\u1031", "\u1038", ["\u103B", "\u103C"], ["\u1056", "\u1057"], ["\u1062", "\u1064"], ["\u1067", "\u106D"], ["\u1083", "\u1084"], ["\u1087", "\u108C"], "\u108F", ["\u109A", "\u109C"], "\u17B6", ["\u17BE", "\u17C5"], ["\u17C7", "\u17C8"], ["\u1923", "\u1926"], ["\u1929", "\u192B"], ["\u1930", "\u1931"], ["\u1933", "\u1938"], ["\u1A19", "\u1A1A"], "\u1A55", "\u1A57", "\u1A61", ["\u1A63", "\u1A64"], ["\u1A6D", "\u1A72"], "\u1B04", "\u1B35", "\u1B3B", ["\u1B3D", "\u1B41"], ["\u1B43", "\u1B44"], "\u1B82", "\u1BA1", ["\u1BA6", "\u1BA7"], "\u1BAA", "\u1BE7", ["\u1BEA", "\u1BEC"], "\u1BEE", ["\u1BF2", "\u1BF3"], ["\u1C24", "\u1C2B"], ["\u1C34", "\u1C35"], "\u1CE1", ["\u1CF2", "\u1CF3"], ["\u302E", "\u302F"], ["\uA823", "\uA824"], "\uA827", ["\uA880", "\uA881"], ["\uA8B4", "\uA8C3"], ["\uA952", "\uA953"], "\uA983", ["\uA9B4", "\uA9B5"], ["\uA9BA", "\uA9BB"], ["\uA9BD", "\uA9C0"], ["\uAA2F", "\uAA30"], ["\uAA33", "\uAA34"], "\uAA4D", "\uAA7B", "\uAA7D", "\uAAEB", ["\uAAEE", "\uAAEF"], "\uAAF5", ["\uABE3", "\uABE4"], ["\uABE6", "\uABE7"], ["\uABE9", "\uABEA"], "\uABEC"], false, false);
+  var peg$e71 = peg$classExpectation([["\u0300", "\u036F"], ["\u0483", "\u0487"], ["\u0591", "\u05BD"], "\u05BF", ["\u05C1", "\u05C2"], ["\u05C4", "\u05C5"], "\u05C7", ["\u0610", "\u061A"], ["\u064B", "\u065F"], "\u0670", ["\u06D6", "\u06DC"], ["\u06DF", "\u06E4"], ["\u06E7", "\u06E8"], ["\u06EA", "\u06ED"], "\u0711", ["\u0730", "\u074A"], ["\u07A6", "\u07B0"], ["\u07EB", "\u07F3"], ["\u0816", "\u0819"], ["\u081B", "\u0823"], ["\u0825", "\u0827"], ["\u0829", "\u082D"], ["\u0859", "\u085B"], ["\u08E3", "\u0902"], "\u093A", "\u093C", ["\u0941", "\u0948"], "\u094D", ["\u0951", "\u0957"], ["\u0962", "\u0963"], "\u0981", "\u09BC", ["\u09C1", "\u09C4"], "\u09CD", ["\u09E2", "\u09E3"], ["\u0A01", "\u0A02"], "\u0A3C", ["\u0A41", "\u0A42"], ["\u0A47", "\u0A48"], ["\u0A4B", "\u0A4D"], "\u0A51", ["\u0A70", "\u0A71"], "\u0A75", ["\u0A81", "\u0A82"], "\u0ABC", ["\u0AC1", "\u0AC5"], ["\u0AC7", "\u0AC8"], "\u0ACD", ["\u0AE2", "\u0AE3"], "\u0B01", "\u0B3C", "\u0B3F", ["\u0B41", "\u0B44"], "\u0B4D", "\u0B56", ["\u0B62", "\u0B63"], "\u0B82", "\u0BC0", "\u0BCD", "\u0C00", ["\u0C3E", "\u0C40"], ["\u0C46", "\u0C48"], ["\u0C4A", "\u0C4D"], ["\u0C55", "\u0C56"], ["\u0C62", "\u0C63"], "\u0C81", "\u0CBC", "\u0CBF", "\u0CC6", ["\u0CCC", "\u0CCD"], ["\u0CE2", "\u0CE3"], "\u0D01", ["\u0D41", "\u0D44"], "\u0D4D", ["\u0D62", "\u0D63"], "\u0DCA", ["\u0DD2", "\u0DD4"], "\u0DD6", "\u0E31", ["\u0E34", "\u0E3A"], ["\u0E47", "\u0E4E"], "\u0EB1", ["\u0EB4", "\u0EB9"], ["\u0EBB", "\u0EBC"], ["\u0EC8", "\u0ECD"], ["\u0F18", "\u0F19"], "\u0F35", "\u0F37", "\u0F39", ["\u0F71", "\u0F7E"], ["\u0F80", "\u0F84"], ["\u0F86", "\u0F87"], ["\u0F8D", "\u0F97"], ["\u0F99", "\u0FBC"], "\u0FC6", ["\u102D", "\u1030"], ["\u1032", "\u1037"], ["\u1039", "\u103A"], ["\u103D", "\u103E"], ["\u1058", "\u1059"], ["\u105E", "\u1060"], ["\u1071", "\u1074"], "\u1082", ["\u1085", "\u1086"], "\u108D", "\u109D", ["\u135D", "\u135F"], ["\u1712", "\u1714"], ["\u1732", "\u1734"], ["\u1752", "\u1753"], ["\u1772", "\u1773"], ["\u17B4", "\u17B5"], ["\u17B7", "\u17BD"], "\u17C6", ["\u17C9", "\u17D3"], "\u17DD", ["\u180B", "\u180D"], "\u18A9", ["\u1920", "\u1922"], ["\u1927", "\u1928"], "\u1932", ["\u1939", "\u193B"], ["\u1A17", "\u1A18"], "\u1A1B", "\u1A56", ["\u1A58", "\u1A5E"], "\u1A60", "\u1A62", ["\u1A65", "\u1A6C"], ["\u1A73", "\u1A7C"], "\u1A7F", ["\u1AB0", "\u1ABD"], ["\u1B00", "\u1B03"], "\u1B34", ["\u1B36", "\u1B3A"], "\u1B3C", "\u1B42", ["\u1B6B", "\u1B73"], ["\u1B80", "\u1B81"], ["\u1BA2", "\u1BA5"], ["\u1BA8", "\u1BA9"], ["\u1BAB", "\u1BAD"], "\u1BE6", ["\u1BE8", "\u1BE9"], "\u1BED", ["\u1BEF", "\u1BF1"], ["\u1C2C", "\u1C33"], ["\u1C36", "\u1C37"], ["\u1CD0", "\u1CD2"], ["\u1CD4", "\u1CE0"], ["\u1CE2", "\u1CE8"], "\u1CED", "\u1CF4", ["\u1CF8", "\u1CF9"], ["\u1DC0", "\u1DF5"], ["\u1DFC", "\u1DFF"], ["\u20D0", "\u20DC"], "\u20E1", ["\u20E5", "\u20F0"], ["\u2CEF", "\u2CF1"], "\u2D7F", ["\u2DE0", "\u2DFF"], ["\u302A", "\u302D"], ["\u3099", "\u309A"], "\uA66F", ["\uA674", "\uA67D"], ["\uA69E", "\uA69F"], ["\uA6F0", "\uA6F1"], "\uA802", "\uA806", "\uA80B", ["\uA825", "\uA826"], "\uA8C4", ["\uA8E0", "\uA8F1"], ["\uA926", "\uA92D"], ["\uA947", "\uA951"], ["\uA980", "\uA982"], "\uA9B3", ["\uA9B6", "\uA9B9"], "\uA9BC", "\uA9E5", ["\uAA29", "\uAA2E"], ["\uAA31", "\uAA32"], ["\uAA35", "\uAA36"], "\uAA43", "\uAA4C", "\uAA7C", "\uAAB0", ["\uAAB2", "\uAAB4"], ["\uAAB7", "\uAAB8"], ["\uAABE", "\uAABF"], "\uAAC1", ["\uAAEC", "\uAAED"], "\uAAF6", "\uABE5", "\uABE8", "\uABED", "\uFB1E", ["\uFE00", "\uFE0F"], ["\uFE20", "\uFE2F"]], false, false);
+  var peg$e72 = peg$classExpectation([["0", "9"], ["\u0660", "\u0669"], ["\u06F0", "\u06F9"], ["\u07C0", "\u07C9"], ["\u0966", "\u096F"], ["\u09E6", "\u09EF"], ["\u0A66", "\u0A6F"], ["\u0AE6", "\u0AEF"], ["\u0B66", "\u0B6F"], ["\u0BE6", "\u0BEF"], ["\u0C66", "\u0C6F"], ["\u0CE6", "\u0CEF"], ["\u0D66", "\u0D6F"], ["\u0DE6", "\u0DEF"], ["\u0E50", "\u0E59"], ["\u0ED0", "\u0ED9"], ["\u0F20", "\u0F29"], ["\u1040", "\u1049"], ["\u1090", "\u1099"], ["\u17E0", "\u17E9"], ["\u1810", "\u1819"], ["\u1946", "\u194F"], ["\u19D0", "\u19D9"], ["\u1A80", "\u1A89"], ["\u1A90", "\u1A99"], ["\u1B50", "\u1B59"], ["\u1BB0", "\u1BB9"], ["\u1C40", "\u1C49"], ["\u1C50", "\u1C59"], ["\uA620", "\uA629"], ["\uA8D0", "\uA8D9"], ["\uA900", "\uA909"], ["\uA9D0", "\uA9D9"], ["\uA9F0", "\uA9F9"], ["\uAA50", "\uAA59"], ["\uABF0", "\uABF9"], ["\uFF10", "\uFF19"]], false, false);
+  var peg$e73 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false);
+  var peg$e74 = peg$classExpectation(["_", ["\u203F", "\u2040"], "\u2054", ["\uFE33", "\uFE34"], ["\uFE4D", "\uFE4F"], "\uFF3F"], false, false);
+  var peg$e75 = peg$classExpectation([" ", "\xA0", "\u1680", ["\u2000", "\u200A"], "\u202F", "\u205F", "\u3000"], false, false);
+  var peg$e76 = peg$literalExpectation(";", false);
 
   var peg$f0 = function(topLevelInitializer, initializer, rules) {
       return {
@@ -451,7 +453,7 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f13 = function(expression, boundaries) {
+  var peg$f13 = function(expression, boundaries, delimiter) {
       let min = boundaries[0];
       let max = boundaries[1];
       if (max.type === "constant" && max.value === 0) {
@@ -463,6 +465,7 @@ function peg$parse(input, options) {
         min,
         max,
         expression,
+        delimiter,
         location: location(),
       };
     };
@@ -1240,7 +1243,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseRepeatedExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
     s0 = peg$currPos;
     s1 = peg$parsePrimaryExpression();
@@ -1258,16 +1261,41 @@ function peg$parse(input, options) {
         s5 = peg$parseBoundaries();
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
-          if (input.charCodeAt(peg$currPos) === 124) {
-            s7 = peg$c12;
+          s7 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s8 = peg$c13;
             peg$currPos++;
           } else {
+            s8 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e13); }
+          }
+          if (s8 !== peg$FAILED) {
+            s9 = peg$parse__();
+            s10 = peg$parseChoiceExpression();
+            if (s10 !== peg$FAILED) {
+              s11 = peg$parse__();
+              s7 = s10;
+            } else {
+              peg$currPos = s7;
+              s7 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s7;
             s7 = peg$FAILED;
+          }
+          if (s7 === peg$FAILED) {
+            s7 = null;
+          }
+          if (input.charCodeAt(peg$currPos) === 124) {
+            s8 = peg$c12;
+            peg$currPos++;
+          } else {
+            s8 = peg$FAILED;
             if (peg$silentFails === 0) { peg$fail(peg$e12); }
           }
-          if (s7 !== peg$FAILED) {
+          if (s8 !== peg$FAILED) {
             peg$savedPos = s0;
-            s0 = peg$f13(s1, s5);
+            s0 = peg$f13(s1, s5, s7);
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -1297,12 +1325,12 @@ function peg$parse(input, options) {
       s1 = null;
     }
     s2 = peg$parse__();
-    if (input.substr(peg$currPos, 2) === peg$c13) {
-      s3 = peg$c13;
+    if (input.substr(peg$currPos, 2) === peg$c14) {
+      s3 = peg$c14;
       peg$currPos += 2;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e13); }
+      if (peg$silentFails === 0) { peg$fail(peg$e14); }
     }
     if (s3 !== peg$FAILED) {
       s4 = peg$parse__();
@@ -1376,11 +1404,11 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 40) {
-                s1 = peg$c14;
+                s1 = peg$c15;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e14); }
+                if (peg$silentFails === 0) { peg$fail(peg$e15); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
@@ -1388,11 +1416,11 @@ function peg$parse(input, options) {
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse__();
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s5 = peg$c15;
+                    s5 = peg$c16;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$e15); }
+                    if (peg$silentFails === 0) { peg$fail(peg$e16); }
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
@@ -1531,7 +1559,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e16); }
+      if (peg$silentFails === 0) { peg$fail(peg$e17); }
     }
 
     return s0;
@@ -1542,51 +1570,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c16;
+      s0 = peg$c17;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e18); }
+      if (peg$silentFails === 0) { peg$fail(peg$e19); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c17;
+        s0 = peg$c18;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e19); }
+        if (peg$silentFails === 0) { peg$fail(peg$e20); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c18;
+          s0 = peg$c19;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e20); }
+          if (peg$silentFails === 0) { peg$fail(peg$e21); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c19;
+            s0 = peg$c20;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e21); }
+            if (peg$silentFails === 0) { peg$fail(peg$e22); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c20;
+              s0 = peg$c21;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e22); }
+              if (peg$silentFails === 0) { peg$fail(peg$e23); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c21;
+                s0 = peg$c22;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e23); }
+                if (peg$silentFails === 0) { peg$fail(peg$e24); }
               }
               if (s0 === peg$FAILED) {
                 s0 = peg$parseZs();
@@ -1599,7 +1627,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e17); }
+      if (peg$silentFails === 0) { peg$fail(peg$e18); }
     }
 
     return s0;
@@ -1613,7 +1641,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e24); }
+      if (peg$silentFails === 0) { peg$fail(peg$e25); }
     }
 
     return s0;
@@ -1624,43 +1652,43 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 10) {
-      s0 = peg$c22;
+      s0 = peg$c23;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e26); }
+      if (peg$silentFails === 0) { peg$fail(peg$e27); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c23) {
-        s0 = peg$c23;
+      if (input.substr(peg$currPos, 2) === peg$c24) {
+        s0 = peg$c24;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e27); }
+        if (peg$silentFails === 0) { peg$fail(peg$e28); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 13) {
-          s0 = peg$c24;
+          s0 = peg$c25;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e28); }
+          if (peg$silentFails === 0) { peg$fail(peg$e29); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 8232) {
-            s0 = peg$c25;
+            s0 = peg$c26;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e29); }
+            if (peg$silentFails === 0) { peg$fail(peg$e30); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 8233) {
-              s0 = peg$c26;
+              s0 = peg$c27;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e30); }
+              if (peg$silentFails === 0) { peg$fail(peg$e31); }
             }
           }
         }
@@ -1669,7 +1697,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e25); }
+      if (peg$silentFails === 0) { peg$fail(peg$e26); }
     }
 
     return s0;
@@ -1686,7 +1714,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e31); }
+      if (peg$silentFails === 0) { peg$fail(peg$e32); }
     }
 
     return s0;
@@ -1696,24 +1724,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c27) {
-      s1 = peg$c27;
+    if (input.substr(peg$currPos, 2) === peg$c28) {
+      s1 = peg$c28;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e32); }
+      if (peg$silentFails === 0) { peg$fail(peg$e33); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c28) {
-        s5 = peg$c28;
+      if (input.substr(peg$currPos, 2) === peg$c29) {
+        s5 = peg$c29;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e33); }
+        if (peg$silentFails === 0) { peg$fail(peg$e34); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -1740,12 +1768,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c28) {
-          s5 = peg$c28;
+        if (input.substr(peg$currPos, 2) === peg$c29) {
+          s5 = peg$c29;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e33); }
+          if (peg$silentFails === 0) { peg$fail(peg$e34); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -1768,12 +1796,12 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       }
-      if (input.substr(peg$currPos, 2) === peg$c28) {
-        s3 = peg$c28;
+      if (input.substr(peg$currPos, 2) === peg$c29) {
+        s3 = peg$c29;
         peg$currPos += 2;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e33); }
+        if (peg$silentFails === 0) { peg$fail(peg$e34); }
       }
       if (s3 !== peg$FAILED) {
         s1 = [s1, s2, s3];
@@ -1794,24 +1822,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c27) {
-      s1 = peg$c27;
+    if (input.substr(peg$currPos, 2) === peg$c28) {
+      s1 = peg$c28;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e32); }
+      if (peg$silentFails === 0) { peg$fail(peg$e33); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c28) {
-        s5 = peg$c28;
+      if (input.substr(peg$currPos, 2) === peg$c29) {
+        s5 = peg$c29;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e33); }
+        if (peg$silentFails === 0) { peg$fail(peg$e34); }
       }
       if (s5 === peg$FAILED) {
         s5 = peg$parseLineTerminator();
@@ -1841,12 +1869,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c28) {
-          s5 = peg$c28;
+        if (input.substr(peg$currPos, 2) === peg$c29) {
+          s5 = peg$c29;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e33); }
+          if (peg$silentFails === 0) { peg$fail(peg$e34); }
         }
         if (s5 === peg$FAILED) {
           s5 = peg$parseLineTerminator();
@@ -1872,12 +1900,12 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       }
-      if (input.substr(peg$currPos, 2) === peg$c28) {
-        s3 = peg$c28;
+      if (input.substr(peg$currPos, 2) === peg$c29) {
+        s3 = peg$c29;
         peg$currPos += 2;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e33); }
+        if (peg$silentFails === 0) { peg$fail(peg$e34); }
       }
       if (s3 !== peg$FAILED) {
         s1 = [s1, s2, s3];
@@ -1898,12 +1926,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c29) {
-      s1 = peg$c29;
+    if (input.substr(peg$currPos, 2) === peg$c30) {
+      s1 = peg$c30;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e34); }
+      if (peg$silentFails === 0) { peg$fail(peg$e35); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1990,7 +2018,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e35); }
+      if (peg$silentFails === 0) { peg$fail(peg$e36); }
     }
 
     return s0;
@@ -2010,20 +2038,20 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 95) {
-          s0 = peg$c30;
+          s0 = peg$c31;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e36); }
+          if (peg$silentFails === 0) { peg$fail(peg$e37); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s1 = peg$c31;
+            s1 = peg$c32;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e37); }
+            if (peg$silentFails === 0) { peg$fail(peg$e38); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseUnicodeEscapeSequence();
@@ -2056,19 +2084,19 @@ function peg$parse(input, options) {
           s0 = peg$parsePc();
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 8204) {
-              s0 = peg$c32;
+              s0 = peg$c33;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e38); }
+              if (peg$silentFails === 0) { peg$fail(peg$e39); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 8205) {
-                s0 = peg$c33;
+                s0 = peg$c34;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e39); }
+                if (peg$silentFails === 0) { peg$fail(peg$e40); }
               }
             }
           }
@@ -2121,11 +2149,11 @@ function peg$parse(input, options) {
     s1 = peg$parseStringLiteral();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 105) {
-        s2 = peg$c34;
+        s2 = peg$c35;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e41); }
+        if (peg$silentFails === 0) { peg$fail(peg$e42); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -2139,7 +2167,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e40); }
+      if (peg$silentFails === 0) { peg$fail(peg$e41); }
     }
 
     return s0;
@@ -2151,11 +2179,11 @@ function peg$parse(input, options) {
     peg$silentFails++;
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c35;
+      s1 = peg$c36;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e43); }
+      if (peg$silentFails === 0) { peg$fail(peg$e44); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -2165,11 +2193,11 @@ function peg$parse(input, options) {
         s3 = peg$parseDoubleStringCharacter();
       }
       if (input.charCodeAt(peg$currPos) === 34) {
-        s3 = peg$c35;
+        s3 = peg$c36;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e43); }
+        if (peg$silentFails === 0) { peg$fail(peg$e44); }
       }
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -2185,11 +2213,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c36;
+        s1 = peg$c37;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e44); }
+        if (peg$silentFails === 0) { peg$fail(peg$e45); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -2199,11 +2227,11 @@ function peg$parse(input, options) {
           s3 = peg$parseSingleStringCharacter();
         }
         if (input.charCodeAt(peg$currPos) === 39) {
-          s3 = peg$c36;
+          s3 = peg$c37;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e44); }
+          if (peg$silentFails === 0) { peg$fail(peg$e45); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -2220,7 +2248,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e42); }
+      if (peg$silentFails === 0) { peg$fail(peg$e43); }
     }
 
     return s0;
@@ -2234,19 +2262,19 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s3 = peg$c35;
+      s3 = peg$c36;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e43); }
+      if (peg$silentFails === 0) { peg$fail(peg$e44); }
     }
     if (s3 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c31;
+        s3 = peg$c32;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e37); }
+        if (peg$silentFails === 0) { peg$fail(peg$e38); }
       }
       if (s3 === peg$FAILED) {
         s3 = peg$parseLineTerminator();
@@ -2280,11 +2308,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c31;
+        s1 = peg$c32;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e37); }
+        if (peg$silentFails === 0) { peg$fail(peg$e38); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -2314,19 +2342,19 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s3 = peg$c36;
+      s3 = peg$c37;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e44); }
+      if (peg$silentFails === 0) { peg$fail(peg$e45); }
     }
     if (s3 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c31;
+        s3 = peg$c32;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e37); }
+        if (peg$silentFails === 0) { peg$fail(peg$e38); }
       }
       if (s3 === peg$FAILED) {
         s3 = peg$parseLineTerminator();
@@ -2360,11 +2388,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c31;
+        s1 = peg$c32;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e37); }
+        if (peg$silentFails === 0) { peg$fail(peg$e38); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -2392,19 +2420,19 @@ function peg$parse(input, options) {
     peg$silentFails++;
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c37;
+      s1 = peg$c38;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e46); }
+      if (peg$silentFails === 0) { peg$fail(peg$e47); }
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 94) {
-        s2 = peg$c38;
+        s2 = peg$c39;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e47); }
+        if (peg$silentFails === 0) { peg$fail(peg$e48); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -2422,19 +2450,19 @@ function peg$parse(input, options) {
         }
       }
       if (input.charCodeAt(peg$currPos) === 93) {
-        s4 = peg$c39;
+        s4 = peg$c40;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e48); }
+        if (peg$silentFails === 0) { peg$fail(peg$e49); }
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 105) {
-          s5 = peg$c34;
+          s5 = peg$c35;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e41); }
+          if (peg$silentFails === 0) { peg$fail(peg$e42); }
         }
         if (s5 === peg$FAILED) {
           s5 = null;
@@ -2452,7 +2480,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e45); }
+      if (peg$silentFails === 0) { peg$fail(peg$e46); }
     }
 
     return s0;
@@ -2465,11 +2493,11 @@ function peg$parse(input, options) {
     s1 = peg$parseClassCharacter();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c40;
+        s2 = peg$c41;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e49); }
+        if (peg$silentFails === 0) { peg$fail(peg$e50); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseClassCharacter();
@@ -2500,19 +2528,19 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 93) {
-      s3 = peg$c39;
+      s3 = peg$c40;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e48); }
+      if (peg$silentFails === 0) { peg$fail(peg$e49); }
     }
     if (s3 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c31;
+        s3 = peg$c32;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e37); }
+        if (peg$silentFails === 0) { peg$fail(peg$e38); }
       }
       if (s3 === peg$FAILED) {
         s3 = peg$parseLineTerminator();
@@ -2546,11 +2574,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c31;
+        s1 = peg$c32;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e37); }
+        if (peg$silentFails === 0) { peg$fail(peg$e38); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -2577,11 +2605,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c31;
+      s1 = peg$c32;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e37); }
+      if (peg$silentFails === 0) { peg$fail(peg$e38); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseLineTerminatorSequence();
@@ -2607,11 +2635,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s1 = peg$c41;
+        s1 = peg$c42;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e50); }
+        if (peg$silentFails === 0) { peg$fail(peg$e51); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
@@ -2661,36 +2689,36 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c36;
+      s0 = peg$c37;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e44); }
+      if (peg$silentFails === 0) { peg$fail(peg$e45); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c35;
+        s0 = peg$c36;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e43); }
+        if (peg$silentFails === 0) { peg$fail(peg$e44); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c31;
+          s0 = peg$c32;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e37); }
+          if (peg$silentFails === 0) { peg$fail(peg$e38); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c42;
+            s1 = peg$c43;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e51); }
+            if (peg$silentFails === 0) { peg$fail(peg$e52); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -2700,11 +2728,11 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c43;
+              s1 = peg$c44;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e52); }
+              if (peg$silentFails === 0) { peg$fail(peg$e53); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
@@ -2714,11 +2742,11 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c44;
+                s1 = peg$c45;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e53); }
+                if (peg$silentFails === 0) { peg$fail(peg$e54); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
@@ -2728,11 +2756,11 @@ function peg$parse(input, options) {
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c45;
+                  s1 = peg$c46;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$e54); }
+                  if (peg$silentFails === 0) { peg$fail(peg$e55); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
@@ -2742,11 +2770,11 @@ function peg$parse(input, options) {
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c46;
+                    s1 = peg$c47;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$e55); }
+                    if (peg$silentFails === 0) { peg$fail(peg$e56); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
@@ -2756,11 +2784,11 @@ function peg$parse(input, options) {
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c47;
+                      s1 = peg$c48;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$e56); }
+                      if (peg$silentFails === 0) { peg$fail(peg$e57); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
@@ -2827,19 +2855,19 @@ function peg$parse(input, options) {
       s0 = peg$parseDecimalDigit();
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 120) {
-          s0 = peg$c48;
+          s0 = peg$c49;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e57); }
+          if (peg$silentFails === 0) { peg$fail(peg$e58); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 117) {
-            s0 = peg$c49;
+            s0 = peg$c50;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e58); }
+            if (peg$silentFails === 0) { peg$fail(peg$e59); }
           }
         }
       }
@@ -2853,11 +2881,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c48;
+      s1 = peg$c49;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e57); }
+      if (peg$silentFails === 0) { peg$fail(peg$e58); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2901,11 +2929,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c49;
+      s1 = peg$c50;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e58); }
+      if (peg$silentFails === 0) { peg$fail(peg$e59); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2964,7 +2992,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e59); }
+      if (peg$silentFails === 0) { peg$fail(peg$e60); }
     }
 
     return s0;
@@ -2978,7 +3006,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e60); }
+      if (peg$silentFails === 0) { peg$fail(peg$e61); }
     }
 
     return s0;
@@ -2989,11 +3017,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c50;
+      s1 = peg$c51;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e61); }
+      if (peg$silentFails === 0) { peg$fail(peg$e62); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -3038,7 +3066,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e62); }
+      if (peg$silentFails === 0) { peg$fail(peg$e63); }
     }
 
     return s0;
@@ -3070,7 +3098,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s5 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e63); }
+      if (peg$silentFails === 0) { peg$fail(peg$e64); }
     }
     peg$silentFails--;
     if (s5 === peg$FAILED) {
@@ -3103,7 +3131,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e63); }
+          if (peg$silentFails === 0) { peg$fail(peg$e64); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -3170,7 +3198,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e63); }
+        if (peg$silentFails === 0) { peg$fail(peg$e64); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -3203,7 +3231,7 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e63); }
+            if (peg$silentFails === 0) { peg$fail(peg$e64); }
           }
           peg$silentFails--;
           if (s5 === peg$FAILED) {
@@ -3302,7 +3330,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e64); }
+      if (peg$silentFails === 0) { peg$fail(peg$e65); }
     }
 
     return s0;
@@ -3316,7 +3344,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e65); }
+      if (peg$silentFails === 0) { peg$fail(peg$e66); }
     }
 
     return s0;
@@ -3330,7 +3358,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e66); }
+      if (peg$silentFails === 0) { peg$fail(peg$e67); }
     }
 
     return s0;
@@ -3344,7 +3372,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e67); }
+      if (peg$silentFails === 0) { peg$fail(peg$e68); }
     }
 
     return s0;
@@ -3358,7 +3386,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e68); }
+      if (peg$silentFails === 0) { peg$fail(peg$e69); }
     }
 
     return s0;
@@ -3372,7 +3400,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e69); }
+      if (peg$silentFails === 0) { peg$fail(peg$e70); }
     }
 
     return s0;
@@ -3386,7 +3414,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e70); }
+      if (peg$silentFails === 0) { peg$fail(peg$e71); }
     }
 
     return s0;
@@ -3400,7 +3428,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e71); }
+      if (peg$silentFails === 0) { peg$fail(peg$e72); }
     }
 
     return s0;
@@ -3414,7 +3442,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e72); }
+      if (peg$silentFails === 0) { peg$fail(peg$e73); }
     }
 
     return s0;
@@ -3428,7 +3456,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e73); }
+      if (peg$silentFails === 0) { peg$fail(peg$e74); }
     }
 
     return s0;
@@ -3442,7 +3470,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e74); }
+      if (peg$silentFails === 0) { peg$fail(peg$e75); }
     }
 
     return s0;
@@ -3498,11 +3526,11 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (input.charCodeAt(peg$currPos) === 59) {
-      s2 = peg$c51;
+      s2 = peg$c52;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e75); }
+      if (peg$silentFails === 0) { peg$fail(peg$e76); }
     }
     if (s2 !== peg$FAILED) {
       s1 = [s1, s2];
@@ -3553,7 +3581,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e16); }
+      if (peg$silentFails === 0) { peg$fail(peg$e17); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -475,7 +475,15 @@ function peg$parse(input, options) {
   var peg$f15 = function(exact) { return [null, exact]; };
   var peg$f16 = function(value) { return { type: "constant", value, location: location() }; };
   var peg$f17 = function(value) { return { type: "variable", value: value[0], location: location() }; };
-  var peg$f18 = function(expression) {
+  var peg$f18 = function(value) {
+    return {
+      type: "function",
+      value: value[0],
+      codeLocation: value[1],
+      location: location(),
+    };
+  };
+  var peg$f19 = function(expression) {
       // The purpose of the "group" AST node is just to isolate label scope. We
       // don't need to put it around nodes that can't contain any labels or
       // nodes that already isolate label scope themselves. This leaves us with
@@ -484,10 +492,10 @@ function peg$parse(input, options) {
           ? { type: "group", expression, location: location() }
           : expression;
     };
-  var peg$f19 = function(name) {
+  var peg$f20 = function(name) {
       return { type: "rule_ref", name: name[0], location: location() };
     };
-  var peg$f20 = function(operator, code) {
+  var peg$f21 = function(operator, code) {
       return {
         type: OPS_TO_SEMANTIC_PREDICATE_TYPES[operator],
         code: code[0],
@@ -495,10 +503,10 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f21 = function(head, tail) {
+  var peg$f22 = function(head, tail) {
       return [head + tail.join(""), location()];
     };
-  var peg$f22 = function(value, ignoreCase) {
+  var peg$f23 = function(value, ignoreCase) {
       return {
         type: "literal",
         value,
@@ -506,9 +514,9 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f23 = function(chars) { return chars.join(""); };
   var peg$f24 = function(chars) { return chars.join(""); };
-  var peg$f25 = function(inverted, parts, ignoreCase) {
+  var peg$f25 = function(chars) { return chars.join(""); };
+  var peg$f26 = function(inverted, parts, ignoreCase) {
       return {
         type: "class",
         parts: parts.filter(part => part !== ""),
@@ -517,7 +525,7 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f26 = function(begin, end) {
+  var peg$f27 = function(begin, end) {
       if (begin.charCodeAt(0) > end.charCodeAt(0)) {
         error(
           "Invalid character range: " + text() + "."
@@ -526,23 +534,23 @@ function peg$parse(input, options) {
 
       return [begin, end];
     };
-  var peg$f27 = function() { return ""; };
-  var peg$f28 = function() { return "\0"; };
-  var peg$f29 = function() { return "\b"; };
-  var peg$f30 = function() { return "\f"; };
-  var peg$f31 = function() { return "\n"; };
-  var peg$f32 = function() { return "\r"; };
-  var peg$f33 = function() { return "\t"; };
-  var peg$f34 = function() { return "\v"; };
-  var peg$f35 = function(digits) {
-      return String.fromCharCode(parseInt(digits, 16));
-    };
+  var peg$f28 = function() { return ""; };
+  var peg$f29 = function() { return "\0"; };
+  var peg$f30 = function() { return "\b"; };
+  var peg$f31 = function() { return "\f"; };
+  var peg$f32 = function() { return "\n"; };
+  var peg$f33 = function() { return "\r"; };
+  var peg$f34 = function() { return "\t"; };
+  var peg$f35 = function() { return "\v"; };
   var peg$f36 = function(digits) {
       return String.fromCharCode(parseInt(digits, 16));
     };
-  var peg$f37 = function() { return { type: "any", location: location() }; };
-  var peg$f38 = function(code) { return [code, location()]; };
-  var peg$f39 = function(digits) { return parseInt(digits); };
+  var peg$f37 = function(digits) {
+      return String.fromCharCode(parseInt(digits, 16));
+    };
+  var peg$f38 = function() { return { type: "any", location: location() }; };
+  var peg$f39 = function(code) { return [code, location()]; };
+  var peg$f40 = function(digits) { return parseInt(digits); };
   var peg$currPos = 0;
   var peg$savedPos = 0;
   var peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -1339,6 +1347,15 @@ function peg$parse(input, options) {
         s1 = peg$f17(s1);
       }
       s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseCodeBlock();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$f18(s1);
+        }
+        s0 = s1;
+      }
     }
 
     return s0;
@@ -1379,7 +1396,7 @@ function peg$parse(input, options) {
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s0 = peg$f18(s3);
+                    s0 = peg$f19(s3);
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -1447,7 +1464,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f19(s1);
+        s0 = peg$f20(s1);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1470,7 +1487,7 @@ function peg$parse(input, options) {
       s3 = peg$parseCodeBlock();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f20(s1, s3);
+        s0 = peg$f21(s1, s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1965,7 +1982,7 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifierPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f21(s1, s2);
+      s0 = peg$f22(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2114,7 +2131,7 @@ function peg$parse(input, options) {
         s2 = null;
       }
       peg$savedPos = s0;
-      s0 = peg$f22(s1, s2);
+      s0 = peg$f23(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2156,7 +2173,7 @@ function peg$parse(input, options) {
       }
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f23(s2);
+        s0 = peg$f24(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2190,7 +2207,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f24(s2);
+          s0 = peg$f25(s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2423,7 +2440,7 @@ function peg$parse(input, options) {
           s5 = null;
         }
         peg$savedPos = s0;
-        s0 = peg$f25(s2, s3, s5);
+        s0 = peg$f26(s2, s3, s5);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2458,7 +2475,7 @@ function peg$parse(input, options) {
         s3 = peg$parseClassCharacter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f26(s1, s3);
+          s0 = peg$f27(s1, s3);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2570,7 +2587,7 @@ function peg$parse(input, options) {
       s2 = peg$parseLineTerminatorSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f27();
+        s0 = peg$f28();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2609,7 +2626,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f28();
+          s0 = peg$f29();
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2677,7 +2694,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$f29();
+            s1 = peg$f30();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -2691,7 +2708,7 @@ function peg$parse(input, options) {
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$f30();
+              s1 = peg$f31();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
@@ -2705,7 +2722,7 @@ function peg$parse(input, options) {
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$f31();
+                s1 = peg$f32();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
@@ -2719,7 +2736,7 @@ function peg$parse(input, options) {
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$f32();
+                  s1 = peg$f33();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
@@ -2733,7 +2750,7 @@ function peg$parse(input, options) {
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$f33();
+                    s1 = peg$f34();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
@@ -2747,7 +2764,7 @@ function peg$parse(input, options) {
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$f34();
+                      s1 = peg$f35();
                     }
                     s0 = s1;
                   }
@@ -2866,7 +2883,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f35(s2);
+        s0 = peg$f36(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2926,7 +2943,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f36(s2);
+        s0 = peg$f37(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2980,7 +2997,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f37();
+      s1 = peg$f38();
     }
     s0 = s1;
 
@@ -3033,7 +3050,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseCode();
     peg$savedPos = s0;
-    s1 = peg$f38(s1);
+    s1 = peg$f39(s1);
     s0 = s1;
 
     return s0;
@@ -3270,7 +3287,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f39(s1);
+      s1 = peg$f40(s1);
     }
     s0 = s1;
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -202,44 +202,46 @@ function peg$parse(input, options) {
   var peg$c9 = "?";
   var peg$c10 = "*";
   var peg$c11 = "+";
-  var peg$c12 = "(";
-  var peg$c13 = ")";
-  var peg$c14 = "\t";
-  var peg$c15 = "\v";
-  var peg$c16 = "\f";
-  var peg$c17 = " ";
-  var peg$c18 = "\xA0";
-  var peg$c19 = "\uFEFF";
-  var peg$c20 = "\n";
-  var peg$c21 = "\r\n";
-  var peg$c22 = "\r";
-  var peg$c23 = "\u2028";
-  var peg$c24 = "\u2029";
-  var peg$c25 = "/*";
-  var peg$c26 = "*/";
-  var peg$c27 = "//";
-  var peg$c28 = "_";
-  var peg$c29 = "\\";
-  var peg$c30 = "\u200C";
-  var peg$c31 = "\u200D";
-  var peg$c32 = "i";
-  var peg$c33 = "\"";
-  var peg$c34 = "'";
-  var peg$c35 = "[";
-  var peg$c36 = "^";
-  var peg$c37 = "]";
-  var peg$c38 = "-";
-  var peg$c39 = "0";
-  var peg$c40 = "b";
-  var peg$c41 = "f";
-  var peg$c42 = "n";
-  var peg$c43 = "r";
-  var peg$c44 = "t";
-  var peg$c45 = "v";
-  var peg$c46 = "x";
-  var peg$c47 = "u";
-  var peg$c48 = ".";
-  var peg$c49 = ";";
+  var peg$c12 = "|";
+  var peg$c13 = "..";
+  var peg$c14 = "(";
+  var peg$c15 = ")";
+  var peg$c16 = "\t";
+  var peg$c17 = "\v";
+  var peg$c18 = "\f";
+  var peg$c19 = " ";
+  var peg$c20 = "\xA0";
+  var peg$c21 = "\uFEFF";
+  var peg$c22 = "\n";
+  var peg$c23 = "\r\n";
+  var peg$c24 = "\r";
+  var peg$c25 = "\u2028";
+  var peg$c26 = "\u2029";
+  var peg$c27 = "/*";
+  var peg$c28 = "*/";
+  var peg$c29 = "//";
+  var peg$c30 = "_";
+  var peg$c31 = "\\";
+  var peg$c32 = "\u200C";
+  var peg$c33 = "\u200D";
+  var peg$c34 = "i";
+  var peg$c35 = "\"";
+  var peg$c36 = "'";
+  var peg$c37 = "[";
+  var peg$c38 = "^";
+  var peg$c39 = "]";
+  var peg$c40 = "-";
+  var peg$c41 = "0";
+  var peg$c42 = "b";
+  var peg$c43 = "f";
+  var peg$c44 = "n";
+  var peg$c45 = "r";
+  var peg$c46 = "t";
+  var peg$c47 = "v";
+  var peg$c48 = "x";
+  var peg$c49 = "u";
+  var peg$c50 = ".";
+  var peg$c51 = ";";
 
   var peg$r0 = /^[\n\r\u2028\u2029]/;
   var peg$r1 = /^[0-9]/;
@@ -269,68 +271,70 @@ function peg$parse(input, options) {
   var peg$e9 = peg$literalExpectation("?", false);
   var peg$e10 = peg$literalExpectation("*", false);
   var peg$e11 = peg$literalExpectation("+", false);
-  var peg$e12 = peg$literalExpectation("(", false);
-  var peg$e13 = peg$literalExpectation(")", false);
-  var peg$e14 = peg$anyExpectation();
-  var peg$e15 = peg$otherExpectation("whitespace");
-  var peg$e16 = peg$literalExpectation("\t", false);
-  var peg$e17 = peg$literalExpectation("\v", false);
-  var peg$e18 = peg$literalExpectation("\f", false);
-  var peg$e19 = peg$literalExpectation(" ", false);
-  var peg$e20 = peg$literalExpectation("\xA0", false);
-  var peg$e21 = peg$literalExpectation("\uFEFF", false);
-  var peg$e22 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false);
-  var peg$e23 = peg$otherExpectation("end of line");
-  var peg$e24 = peg$literalExpectation("\n", false);
-  var peg$e25 = peg$literalExpectation("\r\n", false);
-  var peg$e26 = peg$literalExpectation("\r", false);
-  var peg$e27 = peg$literalExpectation("\u2028", false);
-  var peg$e28 = peg$literalExpectation("\u2029", false);
-  var peg$e29 = peg$otherExpectation("comment");
-  var peg$e30 = peg$literalExpectation("/*", false);
-  var peg$e31 = peg$literalExpectation("*/", false);
-  var peg$e32 = peg$literalExpectation("//", false);
-  var peg$e33 = peg$otherExpectation("identifier");
-  var peg$e34 = peg$literalExpectation("_", false);
-  var peg$e35 = peg$literalExpectation("\\", false);
-  var peg$e36 = peg$literalExpectation("\u200C", false);
-  var peg$e37 = peg$literalExpectation("\u200D", false);
-  var peg$e38 = peg$otherExpectation("literal");
-  var peg$e39 = peg$literalExpectation("i", false);
-  var peg$e40 = peg$otherExpectation("string");
-  var peg$e41 = peg$literalExpectation("\"", false);
-  var peg$e42 = peg$literalExpectation("'", false);
-  var peg$e43 = peg$otherExpectation("character class");
-  var peg$e44 = peg$literalExpectation("[", false);
-  var peg$e45 = peg$literalExpectation("^", false);
-  var peg$e46 = peg$literalExpectation("]", false);
-  var peg$e47 = peg$literalExpectation("-", false);
-  var peg$e48 = peg$literalExpectation("0", false);
-  var peg$e49 = peg$literalExpectation("b", false);
-  var peg$e50 = peg$literalExpectation("f", false);
-  var peg$e51 = peg$literalExpectation("n", false);
-  var peg$e52 = peg$literalExpectation("r", false);
-  var peg$e53 = peg$literalExpectation("t", false);
-  var peg$e54 = peg$literalExpectation("v", false);
-  var peg$e55 = peg$literalExpectation("x", false);
-  var peg$e56 = peg$literalExpectation("u", false);
-  var peg$e57 = peg$classExpectation([["0", "9"]], false, false);
-  var peg$e58 = peg$classExpectation([["0", "9"], ["a", "f"]], false, true);
-  var peg$e59 = peg$literalExpectation(".", false);
-  var peg$e60 = peg$otherExpectation("code block");
-  var peg$e61 = peg$classExpectation(["{", "}"], false, false);
-  var peg$e62 = peg$classExpectation([["a", "z"], "\xB5", ["\xDF", "\xF6"], ["\xF8", "\xFF"], "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", ["\u0137", "\u0138"], "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", ["\u0148", "\u0149"], "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", ["\u017E", "\u0180"], "\u0183", "\u0185", "\u0188", ["\u018C", "\u018D"], "\u0192", "\u0195", ["\u0199", "\u019B"], "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", ["\u01AA", "\u01AB"], "\u01AD", "\u01B0", "\u01B4", "\u01B6", ["\u01B9", "\u01BA"], ["\u01BD", "\u01BF"], "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", ["\u01DC", "\u01DD"], "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", ["\u01EF", "\u01F0"], "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", ["\u0233", "\u0239"], "\u023C", ["\u023F", "\u0240"], "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", ["\u024F", "\u0293"], ["\u0295", "\u02AF"], "\u0371", "\u0373", "\u0377", ["\u037B", "\u037D"], "\u0390", ["\u03AC", "\u03CE"], ["\u03D0", "\u03D1"], ["\u03D5", "\u03D7"], "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", ["\u03EF", "\u03F3"], "\u03F5", "\u03F8", ["\u03FB", "\u03FC"], ["\u0430", "\u045F"], "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", ["\u04CE", "\u04CF"], "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0525", "\u0527", "\u0529", "\u052B", "\u052D", "\u052F", ["\u0561", "\u0587"], ["\u13F8", "\u13FD"], ["\u1D00", "\u1D2B"], ["\u1D6B", "\u1D77"], ["\u1D79", "\u1D9A"], "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", ["\u1E95", "\u1E9D"], "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", ["\u1EFF", "\u1F07"], ["\u1F10", "\u1F15"], ["\u1F20", "\u1F27"], ["\u1F30", "\u1F37"], ["\u1F40", "\u1F45"], ["\u1F50", "\u1F57"], ["\u1F60", "\u1F67"], ["\u1F70", "\u1F7D"], ["\u1F80", "\u1F87"], ["\u1F90", "\u1F97"], ["\u1FA0", "\u1FA7"], ["\u1FB0", "\u1FB4"], ["\u1FB6", "\u1FB7"], "\u1FBE", ["\u1FC2", "\u1FC4"], ["\u1FC6", "\u1FC7"], ["\u1FD0", "\u1FD3"], ["\u1FD6", "\u1FD7"], ["\u1FE0", "\u1FE7"], ["\u1FF2", "\u1FF4"], ["\u1FF6", "\u1FF7"], "\u210A", ["\u210E", "\u210F"], "\u2113", "\u212F", "\u2134", "\u2139", ["\u213C", "\u213D"], ["\u2146", "\u2149"], "\u214E", "\u2184", ["\u2C30", "\u2C5E"], "\u2C61", ["\u2C65", "\u2C66"], "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", ["\u2C73", "\u2C74"], ["\u2C76", "\u2C7B"], "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", ["\u2CE3", "\u2CE4"], "\u2CEC", "\u2CEE", "\u2CF3", ["\u2D00", "\u2D25"], "\u2D27", "\u2D2D", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA661", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA699", "\uA69B", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", ["\uA72F", "\uA731"], "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", ["\uA771", "\uA778"], "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uA78E", "\uA791", ["\uA793", "\uA795"], "\uA797", "\uA799", "\uA79B", "\uA79D", "\uA79F", "\uA7A1", "\uA7A3", "\uA7A5", "\uA7A7", "\uA7A9", "\uA7B5", "\uA7B7", "\uA7FA", ["\uAB30", "\uAB5A"], ["\uAB60", "\uAB65"], ["\uAB70", "\uABBF"], ["\uFB00", "\uFB06"], ["\uFB13", "\uFB17"], ["\uFF41", "\uFF5A"]], false, false);
-  var peg$e63 = peg$classExpectation([["\u02B0", "\u02C1"], ["\u02C6", "\u02D1"], ["\u02E0", "\u02E4"], "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", ["\u06E5", "\u06E6"], ["\u07F4", "\u07F5"], "\u07FA", "\u081A", "\u0824", "\u0828", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1AA7", ["\u1C78", "\u1C7D"], ["\u1D2C", "\u1D6A"], "\u1D78", ["\u1D9B", "\u1DBF"], "\u2071", "\u207F", ["\u2090", "\u209C"], ["\u2C7C", "\u2C7D"], "\u2D6F", "\u2E2F", "\u3005", ["\u3031", "\u3035"], "\u303B", ["\u309D", "\u309E"], ["\u30FC", "\u30FE"], "\uA015", ["\uA4F8", "\uA4FD"], "\uA60C", "\uA67F", ["\uA69C", "\uA69D"], ["\uA717", "\uA71F"], "\uA770", "\uA788", ["\uA7F8", "\uA7F9"], "\uA9CF", "\uA9E6", "\uAA70", "\uAADD", ["\uAAF3", "\uAAF4"], ["\uAB5C", "\uAB5F"], "\uFF70", ["\uFF9E", "\uFF9F"]], false, false);
-  var peg$e64 = peg$classExpectation(["\xAA", "\xBA", "\u01BB", ["\u01C0", "\u01C3"], "\u0294", ["\u05D0", "\u05EA"], ["\u05F0", "\u05F2"], ["\u0620", "\u063F"], ["\u0641", "\u064A"], ["\u066E", "\u066F"], ["\u0671", "\u06D3"], "\u06D5", ["\u06EE", "\u06EF"], ["\u06FA", "\u06FC"], "\u06FF", "\u0710", ["\u0712", "\u072F"], ["\u074D", "\u07A5"], "\u07B1", ["\u07CA", "\u07EA"], ["\u0800", "\u0815"], ["\u0840", "\u0858"], ["\u08A0", "\u08B4"], ["\u0904", "\u0939"], "\u093D", "\u0950", ["\u0958", "\u0961"], ["\u0972", "\u0980"], ["\u0985", "\u098C"], ["\u098F", "\u0990"], ["\u0993", "\u09A8"], ["\u09AA", "\u09B0"], "\u09B2", ["\u09B6", "\u09B9"], "\u09BD", "\u09CE", ["\u09DC", "\u09DD"], ["\u09DF", "\u09E1"], ["\u09F0", "\u09F1"], ["\u0A05", "\u0A0A"], ["\u0A0F", "\u0A10"], ["\u0A13", "\u0A28"], ["\u0A2A", "\u0A30"], ["\u0A32", "\u0A33"], ["\u0A35", "\u0A36"], ["\u0A38", "\u0A39"], ["\u0A59", "\u0A5C"], "\u0A5E", ["\u0A72", "\u0A74"], ["\u0A85", "\u0A8D"], ["\u0A8F", "\u0A91"], ["\u0A93", "\u0AA8"], ["\u0AAA", "\u0AB0"], ["\u0AB2", "\u0AB3"], ["\u0AB5", "\u0AB9"], "\u0ABD", "\u0AD0", ["\u0AE0", "\u0AE1"], "\u0AF9", ["\u0B05", "\u0B0C"], ["\u0B0F", "\u0B10"], ["\u0B13", "\u0B28"], ["\u0B2A", "\u0B30"], ["\u0B32", "\u0B33"], ["\u0B35", "\u0B39"], "\u0B3D", ["\u0B5C", "\u0B5D"], ["\u0B5F", "\u0B61"], "\u0B71", "\u0B83", ["\u0B85", "\u0B8A"], ["\u0B8E", "\u0B90"], ["\u0B92", "\u0B95"], ["\u0B99", "\u0B9A"], "\u0B9C", ["\u0B9E", "\u0B9F"], ["\u0BA3", "\u0BA4"], ["\u0BA8", "\u0BAA"], ["\u0BAE", "\u0BB9"], "\u0BD0", ["\u0C05", "\u0C0C"], ["\u0C0E", "\u0C10"], ["\u0C12", "\u0C28"], ["\u0C2A", "\u0C39"], "\u0C3D", ["\u0C58", "\u0C5A"], ["\u0C60", "\u0C61"], ["\u0C85", "\u0C8C"], ["\u0C8E", "\u0C90"], ["\u0C92", "\u0CA8"], ["\u0CAA", "\u0CB3"], ["\u0CB5", "\u0CB9"], "\u0CBD", "\u0CDE", ["\u0CE0", "\u0CE1"], ["\u0CF1", "\u0CF2"], ["\u0D05", "\u0D0C"], ["\u0D0E", "\u0D10"], ["\u0D12", "\u0D3A"], "\u0D3D", "\u0D4E", ["\u0D5F", "\u0D61"], ["\u0D7A", "\u0D7F"], ["\u0D85", "\u0D96"], ["\u0D9A", "\u0DB1"], ["\u0DB3", "\u0DBB"], "\u0DBD", ["\u0DC0", "\u0DC6"], ["\u0E01", "\u0E30"], ["\u0E32", "\u0E33"], ["\u0E40", "\u0E45"], ["\u0E81", "\u0E82"], "\u0E84", ["\u0E87", "\u0E88"], "\u0E8A", "\u0E8D", ["\u0E94", "\u0E97"], ["\u0E99", "\u0E9F"], ["\u0EA1", "\u0EA3"], "\u0EA5", "\u0EA7", ["\u0EAA", "\u0EAB"], ["\u0EAD", "\u0EB0"], ["\u0EB2", "\u0EB3"], "\u0EBD", ["\u0EC0", "\u0EC4"], ["\u0EDC", "\u0EDF"], "\u0F00", ["\u0F40", "\u0F47"], ["\u0F49", "\u0F6C"], ["\u0F88", "\u0F8C"], ["\u1000", "\u102A"], "\u103F", ["\u1050", "\u1055"], ["\u105A", "\u105D"], "\u1061", ["\u1065", "\u1066"], ["\u106E", "\u1070"], ["\u1075", "\u1081"], "\u108E", ["\u10D0", "\u10FA"], ["\u10FD", "\u1248"], ["\u124A", "\u124D"], ["\u1250", "\u1256"], "\u1258", ["\u125A", "\u125D"], ["\u1260", "\u1288"], ["\u128A", "\u128D"], ["\u1290", "\u12B0"], ["\u12B2", "\u12B5"], ["\u12B8", "\u12BE"], "\u12C0", ["\u12C2", "\u12C5"], ["\u12C8", "\u12D6"], ["\u12D8", "\u1310"], ["\u1312", "\u1315"], ["\u1318", "\u135A"], ["\u1380", "\u138F"], ["\u1401", "\u166C"], ["\u166F", "\u167F"], ["\u1681", "\u169A"], ["\u16A0", "\u16EA"], ["\u16F1", "\u16F8"], ["\u1700", "\u170C"], ["\u170E", "\u1711"], ["\u1720", "\u1731"], ["\u1740", "\u1751"], ["\u1760", "\u176C"], ["\u176E", "\u1770"], ["\u1780", "\u17B3"], "\u17DC", ["\u1820", "\u1842"], ["\u1844", "\u1877"], ["\u1880", "\u18A8"], "\u18AA", ["\u18B0", "\u18F5"], ["\u1900", "\u191E"], ["\u1950", "\u196D"], ["\u1970", "\u1974"], ["\u1980", "\u19AB"], ["\u19B0", "\u19C9"], ["\u1A00", "\u1A16"], ["\u1A20", "\u1A54"], ["\u1B05", "\u1B33"], ["\u1B45", "\u1B4B"], ["\u1B83", "\u1BA0"], ["\u1BAE", "\u1BAF"], ["\u1BBA", "\u1BE5"], ["\u1C00", "\u1C23"], ["\u1C4D", "\u1C4F"], ["\u1C5A", "\u1C77"], ["\u1CE9", "\u1CEC"], ["\u1CEE", "\u1CF1"], ["\u1CF5", "\u1CF6"], ["\u2135", "\u2138"], ["\u2D30", "\u2D67"], ["\u2D80", "\u2D96"], ["\u2DA0", "\u2DA6"], ["\u2DA8", "\u2DAE"], ["\u2DB0", "\u2DB6"], ["\u2DB8", "\u2DBE"], ["\u2DC0", "\u2DC6"], ["\u2DC8", "\u2DCE"], ["\u2DD0", "\u2DD6"], ["\u2DD8", "\u2DDE"], "\u3006", "\u303C", ["\u3041", "\u3096"], "\u309F", ["\u30A1", "\u30FA"], "\u30FF", ["\u3105", "\u312D"], ["\u3131", "\u318E"], ["\u31A0", "\u31BA"], ["\u31F0", "\u31FF"], ["\u3400", "\u4DB5"], ["\u4E00", "\u9FD5"], ["\uA000", "\uA014"], ["\uA016", "\uA48C"], ["\uA4D0", "\uA4F7"], ["\uA500", "\uA60B"], ["\uA610", "\uA61F"], ["\uA62A", "\uA62B"], "\uA66E", ["\uA6A0", "\uA6E5"], "\uA78F", "\uA7F7", ["\uA7FB", "\uA801"], ["\uA803", "\uA805"], ["\uA807", "\uA80A"], ["\uA80C", "\uA822"], ["\uA840", "\uA873"], ["\uA882", "\uA8B3"], ["\uA8F2", "\uA8F7"], "\uA8FB", "\uA8FD", ["\uA90A", "\uA925"], ["\uA930", "\uA946"], ["\uA960", "\uA97C"], ["\uA984", "\uA9B2"], ["\uA9E0", "\uA9E4"], ["\uA9E7", "\uA9EF"], ["\uA9FA", "\uA9FE"], ["\uAA00", "\uAA28"], ["\uAA40", "\uAA42"], ["\uAA44", "\uAA4B"], ["\uAA60", "\uAA6F"], ["\uAA71", "\uAA76"], "\uAA7A", ["\uAA7E", "\uAAAF"], "\uAAB1", ["\uAAB5", "\uAAB6"], ["\uAAB9", "\uAABD"], "\uAAC0", "\uAAC2", ["\uAADB", "\uAADC"], ["\uAAE0", "\uAAEA"], "\uAAF2", ["\uAB01", "\uAB06"], ["\uAB09", "\uAB0E"], ["\uAB11", "\uAB16"], ["\uAB20", "\uAB26"], ["\uAB28", "\uAB2E"], ["\uABC0", "\uABE2"], ["\uAC00", "\uD7A3"], ["\uD7B0", "\uD7C6"], ["\uD7CB", "\uD7FB"], ["\uF900", "\uFA6D"], ["\uFA70", "\uFAD9"], "\uFB1D", ["\uFB1F", "\uFB28"], ["\uFB2A", "\uFB36"], ["\uFB38", "\uFB3C"], "\uFB3E", ["\uFB40", "\uFB41"], ["\uFB43", "\uFB44"], ["\uFB46", "\uFBB1"], ["\uFBD3", "\uFD3D"], ["\uFD50", "\uFD8F"], ["\uFD92", "\uFDC7"], ["\uFDF0", "\uFDFB"], ["\uFE70", "\uFE74"], ["\uFE76", "\uFEFC"], ["\uFF66", "\uFF6F"], ["\uFF71", "\uFF9D"], ["\uFFA0", "\uFFBE"], ["\uFFC2", "\uFFC7"], ["\uFFCA", "\uFFCF"], ["\uFFD2", "\uFFD7"], ["\uFFDA", "\uFFDC"]], false, false);
-  var peg$e65 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", ["\u1F88", "\u1F8F"], ["\u1F98", "\u1F9F"], ["\u1FA8", "\u1FAF"], "\u1FBC", "\u1FCC", "\u1FFC"], false, false);
-  var peg$e66 = peg$classExpectation([["A", "Z"], ["\xC0", "\xD6"], ["\xD8", "\xDE"], "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", ["\u0178", "\u0179"], "\u017B", "\u017D", ["\u0181", "\u0182"], "\u0184", ["\u0186", "\u0187"], ["\u0189", "\u018B"], ["\u018E", "\u0191"], ["\u0193", "\u0194"], ["\u0196", "\u0198"], ["\u019C", "\u019D"], ["\u019F", "\u01A0"], "\u01A2", "\u01A4", ["\u01A6", "\u01A7"], "\u01A9", "\u01AC", ["\u01AE", "\u01AF"], ["\u01B1", "\u01B3"], "\u01B5", ["\u01B7", "\u01B8"], "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", ["\u01F6", "\u01F8"], "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", ["\u023A", "\u023B"], ["\u023D", "\u023E"], "\u0241", ["\u0243", "\u0246"], "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u037F", "\u0386", ["\u0388", "\u038A"], "\u038C", ["\u038E", "\u038F"], ["\u0391", "\u03A1"], ["\u03A3", "\u03AB"], "\u03CF", ["\u03D2", "\u03D4"], "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", ["\u03F9", "\u03FA"], ["\u03FD", "\u042F"], "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", ["\u04C0", "\u04C1"], "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0524", "\u0526", "\u0528", "\u052A", "\u052C", "\u052E", ["\u0531", "\u0556"], ["\u10A0", "\u10C5"], "\u10C7", "\u10CD", ["\u13A0", "\u13F5"], "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", ["\u1F08", "\u1F0F"], ["\u1F18", "\u1F1D"], ["\u1F28", "\u1F2F"], ["\u1F38", "\u1F3F"], ["\u1F48", "\u1F4D"], "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", ["\u1F68", "\u1F6F"], ["\u1FB8", "\u1FBB"], ["\u1FC8", "\u1FCB"], ["\u1FD8", "\u1FDB"], ["\u1FE8", "\u1FEC"], ["\u1FF8", "\u1FFB"], "\u2102", "\u2107", ["\u210B", "\u210D"], ["\u2110", "\u2112"], "\u2115", ["\u2119", "\u211D"], "\u2124", "\u2126", "\u2128", ["\u212A", "\u212D"], ["\u2130", "\u2133"], ["\u213E", "\u213F"], "\u2145", "\u2183", ["\u2C00", "\u2C2E"], "\u2C60", ["\u2C62", "\u2C64"], "\u2C67", "\u2C69", "\u2C6B", ["\u2C6D", "\u2C70"], "\u2C72", "\u2C75", ["\u2C7E", "\u2C80"], "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\u2CEB", "\u2CED", "\u2CF2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA660", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA698", "\uA69A", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", ["\uA77D", "\uA77E"], "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uA78D", "\uA790", "\uA792", "\uA796", "\uA798", "\uA79A", "\uA79C", "\uA79E", "\uA7A0", "\uA7A2", "\uA7A4", "\uA7A6", "\uA7A8", ["\uA7AA", "\uA7AD"], ["\uA7B0", "\uA7B4"], "\uA7B6", ["\uFF21", "\uFF3A"]], false, false);
-  var peg$e67 = peg$classExpectation(["\u0903", "\u093B", ["\u093E", "\u0940"], ["\u0949", "\u094C"], ["\u094E", "\u094F"], ["\u0982", "\u0983"], ["\u09BE", "\u09C0"], ["\u09C7", "\u09C8"], ["\u09CB", "\u09CC"], "\u09D7", "\u0A03", ["\u0A3E", "\u0A40"], "\u0A83", ["\u0ABE", "\u0AC0"], "\u0AC9", ["\u0ACB", "\u0ACC"], ["\u0B02", "\u0B03"], "\u0B3E", "\u0B40", ["\u0B47", "\u0B48"], ["\u0B4B", "\u0B4C"], "\u0B57", ["\u0BBE", "\u0BBF"], ["\u0BC1", "\u0BC2"], ["\u0BC6", "\u0BC8"], ["\u0BCA", "\u0BCC"], "\u0BD7", ["\u0C01", "\u0C03"], ["\u0C41", "\u0C44"], ["\u0C82", "\u0C83"], "\u0CBE", ["\u0CC0", "\u0CC4"], ["\u0CC7", "\u0CC8"], ["\u0CCA", "\u0CCB"], ["\u0CD5", "\u0CD6"], ["\u0D02", "\u0D03"], ["\u0D3E", "\u0D40"], ["\u0D46", "\u0D48"], ["\u0D4A", "\u0D4C"], "\u0D57", ["\u0D82", "\u0D83"], ["\u0DCF", "\u0DD1"], ["\u0DD8", "\u0DDF"], ["\u0DF2", "\u0DF3"], ["\u0F3E", "\u0F3F"], "\u0F7F", ["\u102B", "\u102C"], "\u1031", "\u1038", ["\u103B", "\u103C"], ["\u1056", "\u1057"], ["\u1062", "\u1064"], ["\u1067", "\u106D"], ["\u1083", "\u1084"], ["\u1087", "\u108C"], "\u108F", ["\u109A", "\u109C"], "\u17B6", ["\u17BE", "\u17C5"], ["\u17C7", "\u17C8"], ["\u1923", "\u1926"], ["\u1929", "\u192B"], ["\u1930", "\u1931"], ["\u1933", "\u1938"], ["\u1A19", "\u1A1A"], "\u1A55", "\u1A57", "\u1A61", ["\u1A63", "\u1A64"], ["\u1A6D", "\u1A72"], "\u1B04", "\u1B35", "\u1B3B", ["\u1B3D", "\u1B41"], ["\u1B43", "\u1B44"], "\u1B82", "\u1BA1", ["\u1BA6", "\u1BA7"], "\u1BAA", "\u1BE7", ["\u1BEA", "\u1BEC"], "\u1BEE", ["\u1BF2", "\u1BF3"], ["\u1C24", "\u1C2B"], ["\u1C34", "\u1C35"], "\u1CE1", ["\u1CF2", "\u1CF3"], ["\u302E", "\u302F"], ["\uA823", "\uA824"], "\uA827", ["\uA880", "\uA881"], ["\uA8B4", "\uA8C3"], ["\uA952", "\uA953"], "\uA983", ["\uA9B4", "\uA9B5"], ["\uA9BA", "\uA9BB"], ["\uA9BD", "\uA9C0"], ["\uAA2F", "\uAA30"], ["\uAA33", "\uAA34"], "\uAA4D", "\uAA7B", "\uAA7D", "\uAAEB", ["\uAAEE", "\uAAEF"], "\uAAF5", ["\uABE3", "\uABE4"], ["\uABE6", "\uABE7"], ["\uABE9", "\uABEA"], "\uABEC"], false, false);
-  var peg$e68 = peg$classExpectation([["\u0300", "\u036F"], ["\u0483", "\u0487"], ["\u0591", "\u05BD"], "\u05BF", ["\u05C1", "\u05C2"], ["\u05C4", "\u05C5"], "\u05C7", ["\u0610", "\u061A"], ["\u064B", "\u065F"], "\u0670", ["\u06D6", "\u06DC"], ["\u06DF", "\u06E4"], ["\u06E7", "\u06E8"], ["\u06EA", "\u06ED"], "\u0711", ["\u0730", "\u074A"], ["\u07A6", "\u07B0"], ["\u07EB", "\u07F3"], ["\u0816", "\u0819"], ["\u081B", "\u0823"], ["\u0825", "\u0827"], ["\u0829", "\u082D"], ["\u0859", "\u085B"], ["\u08E3", "\u0902"], "\u093A", "\u093C", ["\u0941", "\u0948"], "\u094D", ["\u0951", "\u0957"], ["\u0962", "\u0963"], "\u0981", "\u09BC", ["\u09C1", "\u09C4"], "\u09CD", ["\u09E2", "\u09E3"], ["\u0A01", "\u0A02"], "\u0A3C", ["\u0A41", "\u0A42"], ["\u0A47", "\u0A48"], ["\u0A4B", "\u0A4D"], "\u0A51", ["\u0A70", "\u0A71"], "\u0A75", ["\u0A81", "\u0A82"], "\u0ABC", ["\u0AC1", "\u0AC5"], ["\u0AC7", "\u0AC8"], "\u0ACD", ["\u0AE2", "\u0AE3"], "\u0B01", "\u0B3C", "\u0B3F", ["\u0B41", "\u0B44"], "\u0B4D", "\u0B56", ["\u0B62", "\u0B63"], "\u0B82", "\u0BC0", "\u0BCD", "\u0C00", ["\u0C3E", "\u0C40"], ["\u0C46", "\u0C48"], ["\u0C4A", "\u0C4D"], ["\u0C55", "\u0C56"], ["\u0C62", "\u0C63"], "\u0C81", "\u0CBC", "\u0CBF", "\u0CC6", ["\u0CCC", "\u0CCD"], ["\u0CE2", "\u0CE3"], "\u0D01", ["\u0D41", "\u0D44"], "\u0D4D", ["\u0D62", "\u0D63"], "\u0DCA", ["\u0DD2", "\u0DD4"], "\u0DD6", "\u0E31", ["\u0E34", "\u0E3A"], ["\u0E47", "\u0E4E"], "\u0EB1", ["\u0EB4", "\u0EB9"], ["\u0EBB", "\u0EBC"], ["\u0EC8", "\u0ECD"], ["\u0F18", "\u0F19"], "\u0F35", "\u0F37", "\u0F39", ["\u0F71", "\u0F7E"], ["\u0F80", "\u0F84"], ["\u0F86", "\u0F87"], ["\u0F8D", "\u0F97"], ["\u0F99", "\u0FBC"], "\u0FC6", ["\u102D", "\u1030"], ["\u1032", "\u1037"], ["\u1039", "\u103A"], ["\u103D", "\u103E"], ["\u1058", "\u1059"], ["\u105E", "\u1060"], ["\u1071", "\u1074"], "\u1082", ["\u1085", "\u1086"], "\u108D", "\u109D", ["\u135D", "\u135F"], ["\u1712", "\u1714"], ["\u1732", "\u1734"], ["\u1752", "\u1753"], ["\u1772", "\u1773"], ["\u17B4", "\u17B5"], ["\u17B7", "\u17BD"], "\u17C6", ["\u17C9", "\u17D3"], "\u17DD", ["\u180B", "\u180D"], "\u18A9", ["\u1920", "\u1922"], ["\u1927", "\u1928"], "\u1932", ["\u1939", "\u193B"], ["\u1A17", "\u1A18"], "\u1A1B", "\u1A56", ["\u1A58", "\u1A5E"], "\u1A60", "\u1A62", ["\u1A65", "\u1A6C"], ["\u1A73", "\u1A7C"], "\u1A7F", ["\u1AB0", "\u1ABD"], ["\u1B00", "\u1B03"], "\u1B34", ["\u1B36", "\u1B3A"], "\u1B3C", "\u1B42", ["\u1B6B", "\u1B73"], ["\u1B80", "\u1B81"], ["\u1BA2", "\u1BA5"], ["\u1BA8", "\u1BA9"], ["\u1BAB", "\u1BAD"], "\u1BE6", ["\u1BE8", "\u1BE9"], "\u1BED", ["\u1BEF", "\u1BF1"], ["\u1C2C", "\u1C33"], ["\u1C36", "\u1C37"], ["\u1CD0", "\u1CD2"], ["\u1CD4", "\u1CE0"], ["\u1CE2", "\u1CE8"], "\u1CED", "\u1CF4", ["\u1CF8", "\u1CF9"], ["\u1DC0", "\u1DF5"], ["\u1DFC", "\u1DFF"], ["\u20D0", "\u20DC"], "\u20E1", ["\u20E5", "\u20F0"], ["\u2CEF", "\u2CF1"], "\u2D7F", ["\u2DE0", "\u2DFF"], ["\u302A", "\u302D"], ["\u3099", "\u309A"], "\uA66F", ["\uA674", "\uA67D"], ["\uA69E", "\uA69F"], ["\uA6F0", "\uA6F1"], "\uA802", "\uA806", "\uA80B", ["\uA825", "\uA826"], "\uA8C4", ["\uA8E0", "\uA8F1"], ["\uA926", "\uA92D"], ["\uA947", "\uA951"], ["\uA980", "\uA982"], "\uA9B3", ["\uA9B6", "\uA9B9"], "\uA9BC", "\uA9E5", ["\uAA29", "\uAA2E"], ["\uAA31", "\uAA32"], ["\uAA35", "\uAA36"], "\uAA43", "\uAA4C", "\uAA7C", "\uAAB0", ["\uAAB2", "\uAAB4"], ["\uAAB7", "\uAAB8"], ["\uAABE", "\uAABF"], "\uAAC1", ["\uAAEC", "\uAAED"], "\uAAF6", "\uABE5", "\uABE8", "\uABED", "\uFB1E", ["\uFE00", "\uFE0F"], ["\uFE20", "\uFE2F"]], false, false);
-  var peg$e69 = peg$classExpectation([["0", "9"], ["\u0660", "\u0669"], ["\u06F0", "\u06F9"], ["\u07C0", "\u07C9"], ["\u0966", "\u096F"], ["\u09E6", "\u09EF"], ["\u0A66", "\u0A6F"], ["\u0AE6", "\u0AEF"], ["\u0B66", "\u0B6F"], ["\u0BE6", "\u0BEF"], ["\u0C66", "\u0C6F"], ["\u0CE6", "\u0CEF"], ["\u0D66", "\u0D6F"], ["\u0DE6", "\u0DEF"], ["\u0E50", "\u0E59"], ["\u0ED0", "\u0ED9"], ["\u0F20", "\u0F29"], ["\u1040", "\u1049"], ["\u1090", "\u1099"], ["\u17E0", "\u17E9"], ["\u1810", "\u1819"], ["\u1946", "\u194F"], ["\u19D0", "\u19D9"], ["\u1A80", "\u1A89"], ["\u1A90", "\u1A99"], ["\u1B50", "\u1B59"], ["\u1BB0", "\u1BB9"], ["\u1C40", "\u1C49"], ["\u1C50", "\u1C59"], ["\uA620", "\uA629"], ["\uA8D0", "\uA8D9"], ["\uA900", "\uA909"], ["\uA9D0", "\uA9D9"], ["\uA9F0", "\uA9F9"], ["\uAA50", "\uAA59"], ["\uABF0", "\uABF9"], ["\uFF10", "\uFF19"]], false, false);
-  var peg$e70 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false);
-  var peg$e71 = peg$classExpectation(["_", ["\u203F", "\u2040"], "\u2054", ["\uFE33", "\uFE34"], ["\uFE4D", "\uFE4F"], "\uFF3F"], false, false);
-  var peg$e72 = peg$classExpectation([" ", "\xA0", "\u1680", ["\u2000", "\u200A"], "\u202F", "\u205F", "\u3000"], false, false);
-  var peg$e73 = peg$literalExpectation(";", false);
+  var peg$e12 = peg$literalExpectation("|", false);
+  var peg$e13 = peg$literalExpectation("..", false);
+  var peg$e14 = peg$literalExpectation("(", false);
+  var peg$e15 = peg$literalExpectation(")", false);
+  var peg$e16 = peg$anyExpectation();
+  var peg$e17 = peg$otherExpectation("whitespace");
+  var peg$e18 = peg$literalExpectation("\t", false);
+  var peg$e19 = peg$literalExpectation("\v", false);
+  var peg$e20 = peg$literalExpectation("\f", false);
+  var peg$e21 = peg$literalExpectation(" ", false);
+  var peg$e22 = peg$literalExpectation("\xA0", false);
+  var peg$e23 = peg$literalExpectation("\uFEFF", false);
+  var peg$e24 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false);
+  var peg$e25 = peg$otherExpectation("end of line");
+  var peg$e26 = peg$literalExpectation("\n", false);
+  var peg$e27 = peg$literalExpectation("\r\n", false);
+  var peg$e28 = peg$literalExpectation("\r", false);
+  var peg$e29 = peg$literalExpectation("\u2028", false);
+  var peg$e30 = peg$literalExpectation("\u2029", false);
+  var peg$e31 = peg$otherExpectation("comment");
+  var peg$e32 = peg$literalExpectation("/*", false);
+  var peg$e33 = peg$literalExpectation("*/", false);
+  var peg$e34 = peg$literalExpectation("//", false);
+  var peg$e35 = peg$otherExpectation("identifier");
+  var peg$e36 = peg$literalExpectation("_", false);
+  var peg$e37 = peg$literalExpectation("\\", false);
+  var peg$e38 = peg$literalExpectation("\u200C", false);
+  var peg$e39 = peg$literalExpectation("\u200D", false);
+  var peg$e40 = peg$otherExpectation("literal");
+  var peg$e41 = peg$literalExpectation("i", false);
+  var peg$e42 = peg$otherExpectation("string");
+  var peg$e43 = peg$literalExpectation("\"", false);
+  var peg$e44 = peg$literalExpectation("'", false);
+  var peg$e45 = peg$otherExpectation("character class");
+  var peg$e46 = peg$literalExpectation("[", false);
+  var peg$e47 = peg$literalExpectation("^", false);
+  var peg$e48 = peg$literalExpectation("]", false);
+  var peg$e49 = peg$literalExpectation("-", false);
+  var peg$e50 = peg$literalExpectation("0", false);
+  var peg$e51 = peg$literalExpectation("b", false);
+  var peg$e52 = peg$literalExpectation("f", false);
+  var peg$e53 = peg$literalExpectation("n", false);
+  var peg$e54 = peg$literalExpectation("r", false);
+  var peg$e55 = peg$literalExpectation("t", false);
+  var peg$e56 = peg$literalExpectation("v", false);
+  var peg$e57 = peg$literalExpectation("x", false);
+  var peg$e58 = peg$literalExpectation("u", false);
+  var peg$e59 = peg$classExpectation([["0", "9"]], false, false);
+  var peg$e60 = peg$classExpectation([["0", "9"], ["a", "f"]], false, true);
+  var peg$e61 = peg$literalExpectation(".", false);
+  var peg$e62 = peg$otherExpectation("code block");
+  var peg$e63 = peg$classExpectation(["{", "}"], false, false);
+  var peg$e64 = peg$classExpectation([["a", "z"], "\xB5", ["\xDF", "\xF6"], ["\xF8", "\xFF"], "\u0101", "\u0103", "\u0105", "\u0107", "\u0109", "\u010B", "\u010D", "\u010F", "\u0111", "\u0113", "\u0115", "\u0117", "\u0119", "\u011B", "\u011D", "\u011F", "\u0121", "\u0123", "\u0125", "\u0127", "\u0129", "\u012B", "\u012D", "\u012F", "\u0131", "\u0133", "\u0135", ["\u0137", "\u0138"], "\u013A", "\u013C", "\u013E", "\u0140", "\u0142", "\u0144", "\u0146", ["\u0148", "\u0149"], "\u014B", "\u014D", "\u014F", "\u0151", "\u0153", "\u0155", "\u0157", "\u0159", "\u015B", "\u015D", "\u015F", "\u0161", "\u0163", "\u0165", "\u0167", "\u0169", "\u016B", "\u016D", "\u016F", "\u0171", "\u0173", "\u0175", "\u0177", "\u017A", "\u017C", ["\u017E", "\u0180"], "\u0183", "\u0185", "\u0188", ["\u018C", "\u018D"], "\u0192", "\u0195", ["\u0199", "\u019B"], "\u019E", "\u01A1", "\u01A3", "\u01A5", "\u01A8", ["\u01AA", "\u01AB"], "\u01AD", "\u01B0", "\u01B4", "\u01B6", ["\u01B9", "\u01BA"], ["\u01BD", "\u01BF"], "\u01C6", "\u01C9", "\u01CC", "\u01CE", "\u01D0", "\u01D2", "\u01D4", "\u01D6", "\u01D8", "\u01DA", ["\u01DC", "\u01DD"], "\u01DF", "\u01E1", "\u01E3", "\u01E5", "\u01E7", "\u01E9", "\u01EB", "\u01ED", ["\u01EF", "\u01F0"], "\u01F3", "\u01F5", "\u01F9", "\u01FB", "\u01FD", "\u01FF", "\u0201", "\u0203", "\u0205", "\u0207", "\u0209", "\u020B", "\u020D", "\u020F", "\u0211", "\u0213", "\u0215", "\u0217", "\u0219", "\u021B", "\u021D", "\u021F", "\u0221", "\u0223", "\u0225", "\u0227", "\u0229", "\u022B", "\u022D", "\u022F", "\u0231", ["\u0233", "\u0239"], "\u023C", ["\u023F", "\u0240"], "\u0242", "\u0247", "\u0249", "\u024B", "\u024D", ["\u024F", "\u0293"], ["\u0295", "\u02AF"], "\u0371", "\u0373", "\u0377", ["\u037B", "\u037D"], "\u0390", ["\u03AC", "\u03CE"], ["\u03D0", "\u03D1"], ["\u03D5", "\u03D7"], "\u03D9", "\u03DB", "\u03DD", "\u03DF", "\u03E1", "\u03E3", "\u03E5", "\u03E7", "\u03E9", "\u03EB", "\u03ED", ["\u03EF", "\u03F3"], "\u03F5", "\u03F8", ["\u03FB", "\u03FC"], ["\u0430", "\u045F"], "\u0461", "\u0463", "\u0465", "\u0467", "\u0469", "\u046B", "\u046D", "\u046F", "\u0471", "\u0473", "\u0475", "\u0477", "\u0479", "\u047B", "\u047D", "\u047F", "\u0481", "\u048B", "\u048D", "\u048F", "\u0491", "\u0493", "\u0495", "\u0497", "\u0499", "\u049B", "\u049D", "\u049F", "\u04A1", "\u04A3", "\u04A5", "\u04A7", "\u04A9", "\u04AB", "\u04AD", "\u04AF", "\u04B1", "\u04B3", "\u04B5", "\u04B7", "\u04B9", "\u04BB", "\u04BD", "\u04BF", "\u04C2", "\u04C4", "\u04C6", "\u04C8", "\u04CA", "\u04CC", ["\u04CE", "\u04CF"], "\u04D1", "\u04D3", "\u04D5", "\u04D7", "\u04D9", "\u04DB", "\u04DD", "\u04DF", "\u04E1", "\u04E3", "\u04E5", "\u04E7", "\u04E9", "\u04EB", "\u04ED", "\u04EF", "\u04F1", "\u04F3", "\u04F5", "\u04F7", "\u04F9", "\u04FB", "\u04FD", "\u04FF", "\u0501", "\u0503", "\u0505", "\u0507", "\u0509", "\u050B", "\u050D", "\u050F", "\u0511", "\u0513", "\u0515", "\u0517", "\u0519", "\u051B", "\u051D", "\u051F", "\u0521", "\u0523", "\u0525", "\u0527", "\u0529", "\u052B", "\u052D", "\u052F", ["\u0561", "\u0587"], ["\u13F8", "\u13FD"], ["\u1D00", "\u1D2B"], ["\u1D6B", "\u1D77"], ["\u1D79", "\u1D9A"], "\u1E01", "\u1E03", "\u1E05", "\u1E07", "\u1E09", "\u1E0B", "\u1E0D", "\u1E0F", "\u1E11", "\u1E13", "\u1E15", "\u1E17", "\u1E19", "\u1E1B", "\u1E1D", "\u1E1F", "\u1E21", "\u1E23", "\u1E25", "\u1E27", "\u1E29", "\u1E2B", "\u1E2D", "\u1E2F", "\u1E31", "\u1E33", "\u1E35", "\u1E37", "\u1E39", "\u1E3B", "\u1E3D", "\u1E3F", "\u1E41", "\u1E43", "\u1E45", "\u1E47", "\u1E49", "\u1E4B", "\u1E4D", "\u1E4F", "\u1E51", "\u1E53", "\u1E55", "\u1E57", "\u1E59", "\u1E5B", "\u1E5D", "\u1E5F", "\u1E61", "\u1E63", "\u1E65", "\u1E67", "\u1E69", "\u1E6B", "\u1E6D", "\u1E6F", "\u1E71", "\u1E73", "\u1E75", "\u1E77", "\u1E79", "\u1E7B", "\u1E7D", "\u1E7F", "\u1E81", "\u1E83", "\u1E85", "\u1E87", "\u1E89", "\u1E8B", "\u1E8D", "\u1E8F", "\u1E91", "\u1E93", ["\u1E95", "\u1E9D"], "\u1E9F", "\u1EA1", "\u1EA3", "\u1EA5", "\u1EA7", "\u1EA9", "\u1EAB", "\u1EAD", "\u1EAF", "\u1EB1", "\u1EB3", "\u1EB5", "\u1EB7", "\u1EB9", "\u1EBB", "\u1EBD", "\u1EBF", "\u1EC1", "\u1EC3", "\u1EC5", "\u1EC7", "\u1EC9", "\u1ECB", "\u1ECD", "\u1ECF", "\u1ED1", "\u1ED3", "\u1ED5", "\u1ED7", "\u1ED9", "\u1EDB", "\u1EDD", "\u1EDF", "\u1EE1", "\u1EE3", "\u1EE5", "\u1EE7", "\u1EE9", "\u1EEB", "\u1EED", "\u1EEF", "\u1EF1", "\u1EF3", "\u1EF5", "\u1EF7", "\u1EF9", "\u1EFB", "\u1EFD", ["\u1EFF", "\u1F07"], ["\u1F10", "\u1F15"], ["\u1F20", "\u1F27"], ["\u1F30", "\u1F37"], ["\u1F40", "\u1F45"], ["\u1F50", "\u1F57"], ["\u1F60", "\u1F67"], ["\u1F70", "\u1F7D"], ["\u1F80", "\u1F87"], ["\u1F90", "\u1F97"], ["\u1FA0", "\u1FA7"], ["\u1FB0", "\u1FB4"], ["\u1FB6", "\u1FB7"], "\u1FBE", ["\u1FC2", "\u1FC4"], ["\u1FC6", "\u1FC7"], ["\u1FD0", "\u1FD3"], ["\u1FD6", "\u1FD7"], ["\u1FE0", "\u1FE7"], ["\u1FF2", "\u1FF4"], ["\u1FF6", "\u1FF7"], "\u210A", ["\u210E", "\u210F"], "\u2113", "\u212F", "\u2134", "\u2139", ["\u213C", "\u213D"], ["\u2146", "\u2149"], "\u214E", "\u2184", ["\u2C30", "\u2C5E"], "\u2C61", ["\u2C65", "\u2C66"], "\u2C68", "\u2C6A", "\u2C6C", "\u2C71", ["\u2C73", "\u2C74"], ["\u2C76", "\u2C7B"], "\u2C81", "\u2C83", "\u2C85", "\u2C87", "\u2C89", "\u2C8B", "\u2C8D", "\u2C8F", "\u2C91", "\u2C93", "\u2C95", "\u2C97", "\u2C99", "\u2C9B", "\u2C9D", "\u2C9F", "\u2CA1", "\u2CA3", "\u2CA5", "\u2CA7", "\u2CA9", "\u2CAB", "\u2CAD", "\u2CAF", "\u2CB1", "\u2CB3", "\u2CB5", "\u2CB7", "\u2CB9", "\u2CBB", "\u2CBD", "\u2CBF", "\u2CC1", "\u2CC3", "\u2CC5", "\u2CC7", "\u2CC9", "\u2CCB", "\u2CCD", "\u2CCF", "\u2CD1", "\u2CD3", "\u2CD5", "\u2CD7", "\u2CD9", "\u2CDB", "\u2CDD", "\u2CDF", "\u2CE1", ["\u2CE3", "\u2CE4"], "\u2CEC", "\u2CEE", "\u2CF3", ["\u2D00", "\u2D25"], "\u2D27", "\u2D2D", "\uA641", "\uA643", "\uA645", "\uA647", "\uA649", "\uA64B", "\uA64D", "\uA64F", "\uA651", "\uA653", "\uA655", "\uA657", "\uA659", "\uA65B", "\uA65D", "\uA65F", "\uA661", "\uA663", "\uA665", "\uA667", "\uA669", "\uA66B", "\uA66D", "\uA681", "\uA683", "\uA685", "\uA687", "\uA689", "\uA68B", "\uA68D", "\uA68F", "\uA691", "\uA693", "\uA695", "\uA697", "\uA699", "\uA69B", "\uA723", "\uA725", "\uA727", "\uA729", "\uA72B", "\uA72D", ["\uA72F", "\uA731"], "\uA733", "\uA735", "\uA737", "\uA739", "\uA73B", "\uA73D", "\uA73F", "\uA741", "\uA743", "\uA745", "\uA747", "\uA749", "\uA74B", "\uA74D", "\uA74F", "\uA751", "\uA753", "\uA755", "\uA757", "\uA759", "\uA75B", "\uA75D", "\uA75F", "\uA761", "\uA763", "\uA765", "\uA767", "\uA769", "\uA76B", "\uA76D", "\uA76F", ["\uA771", "\uA778"], "\uA77A", "\uA77C", "\uA77F", "\uA781", "\uA783", "\uA785", "\uA787", "\uA78C", "\uA78E", "\uA791", ["\uA793", "\uA795"], "\uA797", "\uA799", "\uA79B", "\uA79D", "\uA79F", "\uA7A1", "\uA7A3", "\uA7A5", "\uA7A7", "\uA7A9", "\uA7B5", "\uA7B7", "\uA7FA", ["\uAB30", "\uAB5A"], ["\uAB60", "\uAB65"], ["\uAB70", "\uABBF"], ["\uFB00", "\uFB06"], ["\uFB13", "\uFB17"], ["\uFF41", "\uFF5A"]], false, false);
+  var peg$e65 = peg$classExpectation([["\u02B0", "\u02C1"], ["\u02C6", "\u02D1"], ["\u02E0", "\u02E4"], "\u02EC", "\u02EE", "\u0374", "\u037A", "\u0559", "\u0640", ["\u06E5", "\u06E6"], ["\u07F4", "\u07F5"], "\u07FA", "\u081A", "\u0824", "\u0828", "\u0971", "\u0E46", "\u0EC6", "\u10FC", "\u17D7", "\u1843", "\u1AA7", ["\u1C78", "\u1C7D"], ["\u1D2C", "\u1D6A"], "\u1D78", ["\u1D9B", "\u1DBF"], "\u2071", "\u207F", ["\u2090", "\u209C"], ["\u2C7C", "\u2C7D"], "\u2D6F", "\u2E2F", "\u3005", ["\u3031", "\u3035"], "\u303B", ["\u309D", "\u309E"], ["\u30FC", "\u30FE"], "\uA015", ["\uA4F8", "\uA4FD"], "\uA60C", "\uA67F", ["\uA69C", "\uA69D"], ["\uA717", "\uA71F"], "\uA770", "\uA788", ["\uA7F8", "\uA7F9"], "\uA9CF", "\uA9E6", "\uAA70", "\uAADD", ["\uAAF3", "\uAAF4"], ["\uAB5C", "\uAB5F"], "\uFF70", ["\uFF9E", "\uFF9F"]], false, false);
+  var peg$e66 = peg$classExpectation(["\xAA", "\xBA", "\u01BB", ["\u01C0", "\u01C3"], "\u0294", ["\u05D0", "\u05EA"], ["\u05F0", "\u05F2"], ["\u0620", "\u063F"], ["\u0641", "\u064A"], ["\u066E", "\u066F"], ["\u0671", "\u06D3"], "\u06D5", ["\u06EE", "\u06EF"], ["\u06FA", "\u06FC"], "\u06FF", "\u0710", ["\u0712", "\u072F"], ["\u074D", "\u07A5"], "\u07B1", ["\u07CA", "\u07EA"], ["\u0800", "\u0815"], ["\u0840", "\u0858"], ["\u08A0", "\u08B4"], ["\u0904", "\u0939"], "\u093D", "\u0950", ["\u0958", "\u0961"], ["\u0972", "\u0980"], ["\u0985", "\u098C"], ["\u098F", "\u0990"], ["\u0993", "\u09A8"], ["\u09AA", "\u09B0"], "\u09B2", ["\u09B6", "\u09B9"], "\u09BD", "\u09CE", ["\u09DC", "\u09DD"], ["\u09DF", "\u09E1"], ["\u09F0", "\u09F1"], ["\u0A05", "\u0A0A"], ["\u0A0F", "\u0A10"], ["\u0A13", "\u0A28"], ["\u0A2A", "\u0A30"], ["\u0A32", "\u0A33"], ["\u0A35", "\u0A36"], ["\u0A38", "\u0A39"], ["\u0A59", "\u0A5C"], "\u0A5E", ["\u0A72", "\u0A74"], ["\u0A85", "\u0A8D"], ["\u0A8F", "\u0A91"], ["\u0A93", "\u0AA8"], ["\u0AAA", "\u0AB0"], ["\u0AB2", "\u0AB3"], ["\u0AB5", "\u0AB9"], "\u0ABD", "\u0AD0", ["\u0AE0", "\u0AE1"], "\u0AF9", ["\u0B05", "\u0B0C"], ["\u0B0F", "\u0B10"], ["\u0B13", "\u0B28"], ["\u0B2A", "\u0B30"], ["\u0B32", "\u0B33"], ["\u0B35", "\u0B39"], "\u0B3D", ["\u0B5C", "\u0B5D"], ["\u0B5F", "\u0B61"], "\u0B71", "\u0B83", ["\u0B85", "\u0B8A"], ["\u0B8E", "\u0B90"], ["\u0B92", "\u0B95"], ["\u0B99", "\u0B9A"], "\u0B9C", ["\u0B9E", "\u0B9F"], ["\u0BA3", "\u0BA4"], ["\u0BA8", "\u0BAA"], ["\u0BAE", "\u0BB9"], "\u0BD0", ["\u0C05", "\u0C0C"], ["\u0C0E", "\u0C10"], ["\u0C12", "\u0C28"], ["\u0C2A", "\u0C39"], "\u0C3D", ["\u0C58", "\u0C5A"], ["\u0C60", "\u0C61"], ["\u0C85", "\u0C8C"], ["\u0C8E", "\u0C90"], ["\u0C92", "\u0CA8"], ["\u0CAA", "\u0CB3"], ["\u0CB5", "\u0CB9"], "\u0CBD", "\u0CDE", ["\u0CE0", "\u0CE1"], ["\u0CF1", "\u0CF2"], ["\u0D05", "\u0D0C"], ["\u0D0E", "\u0D10"], ["\u0D12", "\u0D3A"], "\u0D3D", "\u0D4E", ["\u0D5F", "\u0D61"], ["\u0D7A", "\u0D7F"], ["\u0D85", "\u0D96"], ["\u0D9A", "\u0DB1"], ["\u0DB3", "\u0DBB"], "\u0DBD", ["\u0DC0", "\u0DC6"], ["\u0E01", "\u0E30"], ["\u0E32", "\u0E33"], ["\u0E40", "\u0E45"], ["\u0E81", "\u0E82"], "\u0E84", ["\u0E87", "\u0E88"], "\u0E8A", "\u0E8D", ["\u0E94", "\u0E97"], ["\u0E99", "\u0E9F"], ["\u0EA1", "\u0EA3"], "\u0EA5", "\u0EA7", ["\u0EAA", "\u0EAB"], ["\u0EAD", "\u0EB0"], ["\u0EB2", "\u0EB3"], "\u0EBD", ["\u0EC0", "\u0EC4"], ["\u0EDC", "\u0EDF"], "\u0F00", ["\u0F40", "\u0F47"], ["\u0F49", "\u0F6C"], ["\u0F88", "\u0F8C"], ["\u1000", "\u102A"], "\u103F", ["\u1050", "\u1055"], ["\u105A", "\u105D"], "\u1061", ["\u1065", "\u1066"], ["\u106E", "\u1070"], ["\u1075", "\u1081"], "\u108E", ["\u10D0", "\u10FA"], ["\u10FD", "\u1248"], ["\u124A", "\u124D"], ["\u1250", "\u1256"], "\u1258", ["\u125A", "\u125D"], ["\u1260", "\u1288"], ["\u128A", "\u128D"], ["\u1290", "\u12B0"], ["\u12B2", "\u12B5"], ["\u12B8", "\u12BE"], "\u12C0", ["\u12C2", "\u12C5"], ["\u12C8", "\u12D6"], ["\u12D8", "\u1310"], ["\u1312", "\u1315"], ["\u1318", "\u135A"], ["\u1380", "\u138F"], ["\u1401", "\u166C"], ["\u166F", "\u167F"], ["\u1681", "\u169A"], ["\u16A0", "\u16EA"], ["\u16F1", "\u16F8"], ["\u1700", "\u170C"], ["\u170E", "\u1711"], ["\u1720", "\u1731"], ["\u1740", "\u1751"], ["\u1760", "\u176C"], ["\u176E", "\u1770"], ["\u1780", "\u17B3"], "\u17DC", ["\u1820", "\u1842"], ["\u1844", "\u1877"], ["\u1880", "\u18A8"], "\u18AA", ["\u18B0", "\u18F5"], ["\u1900", "\u191E"], ["\u1950", "\u196D"], ["\u1970", "\u1974"], ["\u1980", "\u19AB"], ["\u19B0", "\u19C9"], ["\u1A00", "\u1A16"], ["\u1A20", "\u1A54"], ["\u1B05", "\u1B33"], ["\u1B45", "\u1B4B"], ["\u1B83", "\u1BA0"], ["\u1BAE", "\u1BAF"], ["\u1BBA", "\u1BE5"], ["\u1C00", "\u1C23"], ["\u1C4D", "\u1C4F"], ["\u1C5A", "\u1C77"], ["\u1CE9", "\u1CEC"], ["\u1CEE", "\u1CF1"], ["\u1CF5", "\u1CF6"], ["\u2135", "\u2138"], ["\u2D30", "\u2D67"], ["\u2D80", "\u2D96"], ["\u2DA0", "\u2DA6"], ["\u2DA8", "\u2DAE"], ["\u2DB0", "\u2DB6"], ["\u2DB8", "\u2DBE"], ["\u2DC0", "\u2DC6"], ["\u2DC8", "\u2DCE"], ["\u2DD0", "\u2DD6"], ["\u2DD8", "\u2DDE"], "\u3006", "\u303C", ["\u3041", "\u3096"], "\u309F", ["\u30A1", "\u30FA"], "\u30FF", ["\u3105", "\u312D"], ["\u3131", "\u318E"], ["\u31A0", "\u31BA"], ["\u31F0", "\u31FF"], ["\u3400", "\u4DB5"], ["\u4E00", "\u9FD5"], ["\uA000", "\uA014"], ["\uA016", "\uA48C"], ["\uA4D0", "\uA4F7"], ["\uA500", "\uA60B"], ["\uA610", "\uA61F"], ["\uA62A", "\uA62B"], "\uA66E", ["\uA6A0", "\uA6E5"], "\uA78F", "\uA7F7", ["\uA7FB", "\uA801"], ["\uA803", "\uA805"], ["\uA807", "\uA80A"], ["\uA80C", "\uA822"], ["\uA840", "\uA873"], ["\uA882", "\uA8B3"], ["\uA8F2", "\uA8F7"], "\uA8FB", "\uA8FD", ["\uA90A", "\uA925"], ["\uA930", "\uA946"], ["\uA960", "\uA97C"], ["\uA984", "\uA9B2"], ["\uA9E0", "\uA9E4"], ["\uA9E7", "\uA9EF"], ["\uA9FA", "\uA9FE"], ["\uAA00", "\uAA28"], ["\uAA40", "\uAA42"], ["\uAA44", "\uAA4B"], ["\uAA60", "\uAA6F"], ["\uAA71", "\uAA76"], "\uAA7A", ["\uAA7E", "\uAAAF"], "\uAAB1", ["\uAAB5", "\uAAB6"], ["\uAAB9", "\uAABD"], "\uAAC0", "\uAAC2", ["\uAADB", "\uAADC"], ["\uAAE0", "\uAAEA"], "\uAAF2", ["\uAB01", "\uAB06"], ["\uAB09", "\uAB0E"], ["\uAB11", "\uAB16"], ["\uAB20", "\uAB26"], ["\uAB28", "\uAB2E"], ["\uABC0", "\uABE2"], ["\uAC00", "\uD7A3"], ["\uD7B0", "\uD7C6"], ["\uD7CB", "\uD7FB"], ["\uF900", "\uFA6D"], ["\uFA70", "\uFAD9"], "\uFB1D", ["\uFB1F", "\uFB28"], ["\uFB2A", "\uFB36"], ["\uFB38", "\uFB3C"], "\uFB3E", ["\uFB40", "\uFB41"], ["\uFB43", "\uFB44"], ["\uFB46", "\uFBB1"], ["\uFBD3", "\uFD3D"], ["\uFD50", "\uFD8F"], ["\uFD92", "\uFDC7"], ["\uFDF0", "\uFDFB"], ["\uFE70", "\uFE74"], ["\uFE76", "\uFEFC"], ["\uFF66", "\uFF6F"], ["\uFF71", "\uFF9D"], ["\uFFA0", "\uFFBE"], ["\uFFC2", "\uFFC7"], ["\uFFCA", "\uFFCF"], ["\uFFD2", "\uFFD7"], ["\uFFDA", "\uFFDC"]], false, false);
+  var peg$e67 = peg$classExpectation(["\u01C5", "\u01C8", "\u01CB", "\u01F2", ["\u1F88", "\u1F8F"], ["\u1F98", "\u1F9F"], ["\u1FA8", "\u1FAF"], "\u1FBC", "\u1FCC", "\u1FFC"], false, false);
+  var peg$e68 = peg$classExpectation([["A", "Z"], ["\xC0", "\xD6"], ["\xD8", "\xDE"], "\u0100", "\u0102", "\u0104", "\u0106", "\u0108", "\u010A", "\u010C", "\u010E", "\u0110", "\u0112", "\u0114", "\u0116", "\u0118", "\u011A", "\u011C", "\u011E", "\u0120", "\u0122", "\u0124", "\u0126", "\u0128", "\u012A", "\u012C", "\u012E", "\u0130", "\u0132", "\u0134", "\u0136", "\u0139", "\u013B", "\u013D", "\u013F", "\u0141", "\u0143", "\u0145", "\u0147", "\u014A", "\u014C", "\u014E", "\u0150", "\u0152", "\u0154", "\u0156", "\u0158", "\u015A", "\u015C", "\u015E", "\u0160", "\u0162", "\u0164", "\u0166", "\u0168", "\u016A", "\u016C", "\u016E", "\u0170", "\u0172", "\u0174", "\u0176", ["\u0178", "\u0179"], "\u017B", "\u017D", ["\u0181", "\u0182"], "\u0184", ["\u0186", "\u0187"], ["\u0189", "\u018B"], ["\u018E", "\u0191"], ["\u0193", "\u0194"], ["\u0196", "\u0198"], ["\u019C", "\u019D"], ["\u019F", "\u01A0"], "\u01A2", "\u01A4", ["\u01A6", "\u01A7"], "\u01A9", "\u01AC", ["\u01AE", "\u01AF"], ["\u01B1", "\u01B3"], "\u01B5", ["\u01B7", "\u01B8"], "\u01BC", "\u01C4", "\u01C7", "\u01CA", "\u01CD", "\u01CF", "\u01D1", "\u01D3", "\u01D5", "\u01D7", "\u01D9", "\u01DB", "\u01DE", "\u01E0", "\u01E2", "\u01E4", "\u01E6", "\u01E8", "\u01EA", "\u01EC", "\u01EE", "\u01F1", "\u01F4", ["\u01F6", "\u01F8"], "\u01FA", "\u01FC", "\u01FE", "\u0200", "\u0202", "\u0204", "\u0206", "\u0208", "\u020A", "\u020C", "\u020E", "\u0210", "\u0212", "\u0214", "\u0216", "\u0218", "\u021A", "\u021C", "\u021E", "\u0220", "\u0222", "\u0224", "\u0226", "\u0228", "\u022A", "\u022C", "\u022E", "\u0230", "\u0232", ["\u023A", "\u023B"], ["\u023D", "\u023E"], "\u0241", ["\u0243", "\u0246"], "\u0248", "\u024A", "\u024C", "\u024E", "\u0370", "\u0372", "\u0376", "\u037F", "\u0386", ["\u0388", "\u038A"], "\u038C", ["\u038E", "\u038F"], ["\u0391", "\u03A1"], ["\u03A3", "\u03AB"], "\u03CF", ["\u03D2", "\u03D4"], "\u03D8", "\u03DA", "\u03DC", "\u03DE", "\u03E0", "\u03E2", "\u03E4", "\u03E6", "\u03E8", "\u03EA", "\u03EC", "\u03EE", "\u03F4", "\u03F7", ["\u03F9", "\u03FA"], ["\u03FD", "\u042F"], "\u0460", "\u0462", "\u0464", "\u0466", "\u0468", "\u046A", "\u046C", "\u046E", "\u0470", "\u0472", "\u0474", "\u0476", "\u0478", "\u047A", "\u047C", "\u047E", "\u0480", "\u048A", "\u048C", "\u048E", "\u0490", "\u0492", "\u0494", "\u0496", "\u0498", "\u049A", "\u049C", "\u049E", "\u04A0", "\u04A2", "\u04A4", "\u04A6", "\u04A8", "\u04AA", "\u04AC", "\u04AE", "\u04B0", "\u04B2", "\u04B4", "\u04B6", "\u04B8", "\u04BA", "\u04BC", "\u04BE", ["\u04C0", "\u04C1"], "\u04C3", "\u04C5", "\u04C7", "\u04C9", "\u04CB", "\u04CD", "\u04D0", "\u04D2", "\u04D4", "\u04D6", "\u04D8", "\u04DA", "\u04DC", "\u04DE", "\u04E0", "\u04E2", "\u04E4", "\u04E6", "\u04E8", "\u04EA", "\u04EC", "\u04EE", "\u04F0", "\u04F2", "\u04F4", "\u04F6", "\u04F8", "\u04FA", "\u04FC", "\u04FE", "\u0500", "\u0502", "\u0504", "\u0506", "\u0508", "\u050A", "\u050C", "\u050E", "\u0510", "\u0512", "\u0514", "\u0516", "\u0518", "\u051A", "\u051C", "\u051E", "\u0520", "\u0522", "\u0524", "\u0526", "\u0528", "\u052A", "\u052C", "\u052E", ["\u0531", "\u0556"], ["\u10A0", "\u10C5"], "\u10C7", "\u10CD", ["\u13A0", "\u13F5"], "\u1E00", "\u1E02", "\u1E04", "\u1E06", "\u1E08", "\u1E0A", "\u1E0C", "\u1E0E", "\u1E10", "\u1E12", "\u1E14", "\u1E16", "\u1E18", "\u1E1A", "\u1E1C", "\u1E1E", "\u1E20", "\u1E22", "\u1E24", "\u1E26", "\u1E28", "\u1E2A", "\u1E2C", "\u1E2E", "\u1E30", "\u1E32", "\u1E34", "\u1E36", "\u1E38", "\u1E3A", "\u1E3C", "\u1E3E", "\u1E40", "\u1E42", "\u1E44", "\u1E46", "\u1E48", "\u1E4A", "\u1E4C", "\u1E4E", "\u1E50", "\u1E52", "\u1E54", "\u1E56", "\u1E58", "\u1E5A", "\u1E5C", "\u1E5E", "\u1E60", "\u1E62", "\u1E64", "\u1E66", "\u1E68", "\u1E6A", "\u1E6C", "\u1E6E", "\u1E70", "\u1E72", "\u1E74", "\u1E76", "\u1E78", "\u1E7A", "\u1E7C", "\u1E7E", "\u1E80", "\u1E82", "\u1E84", "\u1E86", "\u1E88", "\u1E8A", "\u1E8C", "\u1E8E", "\u1E90", "\u1E92", "\u1E94", "\u1E9E", "\u1EA0", "\u1EA2", "\u1EA4", "\u1EA6", "\u1EA8", "\u1EAA", "\u1EAC", "\u1EAE", "\u1EB0", "\u1EB2", "\u1EB4", "\u1EB6", "\u1EB8", "\u1EBA", "\u1EBC", "\u1EBE", "\u1EC0", "\u1EC2", "\u1EC4", "\u1EC6", "\u1EC8", "\u1ECA", "\u1ECC", "\u1ECE", "\u1ED0", "\u1ED2", "\u1ED4", "\u1ED6", "\u1ED8", "\u1EDA", "\u1EDC", "\u1EDE", "\u1EE0", "\u1EE2", "\u1EE4", "\u1EE6", "\u1EE8", "\u1EEA", "\u1EEC", "\u1EEE", "\u1EF0", "\u1EF2", "\u1EF4", "\u1EF6", "\u1EF8", "\u1EFA", "\u1EFC", "\u1EFE", ["\u1F08", "\u1F0F"], ["\u1F18", "\u1F1D"], ["\u1F28", "\u1F2F"], ["\u1F38", "\u1F3F"], ["\u1F48", "\u1F4D"], "\u1F59", "\u1F5B", "\u1F5D", "\u1F5F", ["\u1F68", "\u1F6F"], ["\u1FB8", "\u1FBB"], ["\u1FC8", "\u1FCB"], ["\u1FD8", "\u1FDB"], ["\u1FE8", "\u1FEC"], ["\u1FF8", "\u1FFB"], "\u2102", "\u2107", ["\u210B", "\u210D"], ["\u2110", "\u2112"], "\u2115", ["\u2119", "\u211D"], "\u2124", "\u2126", "\u2128", ["\u212A", "\u212D"], ["\u2130", "\u2133"], ["\u213E", "\u213F"], "\u2145", "\u2183", ["\u2C00", "\u2C2E"], "\u2C60", ["\u2C62", "\u2C64"], "\u2C67", "\u2C69", "\u2C6B", ["\u2C6D", "\u2C70"], "\u2C72", "\u2C75", ["\u2C7E", "\u2C80"], "\u2C82", "\u2C84", "\u2C86", "\u2C88", "\u2C8A", "\u2C8C", "\u2C8E", "\u2C90", "\u2C92", "\u2C94", "\u2C96", "\u2C98", "\u2C9A", "\u2C9C", "\u2C9E", "\u2CA0", "\u2CA2", "\u2CA4", "\u2CA6", "\u2CA8", "\u2CAA", "\u2CAC", "\u2CAE", "\u2CB0", "\u2CB2", "\u2CB4", "\u2CB6", "\u2CB8", "\u2CBA", "\u2CBC", "\u2CBE", "\u2CC0", "\u2CC2", "\u2CC4", "\u2CC6", "\u2CC8", "\u2CCA", "\u2CCC", "\u2CCE", "\u2CD0", "\u2CD2", "\u2CD4", "\u2CD6", "\u2CD8", "\u2CDA", "\u2CDC", "\u2CDE", "\u2CE0", "\u2CE2", "\u2CEB", "\u2CED", "\u2CF2", "\uA640", "\uA642", "\uA644", "\uA646", "\uA648", "\uA64A", "\uA64C", "\uA64E", "\uA650", "\uA652", "\uA654", "\uA656", "\uA658", "\uA65A", "\uA65C", "\uA65E", "\uA660", "\uA662", "\uA664", "\uA666", "\uA668", "\uA66A", "\uA66C", "\uA680", "\uA682", "\uA684", "\uA686", "\uA688", "\uA68A", "\uA68C", "\uA68E", "\uA690", "\uA692", "\uA694", "\uA696", "\uA698", "\uA69A", "\uA722", "\uA724", "\uA726", "\uA728", "\uA72A", "\uA72C", "\uA72E", "\uA732", "\uA734", "\uA736", "\uA738", "\uA73A", "\uA73C", "\uA73E", "\uA740", "\uA742", "\uA744", "\uA746", "\uA748", "\uA74A", "\uA74C", "\uA74E", "\uA750", "\uA752", "\uA754", "\uA756", "\uA758", "\uA75A", "\uA75C", "\uA75E", "\uA760", "\uA762", "\uA764", "\uA766", "\uA768", "\uA76A", "\uA76C", "\uA76E", "\uA779", "\uA77B", ["\uA77D", "\uA77E"], "\uA780", "\uA782", "\uA784", "\uA786", "\uA78B", "\uA78D", "\uA790", "\uA792", "\uA796", "\uA798", "\uA79A", "\uA79C", "\uA79E", "\uA7A0", "\uA7A2", "\uA7A4", "\uA7A6", "\uA7A8", ["\uA7AA", "\uA7AD"], ["\uA7B0", "\uA7B4"], "\uA7B6", ["\uFF21", "\uFF3A"]], false, false);
+  var peg$e69 = peg$classExpectation(["\u0903", "\u093B", ["\u093E", "\u0940"], ["\u0949", "\u094C"], ["\u094E", "\u094F"], ["\u0982", "\u0983"], ["\u09BE", "\u09C0"], ["\u09C7", "\u09C8"], ["\u09CB", "\u09CC"], "\u09D7", "\u0A03", ["\u0A3E", "\u0A40"], "\u0A83", ["\u0ABE", "\u0AC0"], "\u0AC9", ["\u0ACB", "\u0ACC"], ["\u0B02", "\u0B03"], "\u0B3E", "\u0B40", ["\u0B47", "\u0B48"], ["\u0B4B", "\u0B4C"], "\u0B57", ["\u0BBE", "\u0BBF"], ["\u0BC1", "\u0BC2"], ["\u0BC6", "\u0BC8"], ["\u0BCA", "\u0BCC"], "\u0BD7", ["\u0C01", "\u0C03"], ["\u0C41", "\u0C44"], ["\u0C82", "\u0C83"], "\u0CBE", ["\u0CC0", "\u0CC4"], ["\u0CC7", "\u0CC8"], ["\u0CCA", "\u0CCB"], ["\u0CD5", "\u0CD6"], ["\u0D02", "\u0D03"], ["\u0D3E", "\u0D40"], ["\u0D46", "\u0D48"], ["\u0D4A", "\u0D4C"], "\u0D57", ["\u0D82", "\u0D83"], ["\u0DCF", "\u0DD1"], ["\u0DD8", "\u0DDF"], ["\u0DF2", "\u0DF3"], ["\u0F3E", "\u0F3F"], "\u0F7F", ["\u102B", "\u102C"], "\u1031", "\u1038", ["\u103B", "\u103C"], ["\u1056", "\u1057"], ["\u1062", "\u1064"], ["\u1067", "\u106D"], ["\u1083", "\u1084"], ["\u1087", "\u108C"], "\u108F", ["\u109A", "\u109C"], "\u17B6", ["\u17BE", "\u17C5"], ["\u17C7", "\u17C8"], ["\u1923", "\u1926"], ["\u1929", "\u192B"], ["\u1930", "\u1931"], ["\u1933", "\u1938"], ["\u1A19", "\u1A1A"], "\u1A55", "\u1A57", "\u1A61", ["\u1A63", "\u1A64"], ["\u1A6D", "\u1A72"], "\u1B04", "\u1B35", "\u1B3B", ["\u1B3D", "\u1B41"], ["\u1B43", "\u1B44"], "\u1B82", "\u1BA1", ["\u1BA6", "\u1BA7"], "\u1BAA", "\u1BE7", ["\u1BEA", "\u1BEC"], "\u1BEE", ["\u1BF2", "\u1BF3"], ["\u1C24", "\u1C2B"], ["\u1C34", "\u1C35"], "\u1CE1", ["\u1CF2", "\u1CF3"], ["\u302E", "\u302F"], ["\uA823", "\uA824"], "\uA827", ["\uA880", "\uA881"], ["\uA8B4", "\uA8C3"], ["\uA952", "\uA953"], "\uA983", ["\uA9B4", "\uA9B5"], ["\uA9BA", "\uA9BB"], ["\uA9BD", "\uA9C0"], ["\uAA2F", "\uAA30"], ["\uAA33", "\uAA34"], "\uAA4D", "\uAA7B", "\uAA7D", "\uAAEB", ["\uAAEE", "\uAAEF"], "\uAAF5", ["\uABE3", "\uABE4"], ["\uABE6", "\uABE7"], ["\uABE9", "\uABEA"], "\uABEC"], false, false);
+  var peg$e70 = peg$classExpectation([["\u0300", "\u036F"], ["\u0483", "\u0487"], ["\u0591", "\u05BD"], "\u05BF", ["\u05C1", "\u05C2"], ["\u05C4", "\u05C5"], "\u05C7", ["\u0610", "\u061A"], ["\u064B", "\u065F"], "\u0670", ["\u06D6", "\u06DC"], ["\u06DF", "\u06E4"], ["\u06E7", "\u06E8"], ["\u06EA", "\u06ED"], "\u0711", ["\u0730", "\u074A"], ["\u07A6", "\u07B0"], ["\u07EB", "\u07F3"], ["\u0816", "\u0819"], ["\u081B", "\u0823"], ["\u0825", "\u0827"], ["\u0829", "\u082D"], ["\u0859", "\u085B"], ["\u08E3", "\u0902"], "\u093A", "\u093C", ["\u0941", "\u0948"], "\u094D", ["\u0951", "\u0957"], ["\u0962", "\u0963"], "\u0981", "\u09BC", ["\u09C1", "\u09C4"], "\u09CD", ["\u09E2", "\u09E3"], ["\u0A01", "\u0A02"], "\u0A3C", ["\u0A41", "\u0A42"], ["\u0A47", "\u0A48"], ["\u0A4B", "\u0A4D"], "\u0A51", ["\u0A70", "\u0A71"], "\u0A75", ["\u0A81", "\u0A82"], "\u0ABC", ["\u0AC1", "\u0AC5"], ["\u0AC7", "\u0AC8"], "\u0ACD", ["\u0AE2", "\u0AE3"], "\u0B01", "\u0B3C", "\u0B3F", ["\u0B41", "\u0B44"], "\u0B4D", "\u0B56", ["\u0B62", "\u0B63"], "\u0B82", "\u0BC0", "\u0BCD", "\u0C00", ["\u0C3E", "\u0C40"], ["\u0C46", "\u0C48"], ["\u0C4A", "\u0C4D"], ["\u0C55", "\u0C56"], ["\u0C62", "\u0C63"], "\u0C81", "\u0CBC", "\u0CBF", "\u0CC6", ["\u0CCC", "\u0CCD"], ["\u0CE2", "\u0CE3"], "\u0D01", ["\u0D41", "\u0D44"], "\u0D4D", ["\u0D62", "\u0D63"], "\u0DCA", ["\u0DD2", "\u0DD4"], "\u0DD6", "\u0E31", ["\u0E34", "\u0E3A"], ["\u0E47", "\u0E4E"], "\u0EB1", ["\u0EB4", "\u0EB9"], ["\u0EBB", "\u0EBC"], ["\u0EC8", "\u0ECD"], ["\u0F18", "\u0F19"], "\u0F35", "\u0F37", "\u0F39", ["\u0F71", "\u0F7E"], ["\u0F80", "\u0F84"], ["\u0F86", "\u0F87"], ["\u0F8D", "\u0F97"], ["\u0F99", "\u0FBC"], "\u0FC6", ["\u102D", "\u1030"], ["\u1032", "\u1037"], ["\u1039", "\u103A"], ["\u103D", "\u103E"], ["\u1058", "\u1059"], ["\u105E", "\u1060"], ["\u1071", "\u1074"], "\u1082", ["\u1085", "\u1086"], "\u108D", "\u109D", ["\u135D", "\u135F"], ["\u1712", "\u1714"], ["\u1732", "\u1734"], ["\u1752", "\u1753"], ["\u1772", "\u1773"], ["\u17B4", "\u17B5"], ["\u17B7", "\u17BD"], "\u17C6", ["\u17C9", "\u17D3"], "\u17DD", ["\u180B", "\u180D"], "\u18A9", ["\u1920", "\u1922"], ["\u1927", "\u1928"], "\u1932", ["\u1939", "\u193B"], ["\u1A17", "\u1A18"], "\u1A1B", "\u1A56", ["\u1A58", "\u1A5E"], "\u1A60", "\u1A62", ["\u1A65", "\u1A6C"], ["\u1A73", "\u1A7C"], "\u1A7F", ["\u1AB0", "\u1ABD"], ["\u1B00", "\u1B03"], "\u1B34", ["\u1B36", "\u1B3A"], "\u1B3C", "\u1B42", ["\u1B6B", "\u1B73"], ["\u1B80", "\u1B81"], ["\u1BA2", "\u1BA5"], ["\u1BA8", "\u1BA9"], ["\u1BAB", "\u1BAD"], "\u1BE6", ["\u1BE8", "\u1BE9"], "\u1BED", ["\u1BEF", "\u1BF1"], ["\u1C2C", "\u1C33"], ["\u1C36", "\u1C37"], ["\u1CD0", "\u1CD2"], ["\u1CD4", "\u1CE0"], ["\u1CE2", "\u1CE8"], "\u1CED", "\u1CF4", ["\u1CF8", "\u1CF9"], ["\u1DC0", "\u1DF5"], ["\u1DFC", "\u1DFF"], ["\u20D0", "\u20DC"], "\u20E1", ["\u20E5", "\u20F0"], ["\u2CEF", "\u2CF1"], "\u2D7F", ["\u2DE0", "\u2DFF"], ["\u302A", "\u302D"], ["\u3099", "\u309A"], "\uA66F", ["\uA674", "\uA67D"], ["\uA69E", "\uA69F"], ["\uA6F0", "\uA6F1"], "\uA802", "\uA806", "\uA80B", ["\uA825", "\uA826"], "\uA8C4", ["\uA8E0", "\uA8F1"], ["\uA926", "\uA92D"], ["\uA947", "\uA951"], ["\uA980", "\uA982"], "\uA9B3", ["\uA9B6", "\uA9B9"], "\uA9BC", "\uA9E5", ["\uAA29", "\uAA2E"], ["\uAA31", "\uAA32"], ["\uAA35", "\uAA36"], "\uAA43", "\uAA4C", "\uAA7C", "\uAAB0", ["\uAAB2", "\uAAB4"], ["\uAAB7", "\uAAB8"], ["\uAABE", "\uAABF"], "\uAAC1", ["\uAAEC", "\uAAED"], "\uAAF6", "\uABE5", "\uABE8", "\uABED", "\uFB1E", ["\uFE00", "\uFE0F"], ["\uFE20", "\uFE2F"]], false, false);
+  var peg$e71 = peg$classExpectation([["0", "9"], ["\u0660", "\u0669"], ["\u06F0", "\u06F9"], ["\u07C0", "\u07C9"], ["\u0966", "\u096F"], ["\u09E6", "\u09EF"], ["\u0A66", "\u0A6F"], ["\u0AE6", "\u0AEF"], ["\u0B66", "\u0B6F"], ["\u0BE6", "\u0BEF"], ["\u0C66", "\u0C6F"], ["\u0CE6", "\u0CEF"], ["\u0D66", "\u0D6F"], ["\u0DE6", "\u0DEF"], ["\u0E50", "\u0E59"], ["\u0ED0", "\u0ED9"], ["\u0F20", "\u0F29"], ["\u1040", "\u1049"], ["\u1090", "\u1099"], ["\u17E0", "\u17E9"], ["\u1810", "\u1819"], ["\u1946", "\u194F"], ["\u19D0", "\u19D9"], ["\u1A80", "\u1A89"], ["\u1A90", "\u1A99"], ["\u1B50", "\u1B59"], ["\u1BB0", "\u1BB9"], ["\u1C40", "\u1C49"], ["\u1C50", "\u1C59"], ["\uA620", "\uA629"], ["\uA8D0", "\uA8D9"], ["\uA900", "\uA909"], ["\uA9D0", "\uA9D9"], ["\uA9F0", "\uA9F9"], ["\uAA50", "\uAA59"], ["\uABF0", "\uABF9"], ["\uFF10", "\uFF19"]], false, false);
+  var peg$e72 = peg$classExpectation([["\u16EE", "\u16F0"], ["\u2160", "\u2182"], ["\u2185", "\u2188"], "\u3007", ["\u3021", "\u3029"], ["\u3038", "\u303A"], ["\uA6E6", "\uA6EF"]], false, false);
+  var peg$e73 = peg$classExpectation(["_", ["\u203F", "\u2040"], "\u2054", ["\uFE33", "\uFE34"], ["\uFE4D", "\uFE4F"], "\uFF3F"], false, false);
+  var peg$e74 = peg$classExpectation([" ", "\xA0", "\u1680", ["\u2000", "\u200A"], "\u202F", "\u205F", "\u3000"], false, false);
+  var peg$e75 = peg$literalExpectation(";", false);
 
   var peg$f0 = function(topLevelInitializer, initializer, rules) {
       return {
@@ -447,7 +451,30 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f13 = function(expression) {
+  var peg$f13 = function(expression, boundaries) {
+      let min = boundaries[0];
+      let max = boundaries[1];
+      if (max.value === 0) {
+        error("The maximum count of repetitions of the rule must be > 0", max.location);
+      }
+
+      return {
+        type: "repeated",
+        min,
+        max,
+        expression,
+        location: location(),
+      };
+    };
+  var peg$f14 = function(min, max) {
+    return [
+      min !== null ? min : { type: "constant", value: 0 },
+      max !== null ? max : { type: "constant", value: null },
+    ];
+  };
+  var peg$f15 = function(exact) { return [null, exact]; };
+  var peg$f16 = function(value) { return { type: "constant", value, location: location() }; };
+  var peg$f17 = function(expression) {
       // The purpose of the "group" AST node is just to isolate label scope. We
       // don't need to put it around nodes that can't contain any labels or
       // nodes that already isolate label scope themselves. This leaves us with
@@ -456,10 +483,10 @@ function peg$parse(input, options) {
           ? { type: "group", expression, location: location() }
           : expression;
     };
-  var peg$f14 = function(name) {
+  var peg$f18 = function(name) {
       return { type: "rule_ref", name: name[0], location: location() };
     };
-  var peg$f15 = function(operator, code) {
+  var peg$f19 = function(operator, code) {
       return {
         type: OPS_TO_SEMANTIC_PREDICATE_TYPES[operator],
         code: code[0],
@@ -467,10 +494,10 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f16 = function(head, tail) {
+  var peg$f20 = function(head, tail) {
       return [head + tail.join(""), location()];
     };
-  var peg$f17 = function(value, ignoreCase) {
+  var peg$f21 = function(value, ignoreCase) {
       return {
         type: "literal",
         value,
@@ -478,9 +505,9 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f18 = function(chars) { return chars.join(""); };
-  var peg$f19 = function(chars) { return chars.join(""); };
-  var peg$f20 = function(inverted, parts, ignoreCase) {
+  var peg$f22 = function(chars) { return chars.join(""); };
+  var peg$f23 = function(chars) { return chars.join(""); };
+  var peg$f24 = function(inverted, parts, ignoreCase) {
       return {
         type: "class",
         parts: parts.filter(part => part !== ""),
@@ -489,7 +516,7 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f21 = function(begin, end) {
+  var peg$f25 = function(begin, end) {
       if (begin.charCodeAt(0) > end.charCodeAt(0)) {
         error(
           "Invalid character range: " + text() + "."
@@ -498,22 +525,23 @@ function peg$parse(input, options) {
 
       return [begin, end];
     };
-  var peg$f22 = function() { return ""; };
-  var peg$f23 = function() { return "\0"; };
-  var peg$f24 = function() { return "\b"; };
-  var peg$f25 = function() { return "\f"; };
-  var peg$f26 = function() { return "\n"; };
-  var peg$f27 = function() { return "\r"; };
-  var peg$f28 = function() { return "\t"; };
-  var peg$f29 = function() { return "\v"; };
-  var peg$f30 = function(digits) {
+  var peg$f26 = function() { return ""; };
+  var peg$f27 = function() { return "\0"; };
+  var peg$f28 = function() { return "\b"; };
+  var peg$f29 = function() { return "\f"; };
+  var peg$f30 = function() { return "\n"; };
+  var peg$f31 = function() { return "\r"; };
+  var peg$f32 = function() { return "\t"; };
+  var peg$f33 = function() { return "\v"; };
+  var peg$f34 = function(digits) {
       return String.fromCharCode(parseInt(digits, 16));
     };
-  var peg$f31 = function(digits) {
+  var peg$f35 = function(digits) {
       return String.fromCharCode(parseInt(digits, 16));
     };
-  var peg$f32 = function() { return { type: "any", location: location() }; };
-  var peg$f33 = function(code) { return [code, location()]; };
+  var peg$f36 = function() { return { type: "any", location: location() }; };
+  var peg$f37 = function(code) { return [code, location()]; };
+  var peg$f38 = function(digits) { return parseInt(digits); };
   var peg$currPos = 0;
   var peg$savedPos = 0;
   var peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -1161,7 +1189,10 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$parsePrimaryExpression();
+      s0 = peg$parseRepeatedExpression();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parsePrimaryExpression();
+      }
     }
 
     return s0;
@@ -1199,6 +1230,110 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseRepeatedExpression() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parsePrimaryExpression();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (input.charCodeAt(peg$currPos) === 124) {
+        s3 = peg$c12;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e12); }
+      }
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse__();
+        s5 = peg$parseBoundaries();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (input.charCodeAt(peg$currPos) === 124) {
+            s7 = peg$c12;
+            peg$currPos++;
+          } else {
+            s7 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e12); }
+          }
+          if (s7 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s0 = peg$f13(s1, s5);
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseBoundaries() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = peg$parseBoundary();
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    s2 = peg$parse__();
+    if (input.substr(peg$currPos, 2) === peg$c13) {
+      s3 = peg$c13;
+      peg$currPos += 2;
+    } else {
+      s3 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e13); }
+    }
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse__();
+      s5 = peg$parseBoundary();
+      if (s5 === peg$FAILED) {
+        s5 = null;
+      }
+      peg$savedPos = s0;
+      s0 = peg$f14(s1, s5);
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseBoundary();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$f15(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseBoundary() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseInteger();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$f16(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parsePrimaryExpression() {
     var s0, s1, s2, s3, s4, s5;
 
@@ -1214,11 +1349,11 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 40) {
-                s1 = peg$c12;
+                s1 = peg$c14;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e12); }
+                if (peg$silentFails === 0) { peg$fail(peg$e14); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
@@ -1226,15 +1361,15 @@ function peg$parse(input, options) {
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse__();
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s5 = peg$c13;
+                    s5 = peg$c15;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$e13); }
+                    if (peg$silentFails === 0) { peg$fail(peg$e15); }
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s0 = peg$f13(s3);
+                    s0 = peg$f17(s3);
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -1302,7 +1437,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f14(s1);
+        s0 = peg$f18(s1);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1325,7 +1460,7 @@ function peg$parse(input, options) {
       s3 = peg$parseCodeBlock();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f15(s1, s3);
+        s0 = peg$f19(s1, s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1369,7 +1504,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e14); }
+      if (peg$silentFails === 0) { peg$fail(peg$e16); }
     }
 
     return s0;
@@ -1380,51 +1515,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c14;
+      s0 = peg$c16;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e16); }
+      if (peg$silentFails === 0) { peg$fail(peg$e18); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c15;
+        s0 = peg$c17;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e17); }
+        if (peg$silentFails === 0) { peg$fail(peg$e19); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c16;
+          s0 = peg$c18;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e18); }
+          if (peg$silentFails === 0) { peg$fail(peg$e20); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c17;
+            s0 = peg$c19;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e19); }
+            if (peg$silentFails === 0) { peg$fail(peg$e21); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c18;
+              s0 = peg$c20;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e20); }
+              if (peg$silentFails === 0) { peg$fail(peg$e22); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c19;
+                s0 = peg$c21;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e21); }
+                if (peg$silentFails === 0) { peg$fail(peg$e23); }
               }
               if (s0 === peg$FAILED) {
                 s0 = peg$parseZs();
@@ -1437,7 +1572,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e15); }
+      if (peg$silentFails === 0) { peg$fail(peg$e17); }
     }
 
     return s0;
@@ -1451,7 +1586,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e22); }
+      if (peg$silentFails === 0) { peg$fail(peg$e24); }
     }
 
     return s0;
@@ -1462,43 +1597,43 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 10) {
-      s0 = peg$c20;
+      s0 = peg$c22;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e24); }
+      if (peg$silentFails === 0) { peg$fail(peg$e26); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c21) {
-        s0 = peg$c21;
+      if (input.substr(peg$currPos, 2) === peg$c23) {
+        s0 = peg$c23;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e25); }
+        if (peg$silentFails === 0) { peg$fail(peg$e27); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 13) {
-          s0 = peg$c22;
+          s0 = peg$c24;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e26); }
+          if (peg$silentFails === 0) { peg$fail(peg$e28); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 8232) {
-            s0 = peg$c23;
+            s0 = peg$c25;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e27); }
+            if (peg$silentFails === 0) { peg$fail(peg$e29); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 8233) {
-              s0 = peg$c24;
+              s0 = peg$c26;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e28); }
+              if (peg$silentFails === 0) { peg$fail(peg$e30); }
             }
           }
         }
@@ -1507,7 +1642,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e23); }
+      if (peg$silentFails === 0) { peg$fail(peg$e25); }
     }
 
     return s0;
@@ -1524,7 +1659,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e29); }
+      if (peg$silentFails === 0) { peg$fail(peg$e31); }
     }
 
     return s0;
@@ -1534,24 +1669,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c25) {
-      s1 = peg$c25;
+    if (input.substr(peg$currPos, 2) === peg$c27) {
+      s1 = peg$c27;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e30); }
+      if (peg$silentFails === 0) { peg$fail(peg$e32); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c26) {
-        s5 = peg$c26;
+      if (input.substr(peg$currPos, 2) === peg$c28) {
+        s5 = peg$c28;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e31); }
+        if (peg$silentFails === 0) { peg$fail(peg$e33); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -1578,12 +1713,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c26) {
-          s5 = peg$c26;
+        if (input.substr(peg$currPos, 2) === peg$c28) {
+          s5 = peg$c28;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e31); }
+          if (peg$silentFails === 0) { peg$fail(peg$e33); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -1606,12 +1741,12 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       }
-      if (input.substr(peg$currPos, 2) === peg$c26) {
-        s3 = peg$c26;
+      if (input.substr(peg$currPos, 2) === peg$c28) {
+        s3 = peg$c28;
         peg$currPos += 2;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e31); }
+        if (peg$silentFails === 0) { peg$fail(peg$e33); }
       }
       if (s3 !== peg$FAILED) {
         s1 = [s1, s2, s3];
@@ -1632,24 +1767,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c25) {
-      s1 = peg$c25;
+    if (input.substr(peg$currPos, 2) === peg$c27) {
+      s1 = peg$c27;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e30); }
+      if (peg$silentFails === 0) { peg$fail(peg$e32); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c26) {
-        s5 = peg$c26;
+      if (input.substr(peg$currPos, 2) === peg$c28) {
+        s5 = peg$c28;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e31); }
+        if (peg$silentFails === 0) { peg$fail(peg$e33); }
       }
       if (s5 === peg$FAILED) {
         s5 = peg$parseLineTerminator();
@@ -1679,12 +1814,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c26) {
-          s5 = peg$c26;
+        if (input.substr(peg$currPos, 2) === peg$c28) {
+          s5 = peg$c28;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e31); }
+          if (peg$silentFails === 0) { peg$fail(peg$e33); }
         }
         if (s5 === peg$FAILED) {
           s5 = peg$parseLineTerminator();
@@ -1710,12 +1845,12 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       }
-      if (input.substr(peg$currPos, 2) === peg$c26) {
-        s3 = peg$c26;
+      if (input.substr(peg$currPos, 2) === peg$c28) {
+        s3 = peg$c28;
         peg$currPos += 2;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e31); }
+        if (peg$silentFails === 0) { peg$fail(peg$e33); }
       }
       if (s3 !== peg$FAILED) {
         s1 = [s1, s2, s3];
@@ -1736,12 +1871,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c27) {
-      s1 = peg$c27;
+    if (input.substr(peg$currPos, 2) === peg$c29) {
+      s1 = peg$c29;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e32); }
+      if (peg$silentFails === 0) { peg$fail(peg$e34); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1820,7 +1955,7 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifierPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f16(s1, s2);
+      s0 = peg$f20(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1828,7 +1963,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e33); }
+      if (peg$silentFails === 0) { peg$fail(peg$e35); }
     }
 
     return s0;
@@ -1848,20 +1983,20 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 95) {
-          s0 = peg$c28;
+          s0 = peg$c30;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e34); }
+          if (peg$silentFails === 0) { peg$fail(peg$e36); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s1 = peg$c29;
+            s1 = peg$c31;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e35); }
+            if (peg$silentFails === 0) { peg$fail(peg$e37); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseUnicodeEscapeSequence();
@@ -1894,19 +2029,19 @@ function peg$parse(input, options) {
           s0 = peg$parsePc();
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 8204) {
-              s0 = peg$c30;
+              s0 = peg$c32;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e36); }
+              if (peg$silentFails === 0) { peg$fail(peg$e38); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 8205) {
-                s0 = peg$c31;
+                s0 = peg$c33;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e37); }
+                if (peg$silentFails === 0) { peg$fail(peg$e39); }
               }
             }
           }
@@ -1959,17 +2094,17 @@ function peg$parse(input, options) {
     s1 = peg$parseStringLiteral();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 105) {
-        s2 = peg$c32;
+        s2 = peg$c34;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e39); }
+        if (peg$silentFails === 0) { peg$fail(peg$e41); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
       }
       peg$savedPos = s0;
-      s0 = peg$f17(s1, s2);
+      s0 = peg$f21(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1977,7 +2112,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e38); }
+      if (peg$silentFails === 0) { peg$fail(peg$e40); }
     }
 
     return s0;
@@ -1989,11 +2124,11 @@ function peg$parse(input, options) {
     peg$silentFails++;
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c33;
+      s1 = peg$c35;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e41); }
+      if (peg$silentFails === 0) { peg$fail(peg$e43); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -2003,15 +2138,15 @@ function peg$parse(input, options) {
         s3 = peg$parseDoubleStringCharacter();
       }
       if (input.charCodeAt(peg$currPos) === 34) {
-        s3 = peg$c33;
+        s3 = peg$c35;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e41); }
+        if (peg$silentFails === 0) { peg$fail(peg$e43); }
       }
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f18(s2);
+        s0 = peg$f22(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2023,11 +2158,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c34;
+        s1 = peg$c36;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e42); }
+        if (peg$silentFails === 0) { peg$fail(peg$e44); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -2037,15 +2172,15 @@ function peg$parse(input, options) {
           s3 = peg$parseSingleStringCharacter();
         }
         if (input.charCodeAt(peg$currPos) === 39) {
-          s3 = peg$c34;
+          s3 = peg$c36;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e42); }
+          if (peg$silentFails === 0) { peg$fail(peg$e44); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f19(s2);
+          s0 = peg$f23(s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2058,7 +2193,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e40); }
+      if (peg$silentFails === 0) { peg$fail(peg$e42); }
     }
 
     return s0;
@@ -2072,19 +2207,19 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s3 = peg$c33;
+      s3 = peg$c35;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e41); }
+      if (peg$silentFails === 0) { peg$fail(peg$e43); }
     }
     if (s3 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c29;
+        s3 = peg$c31;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e35); }
+        if (peg$silentFails === 0) { peg$fail(peg$e37); }
       }
       if (s3 === peg$FAILED) {
         s3 = peg$parseLineTerminator();
@@ -2118,11 +2253,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c29;
+        s1 = peg$c31;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e35); }
+        if (peg$silentFails === 0) { peg$fail(peg$e37); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -2152,19 +2287,19 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s3 = peg$c34;
+      s3 = peg$c36;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e42); }
+      if (peg$silentFails === 0) { peg$fail(peg$e44); }
     }
     if (s3 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c29;
+        s3 = peg$c31;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e35); }
+        if (peg$silentFails === 0) { peg$fail(peg$e37); }
       }
       if (s3 === peg$FAILED) {
         s3 = peg$parseLineTerminator();
@@ -2198,11 +2333,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c29;
+        s1 = peg$c31;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e35); }
+        if (peg$silentFails === 0) { peg$fail(peg$e37); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -2230,19 +2365,19 @@ function peg$parse(input, options) {
     peg$silentFails++;
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c35;
+      s1 = peg$c37;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e44); }
+      if (peg$silentFails === 0) { peg$fail(peg$e46); }
     }
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 94) {
-        s2 = peg$c36;
+        s2 = peg$c38;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e45); }
+        if (peg$silentFails === 0) { peg$fail(peg$e47); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -2260,25 +2395,25 @@ function peg$parse(input, options) {
         }
       }
       if (input.charCodeAt(peg$currPos) === 93) {
-        s4 = peg$c37;
+        s4 = peg$c39;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e46); }
+        if (peg$silentFails === 0) { peg$fail(peg$e48); }
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 105) {
-          s5 = peg$c32;
+          s5 = peg$c34;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e39); }
+          if (peg$silentFails === 0) { peg$fail(peg$e41); }
         }
         if (s5 === peg$FAILED) {
           s5 = null;
         }
         peg$savedPos = s0;
-        s0 = peg$f20(s2, s3, s5);
+        s0 = peg$f24(s2, s3, s5);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2290,7 +2425,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e43); }
+      if (peg$silentFails === 0) { peg$fail(peg$e45); }
     }
 
     return s0;
@@ -2303,17 +2438,17 @@ function peg$parse(input, options) {
     s1 = peg$parseClassCharacter();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c38;
+        s2 = peg$c40;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e47); }
+        if (peg$silentFails === 0) { peg$fail(peg$e49); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseClassCharacter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f21(s1, s3);
+          s0 = peg$f25(s1, s3);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2338,19 +2473,19 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 93) {
-      s3 = peg$c37;
+      s3 = peg$c39;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e46); }
+      if (peg$silentFails === 0) { peg$fail(peg$e48); }
     }
     if (s3 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s3 = peg$c29;
+        s3 = peg$c31;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e35); }
+        if (peg$silentFails === 0) { peg$fail(peg$e37); }
       }
       if (s3 === peg$FAILED) {
         s3 = peg$parseLineTerminator();
@@ -2384,11 +2519,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c29;
+        s1 = peg$c31;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e35); }
+        if (peg$silentFails === 0) { peg$fail(peg$e37); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -2415,17 +2550,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c29;
+      s1 = peg$c31;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e35); }
+      if (peg$silentFails === 0) { peg$fail(peg$e37); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseLineTerminatorSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f22();
+        s0 = peg$f26();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2445,11 +2580,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s1 = peg$c39;
+        s1 = peg$c41;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e48); }
+        if (peg$silentFails === 0) { peg$fail(peg$e50); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
@@ -2464,7 +2599,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f23();
+          s0 = peg$f27();
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2499,110 +2634,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c34;
+      s0 = peg$c36;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e42); }
+      if (peg$silentFails === 0) { peg$fail(peg$e44); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c33;
+        s0 = peg$c35;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e41); }
+        if (peg$silentFails === 0) { peg$fail(peg$e43); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c29;
+          s0 = peg$c31;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e35); }
+          if (peg$silentFails === 0) { peg$fail(peg$e37); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c40;
+            s1 = peg$c42;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e49); }
+            if (peg$silentFails === 0) { peg$fail(peg$e51); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$f24();
+            s1 = peg$f28();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c41;
+              s1 = peg$c43;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e50); }
+              if (peg$silentFails === 0) { peg$fail(peg$e52); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$f25();
+              s1 = peg$f29();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c42;
+                s1 = peg$c44;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e51); }
+                if (peg$silentFails === 0) { peg$fail(peg$e53); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$f26();
+                s1 = peg$f30();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c43;
+                  s1 = peg$c45;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$e52); }
+                  if (peg$silentFails === 0) { peg$fail(peg$e54); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$f27();
+                  s1 = peg$f31();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c44;
+                    s1 = peg$c46;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$e53); }
+                    if (peg$silentFails === 0) { peg$fail(peg$e55); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$f28();
+                    s1 = peg$f32();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c45;
+                      s1 = peg$c47;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$e54); }
+                      if (peg$silentFails === 0) { peg$fail(peg$e56); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$f29();
+                      s1 = peg$f33();
                     }
                     s0 = s1;
                   }
@@ -2665,19 +2800,19 @@ function peg$parse(input, options) {
       s0 = peg$parseDecimalDigit();
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 120) {
-          s0 = peg$c46;
+          s0 = peg$c48;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e55); }
+          if (peg$silentFails === 0) { peg$fail(peg$e57); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 117) {
-            s0 = peg$c47;
+            s0 = peg$c49;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e56); }
+            if (peg$silentFails === 0) { peg$fail(peg$e58); }
           }
         }
       }
@@ -2691,11 +2826,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c46;
+      s1 = peg$c48;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e55); }
+      if (peg$silentFails === 0) { peg$fail(peg$e57); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2721,7 +2856,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f30(s2);
+        s0 = peg$f34(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2739,11 +2874,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c47;
+      s1 = peg$c49;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e56); }
+      if (peg$silentFails === 0) { peg$fail(peg$e58); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2781,7 +2916,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f31(s2);
+        s0 = peg$f35(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2802,7 +2937,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e57); }
+      if (peg$silentFails === 0) { peg$fail(peg$e59); }
     }
 
     return s0;
@@ -2816,7 +2951,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e58); }
+      if (peg$silentFails === 0) { peg$fail(peg$e60); }
     }
 
     return s0;
@@ -2827,15 +2962,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c48;
+      s1 = peg$c50;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e59); }
+      if (peg$silentFails === 0) { peg$fail(peg$e61); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f32();
+      s1 = peg$f36();
     }
     s0 = s1;
 
@@ -2876,7 +3011,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e60); }
+      if (peg$silentFails === 0) { peg$fail(peg$e62); }
     }
 
     return s0;
@@ -2888,7 +3023,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseCode();
     peg$savedPos = s0;
-    s1 = peg$f33(s1);
+    s1 = peg$f37(s1);
     s0 = s1;
 
     return s0;
@@ -2908,7 +3043,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s5 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e61); }
+      if (peg$silentFails === 0) { peg$fail(peg$e63); }
     }
     peg$silentFails--;
     if (s5 === peg$FAILED) {
@@ -2941,7 +3076,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e61); }
+          if (peg$silentFails === 0) { peg$fail(peg$e63); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -3008,7 +3143,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e61); }
+        if (peg$silentFails === 0) { peg$fail(peg$e63); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -3041,7 +3176,7 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e61); }
+            if (peg$silentFails === 0) { peg$fail(peg$e63); }
           }
           peg$silentFails--;
           if (s5 === peg$FAILED) {
@@ -3103,6 +3238,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseInteger() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$currPos;
+    s2 = [];
+    s3 = peg$parseDecimalDigit();
+    if (s3 !== peg$FAILED) {
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseDecimalDigit();
+      }
+    } else {
+      s2 = peg$FAILED;
+    }
+    if (s2 !== peg$FAILED) {
+      s1 = input.substring(s1, peg$currPos);
+    } else {
+      s1 = s2;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$f38(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parseLl() {
     var s0;
 
@@ -3111,7 +3275,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e62); }
+      if (peg$silentFails === 0) { peg$fail(peg$e64); }
     }
 
     return s0;
@@ -3125,7 +3289,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e63); }
+      if (peg$silentFails === 0) { peg$fail(peg$e65); }
     }
 
     return s0;
@@ -3139,7 +3303,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e64); }
+      if (peg$silentFails === 0) { peg$fail(peg$e66); }
     }
 
     return s0;
@@ -3153,7 +3317,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e65); }
+      if (peg$silentFails === 0) { peg$fail(peg$e67); }
     }
 
     return s0;
@@ -3167,7 +3331,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e66); }
+      if (peg$silentFails === 0) { peg$fail(peg$e68); }
     }
 
     return s0;
@@ -3181,7 +3345,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e67); }
+      if (peg$silentFails === 0) { peg$fail(peg$e69); }
     }
 
     return s0;
@@ -3195,7 +3359,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e68); }
+      if (peg$silentFails === 0) { peg$fail(peg$e70); }
     }
 
     return s0;
@@ -3209,7 +3373,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e69); }
+      if (peg$silentFails === 0) { peg$fail(peg$e71); }
     }
 
     return s0;
@@ -3223,7 +3387,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e70); }
+      if (peg$silentFails === 0) { peg$fail(peg$e72); }
     }
 
     return s0;
@@ -3237,7 +3401,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e71); }
+      if (peg$silentFails === 0) { peg$fail(peg$e73); }
     }
 
     return s0;
@@ -3251,7 +3415,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e72); }
+      if (peg$silentFails === 0) { peg$fail(peg$e74); }
     }
 
     return s0;
@@ -3307,11 +3471,11 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (input.charCodeAt(peg$currPos) === 59) {
-      s2 = peg$c49;
+      s2 = peg$c51;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e73); }
+      if (peg$silentFails === 0) { peg$fail(peg$e75); }
     }
     if (s2 !== peg$FAILED) {
       s1 = [s1, s2];
@@ -3362,7 +3526,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e14); }
+      if (peg$silentFails === 0) { peg$fail(peg$e16); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -454,7 +454,7 @@ function peg$parse(input, options) {
   var peg$f13 = function(expression, boundaries) {
       let min = boundaries[0];
       let max = boundaries[1];
-      if (max.value === 0) {
+      if (max.type === "constant" && max.value === 0) {
         error("The maximum count of repetitions of the rule must be > 0", max.location);
       }
 
@@ -474,7 +474,8 @@ function peg$parse(input, options) {
   };
   var peg$f15 = function(exact) { return [null, exact]; };
   var peg$f16 = function(value) { return { type: "constant", value, location: location() }; };
-  var peg$f17 = function(expression) {
+  var peg$f17 = function(value) { return { type: "variable", value: value[0], location: location() }; };
+  var peg$f18 = function(expression) {
       // The purpose of the "group" AST node is just to isolate label scope. We
       // don't need to put it around nodes that can't contain any labels or
       // nodes that already isolate label scope themselves. This leaves us with
@@ -483,10 +484,10 @@ function peg$parse(input, options) {
           ? { type: "group", expression, location: location() }
           : expression;
     };
-  var peg$f18 = function(name) {
+  var peg$f19 = function(name) {
       return { type: "rule_ref", name: name[0], location: location() };
     };
-  var peg$f19 = function(operator, code) {
+  var peg$f20 = function(operator, code) {
       return {
         type: OPS_TO_SEMANTIC_PREDICATE_TYPES[operator],
         code: code[0],
@@ -494,10 +495,10 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f20 = function(head, tail) {
+  var peg$f21 = function(head, tail) {
       return [head + tail.join(""), location()];
     };
-  var peg$f21 = function(value, ignoreCase) {
+  var peg$f22 = function(value, ignoreCase) {
       return {
         type: "literal",
         value,
@@ -505,9 +506,9 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f22 = function(chars) { return chars.join(""); };
   var peg$f23 = function(chars) { return chars.join(""); };
-  var peg$f24 = function(inverted, parts, ignoreCase) {
+  var peg$f24 = function(chars) { return chars.join(""); };
+  var peg$f25 = function(inverted, parts, ignoreCase) {
       return {
         type: "class",
         parts: parts.filter(part => part !== ""),
@@ -516,7 +517,7 @@ function peg$parse(input, options) {
         location: location()
       };
     };
-  var peg$f25 = function(begin, end) {
+  var peg$f26 = function(begin, end) {
       if (begin.charCodeAt(0) > end.charCodeAt(0)) {
         error(
           "Invalid character range: " + text() + "."
@@ -525,23 +526,23 @@ function peg$parse(input, options) {
 
       return [begin, end];
     };
-  var peg$f26 = function() { return ""; };
-  var peg$f27 = function() { return "\0"; };
-  var peg$f28 = function() { return "\b"; };
-  var peg$f29 = function() { return "\f"; };
-  var peg$f30 = function() { return "\n"; };
-  var peg$f31 = function() { return "\r"; };
-  var peg$f32 = function() { return "\t"; };
-  var peg$f33 = function() { return "\v"; };
-  var peg$f34 = function(digits) {
-      return String.fromCharCode(parseInt(digits, 16));
-    };
+  var peg$f27 = function() { return ""; };
+  var peg$f28 = function() { return "\0"; };
+  var peg$f29 = function() { return "\b"; };
+  var peg$f30 = function() { return "\f"; };
+  var peg$f31 = function() { return "\n"; };
+  var peg$f32 = function() { return "\r"; };
+  var peg$f33 = function() { return "\t"; };
+  var peg$f34 = function() { return "\v"; };
   var peg$f35 = function(digits) {
       return String.fromCharCode(parseInt(digits, 16));
     };
-  var peg$f36 = function() { return { type: "any", location: location() }; };
-  var peg$f37 = function(code) { return [code, location()]; };
-  var peg$f38 = function(digits) { return parseInt(digits); };
+  var peg$f36 = function(digits) {
+      return String.fromCharCode(parseInt(digits, 16));
+    };
+  var peg$f37 = function() { return { type: "any", location: location() }; };
+  var peg$f38 = function(code) { return [code, location()]; };
+  var peg$f39 = function(digits) { return parseInt(digits); };
   var peg$currPos = 0;
   var peg$savedPos = 0;
   var peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -1330,6 +1331,15 @@ function peg$parse(input, options) {
       s1 = peg$f16(s1);
     }
     s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseIdentifierName();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$f17(s1);
+      }
+      s0 = s1;
+    }
 
     return s0;
   }
@@ -1369,7 +1379,7 @@ function peg$parse(input, options) {
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s0 = peg$f17(s3);
+                    s0 = peg$f18(s3);
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -1437,7 +1447,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f18(s1);
+        s0 = peg$f19(s1);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1460,7 +1470,7 @@ function peg$parse(input, options) {
       s3 = peg$parseCodeBlock();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f19(s1, s3);
+        s0 = peg$f20(s1, s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1955,7 +1965,7 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifierPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f20(s1, s2);
+      s0 = peg$f21(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2104,7 +2114,7 @@ function peg$parse(input, options) {
         s2 = null;
       }
       peg$savedPos = s0;
-      s0 = peg$f21(s1, s2);
+      s0 = peg$f22(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2146,7 +2156,7 @@ function peg$parse(input, options) {
       }
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f22(s2);
+        s0 = peg$f23(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2180,7 +2190,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f23(s2);
+          s0 = peg$f24(s2);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2413,7 +2423,7 @@ function peg$parse(input, options) {
           s5 = null;
         }
         peg$savedPos = s0;
-        s0 = peg$f24(s2, s3, s5);
+        s0 = peg$f25(s2, s3, s5);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2448,7 +2458,7 @@ function peg$parse(input, options) {
         s3 = peg$parseClassCharacter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f25(s1, s3);
+          s0 = peg$f26(s1, s3);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2560,7 +2570,7 @@ function peg$parse(input, options) {
       s2 = peg$parseLineTerminatorSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f26();
+        s0 = peg$f27();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2599,7 +2609,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f27();
+          s0 = peg$f28();
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2667,7 +2677,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$f28();
+            s1 = peg$f29();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -2681,7 +2691,7 @@ function peg$parse(input, options) {
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$f29();
+              s1 = peg$f30();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
@@ -2695,7 +2705,7 @@ function peg$parse(input, options) {
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$f30();
+                s1 = peg$f31();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
@@ -2709,7 +2719,7 @@ function peg$parse(input, options) {
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$f31();
+                  s1 = peg$f32();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
@@ -2723,7 +2733,7 @@ function peg$parse(input, options) {
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$f32();
+                    s1 = peg$f33();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
@@ -2737,7 +2747,7 @@ function peg$parse(input, options) {
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$f33();
+                      s1 = peg$f34();
                     }
                     s0 = s1;
                   }
@@ -2856,7 +2866,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f34(s2);
+        s0 = peg$f35(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2916,7 +2926,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f35(s2);
+        s0 = peg$f36(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2970,7 +2980,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f36();
+      s1 = peg$f37();
     }
     s0 = s1;
 
@@ -3023,7 +3033,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseCode();
     peg$savedPos = s0;
-    s1 = peg$f37(s1);
+    s1 = peg$f38(s1);
     s0 = s1;
 
     return s0;
@@ -3260,7 +3270,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f38(s1);
+      s1 = peg$f39(s1);
     }
     s0 = s1;
 

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -231,6 +231,11 @@ declare namespace ast {
     min: RepeatedBoundary | null;
     /** Maximum count of repetitions. */
     max: RepeatedBoundary;
+    /**
+     * An expression that should appeared between occurrences of the `expression`.
+     * Matched parts of input skipped and do not included to the result array.
+     */
+    delimiter: Expression | null;
     expression: Primary;
   }
 

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -210,9 +210,17 @@ declare namespace ast {
     value: string;
   }
 
+  interface FunctionBoundary extends Boundary<"function"> {
+    /** The code from the grammar. */
+    value: string;
+    /** Span that covers all code between `{` and `}`. */
+    codeLocation: LocationRange;
+  }
+
   type RepeatedBoundary
     = ConstantBoundary
-    | VariableBoundary;
+    | VariableBoundary
+    | FunctionBoundary;
 
   /** Expression repeated from `min` to `max` times. */
   interface Repeated extends Expr<"repeated"> {

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -205,8 +205,14 @@ declare namespace ast {
     value: number;
   }
 
+  interface VariableBoundary extends Boundary<"variable"> {
+    /** Repetition count - name of the label of the one of preceding expressions. */
+    value: string;
+  }
+
   type RepeatedBoundary
-    = ConstantBoundary;
+    = ConstantBoundary
+    | VariableBoundary;
 
   /** Expression repeated from `min` to `max` times. */
   interface Repeated extends Expr<"repeated"> {

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -209,7 +209,7 @@ RepeatedExpression
   = expression:PrimaryExpression __ "|" __ boundaries:Boundaries __ "|" {
       let min = boundaries[0];
       let max = boundaries[1];
-      if (max.value === 0) {
+      if (max.type === "constant" && max.value === 0) {
         error("The maximum count of repetitions of the rule must be > 0", max.location);
       }
 
@@ -233,6 +233,7 @@ Boundaries
 
 Boundary
   = value:Integer { return { type: "constant", value, location: location() }; }
+  / value:IdentifierName { return { type: "variable", value: value[0], location: location() }; }
 
 PrimaryExpression
   = LiteralMatcher

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -234,6 +234,14 @@ Boundaries
 Boundary
   = value:Integer { return { type: "constant", value, location: location() }; }
   / value:IdentifierName { return { type: "variable", value: value[0], location: location() }; }
+  / value:CodeBlock {
+    return {
+      type: "function",
+      value: value[0],
+      codeLocation: value[1],
+      location: location(),
+    };
+  }
 
 PrimaryExpression
   = LiteralMatcher

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -206,7 +206,7 @@ SuffixedOperator
   / "+"
 
 RepeatedExpression
-  = expression:PrimaryExpression __ "|" __ boundaries:Boundaries __ "|" {
+  = expression:PrimaryExpression __ "|" __ boundaries:Boundaries __ delimiter:("," __ @Expression __)? "|" {
       let min = boundaries[0];
       let max = boundaries[1];
       if (max.type === "constant" && max.value === 0) {
@@ -218,6 +218,7 @@ RepeatedExpression
         min,
         max,
         expression,
+        delimiter,
         location: location(),
       };
     }

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -197,12 +197,42 @@ SuffixedExpression
         location: location()
       };
     }
+  / RepeatedExpression
   / PrimaryExpression
 
 SuffixedOperator
   = "?"
   / "*"
   / "+"
+
+RepeatedExpression
+  = expression:PrimaryExpression __ "|" __ boundaries:Boundaries __ "|" {
+      let min = boundaries[0];
+      let max = boundaries[1];
+      if (max.value === 0) {
+        error("The maximum count of repetitions of the rule must be > 0", max.location);
+      }
+
+      return {
+        type: "repeated",
+        min,
+        max,
+        expression,
+        location: location(),
+      };
+    }
+
+Boundaries
+  = min:Boundary? __ ".." __ max:Boundary? {
+    return [
+      min !== null ? min : { type: "constant", value: 0 },
+      max !== null ? max : { type: "constant", value: null },
+    ];
+  }
+  / exact:Boundary { return [null, exact]; }
+
+Boundary
+  = value:Integer { return { type: "constant", value, location: location() }; }
 
 PrimaryExpression
   = LiteralMatcher
@@ -429,6 +459,9 @@ BareCodeBlock
 
 Code
   = $((![{}] SourceCharacter)+ / "{" Code "}")*
+
+Integer
+  = digits:$DecimalDigit+ { return parseInt(digits); }
 
 // Unicode Character Categories
 //

--- a/test/behavior/generated-parser-behavior.spec.js
+++ b/test/behavior/generated-parser-behavior.spec.js
@@ -1481,6 +1481,543 @@ describe("generated parser behavior", () => {
           });
         });
       });
+
+      describe("with delimiter", () => {
+        describe("with constant boundaries", () => {
+          it("| .. , delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|.., '~'|", options);
+
+            expect(parser).to.parse("",      []);
+            expect(parser).to.parse("a",     ["a"]);
+            expect(parser).to.parse("a~a",   ["a", "a"]);
+            expect(parser).to.parse("a~a~a", ["a", "a", "a"]);
+          });
+
+          it("|0.. , delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|0.., '~'|", options);
+
+            expect(parser).to.parse("",      []);
+            expect(parser).to.parse("a",     ["a"]);
+            expect(parser).to.parse("a~a",   ["a", "a"]);
+            expect(parser).to.parse("a~a~a", ["a", "a", "a"]);
+          });
+
+          it("|1.. , delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|1.., '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.parse("a",     ["a"]);
+            expect(parser).to.parse("a~a",   ["a", "a"]);
+            expect(parser).to.parse("a~a~a", ["a", "a", "a"]);
+          });
+
+          it("|2.. , delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|2.., '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("a~a",   ["a", "a"]);
+            expect(parser).to.parse("a~a~a", ["a", "a", "a"]);
+          });
+
+          it("| ..1, delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|..1, '~'|", options);
+
+            expect(parser).to.parse("",    []);
+            expect(parser).to.parse("a",   ["a"]);
+            expect(parser).to.failToParse("a~a");
+            expect(parser).to.failToParse("a~a~a");
+          });
+
+          it("| ..2, delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|..2, '~'|", options);
+
+            expect(parser).to.parse("",     []);
+            expect(parser).to.parse("a",    ["a"]);
+            expect(parser).to.parse("a~a",  ["a", "a"]);
+            expect(parser).to.failToParse("a~a~a");
+          });
+
+          it("|2..3, delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|2..3, '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("a~a",   ["a", "a"]);
+            expect(parser).to.parse("a~a~a", ["a", "a", "a"]);
+            expect(parser).to.failToParse("a~a~a~a");
+          });
+
+          it("|2..2, delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|2..2, '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("a~a",  ["a", "a"]);
+            expect(parser).to.failToParse("a~a~a");
+          });
+
+          it("|2   , delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|2, '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("a~a",  ["a", "a"]);
+            expect(parser).to.failToParse("a~a~a");
+          });
+
+          it("|3..2, delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|3..2, '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.failToParse("a~a");
+            expect(parser).to.failToParse("a~a~a");
+          });
+        });
+
+        describe("with variable boundaries", () => {
+          it("|min..   , delimiter| matches correctly", () => {
+            const parser = buildParser("val.., '~'");
+
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start1" + i };
+              expect(parser).to.failToParse("", undefined, opt);
+              expect(parser).to.parse("0", [0, [], ""], opt);
+              expect(parser).to.parse("0==", [0, ["="], "="], opt);
+              expect(parser).to.parse("0=~=", [0, ["=", "="], ""], opt);
+              expect(parser).to.failToParse("1", undefined, opt);
+              expect(parser).to.failToParse("1~", undefined, opt);
+              expect(parser).to.failToParse("2=", undefined, opt);
+              expect(parser).to.failToParse("2=~", undefined, opt);
+              expect(parser).to.failToParse("2==", undefined, opt);
+              expect(parser).to.parse("2=~=", [2, ["=", "="], ""], opt);
+              expect(parser).to.parse("2=~=~", [2, ["=", "="], "~"], opt);
+              expect(parser).to.parse("2=~=~=~=~=", [2, ["=", "=", "=", "=", "="], ""], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start2" + i };
+              expect(parser).to.failToParse("-", undefined, opt);
+              expect(parser).to.parse("-0", ["-", 0, [], ""], opt);
+              expect(parser).to.parse("-0==", ["-", 0, ["="], "="], opt);
+              expect(parser).to.parse("-0=~=", ["-", 0, ["=", "="], ""], opt);
+              expect(parser).to.failToParse("-1", undefined, opt);
+              expect(parser).to.failToParse("-1~", undefined, opt);
+              expect(parser).to.failToParse("-2=", undefined, opt);
+              expect(parser).to.failToParse("-2=~", undefined, opt);
+              expect(parser).to.failToParse("-2==", undefined, opt);
+              expect(parser).to.parse("-2=~=", ["-", 2, ["=", "="], ""], opt);
+              expect(parser).to.parse("-2=~=~", ["-", 2, ["=", "="], "~"], opt);
+              expect(parser).to.parse("-2=~=~=~=~=", ["-", 2, ["=", "=", "=", "=", "="], ""], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start3" + i };
+              expect(parser).to.failToParse("-", undefined, opt);
+              expect(parser).to.parse("-0", ["-", 0, [], ""], opt);
+              expect(parser).to.parse("-0==", ["-", 0, ["="], "="], opt);
+              expect(parser).to.parse("-0=~=", ["-", 0, ["=", "="], ""], opt);
+              expect(parser).to.failToParse("-1", undefined, opt);
+              expect(parser).to.failToParse("-1~", undefined, opt);
+              expect(parser).to.failToParse("-2=", undefined, opt);
+              expect(parser).to.failToParse("-2=~", undefined, opt);
+              expect(parser).to.failToParse("-2==", undefined, opt);
+              expect(parser).to.parse("-2=~=", ["-", 2, ["=", "="], ""], opt);
+              expect(parser).to.parse("-2=~=~", ["-", 2, ["=", "="], "~"], opt);
+              expect(parser).to.parse("-2=~=~=~=~=", ["-", 2, ["=", "=", "=", "=", "="], ""], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start4" + i };
+              expect(parser).to.failToParse("--", undefined, opt);
+              expect(parser).to.parse("--0", ["-", "-", 0, [], ""], opt);
+              expect(parser).to.parse("--0==", ["-", "-", 0, ["="], "="], opt);
+              expect(parser).to.parse("--0=~=", ["-", "-", 0, ["=", "="], ""], opt);
+              expect(parser).to.failToParse("--1", undefined, opt);
+              expect(parser).to.failToParse("--1~", undefined, opt);
+              expect(parser).to.failToParse("--2=", undefined, opt);
+              expect(parser).to.failToParse("--2=~", undefined, opt);
+              expect(parser).to.failToParse("--2==", undefined, opt);
+              expect(parser).to.parse("--2=~=", ["-", "-", 2, ["=", "="], ""], opt);
+              expect(parser).to.parse("--2=~=~", ["-", "-", 2, ["=", "="], "~"], opt);
+              expect(parser).to.parse("--2=~=~=~=~=", ["-", "-", 2, ["=", "=", "=", "=", "="], ""], opt);
+            }
+          });
+
+          it("|   ..max, delimiter| matches correctly", () => {
+            const parser = buildParser("..val, '~'");
+
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start1" + i };
+              expect(parser).to.failToParse("", undefined, opt);
+              expect(parser).to.parse("0", [0, [], ""], opt);
+              expect(parser).to.parse("0==", [0, [], "=="], opt);
+              expect(parser).to.parse("0=~=", [0, [], "=~="], opt);
+              expect(parser).to.parse("3", [3, [], ""], opt);
+              expect(parser).to.parse("3=", [3, ["="], ""], opt);
+              expect(parser).to.parse("3===", [3, ["="], "=="], opt);
+              expect(parser).to.parse("3=~=~", [3, ["=", "="], "~"], opt);
+              expect(parser).to.parse("3=~=~=", [3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("3=~=~=~=~=", [3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start2" + i };
+              expect(parser).to.failToParse("-", undefined, opt);
+              expect(parser).to.parse("-0", ["-", 0, [], ""], opt);
+              expect(parser).to.parse("-0==", ["-", 0, [], "=="], opt);
+              expect(parser).to.parse("-0=~=", ["-", 0, [], "=~="], opt);
+              expect(parser).to.parse("-3", ["-", 3, [], ""], opt);
+              expect(parser).to.parse("-3=", ["-", 3, ["="], ""], opt);
+              expect(parser).to.parse("-3===", ["-", 3, ["="], "=="], opt);
+              expect(parser).to.parse("-3=~=~", ["-", 3, ["=", "="], "~"], opt);
+              expect(parser).to.parse("-3=~=~=", ["-", 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("-3=~=~=~=~=", ["-", 3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start3" + i };
+              expect(parser).to.failToParse("-", undefined, opt);
+              expect(parser).to.parse("-0", ["-", 0, [], ""], opt);
+              expect(parser).to.parse("-0==", ["-", 0, [], "=="], opt);
+              expect(parser).to.parse("-0=~=", ["-", 0, [], "=~="], opt);
+              expect(parser).to.parse("-3", ["-", 3, [], ""], opt);
+              expect(parser).to.parse("-3=", ["-", 3, ["="], ""], opt);
+              expect(parser).to.parse("-3===", ["-", 3, ["="], "=="], opt);
+              expect(parser).to.parse("-3=~=~", ["-", 3, ["=", "="], "~"], opt);
+              expect(parser).to.parse("-3=~=~=", ["-", 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("-3=~=~=~=~=", ["-", 3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start4" + i };
+              expect(parser).to.failToParse("--", undefined, opt);
+              expect(parser).to.parse("--0", ["-", "-", 0, [], ""], opt);
+              expect(parser).to.parse("--0==", ["-", "-", 0, [], "=="], opt);
+              expect(parser).to.parse("--0=~=", ["-", "-", 0, [], "=~="], opt);
+              expect(parser).to.parse("--3", ["-", "-", 3, [], ""], opt);
+              expect(parser).to.parse("--3=", ["-", "-", 3, ["="], ""], opt);
+              expect(parser).to.parse("--3===", ["-", "-", 3, ["="], "=="], opt);
+              expect(parser).to.parse("--3=~=~", ["-", "-", 3, ["=", "="], "~"], opt);
+              expect(parser).to.parse("--3=~=~=", ["-", "-", 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("--3=~=~=~=~=", ["-", "-", 3, ["=", "=", "="], "~=~="], opt);
+            }
+          });
+
+          it("|min..max, delimiter| matches correctly", () => {
+            function buildRangeParser() {
+              const start = [];
+              for (let i = 1; i <= 4; ++i) {
+                for (let j = 1; j <= 4; ++j) {
+                  start[start.length] = "start" + String(i) + j;
+                }
+              }
+              const opt = clone(options);
+              opt.allowedStartRules = start;
+
+              return peg.generate([
+                "start11 =         min:n1 max:n1      .|min..max, '~'|      $.*",
+                "start12 =         min:n1 max:n1 data:.|min..max, '~'|      $.*",
+                "start13 =         min:n1 max:n1      .|min..max, '~'| rest:$.*",
+                "start14 =         min:n1 max:n1 data:.|min..max, '~'| rest:$.*",
+
+                "start21 = .       min:n1 max:n1      .|min..max, '~'|      $.*",
+                "start22 = .       min:n1 max:n1 data:.|min..max, '~'|      $.*",
+                "start23 = .       min:n1 max:n1      .|min..max, '~'| rest:$.*",
+                "start24 = .       min:n1 max:n1 data:.|min..max, '~'| rest:$.*",
+
+                "start31 = a:.     min:n1 max:n1      .|min..max, '~'|      $.*",
+                "start32 = a:.     min:n1 max:n1 data:.|min..max, '~'|      $.*",
+                "start33 = a:.     min:n1 max:n1      .|min..max, '~'| rest:$.*",
+                "start34 = a:.     min:n1 max:n1 data:.|min..max, '~'| rest:$.*",
+
+                "start41 = a:. b:. min:n1 max:n1      .|min..max, '~'|      $.*",
+                "start42 = a:. b:. min:n1 max:n1 data:.|min..max, '~'|      $.*",
+                "start43 = a:. b:. min:n1 max:n1      .|min..max, '~'| rest:$.*",
+                "start44 = a:. b:. min:n1 max:n1 data:.|min..max, '~'| rest:$.*",
+
+                "n1 = n:$[0-9] { return parseInt(n, 10); }",
+              ].join(";\n"), opt);
+            }
+
+            const parser = buildRangeParser();
+
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start1" + i };
+              expect(parser).to.failToParse("", undefined, opt);
+              expect(parser).to.parse("00", [0, 0, [], ""], opt);
+              expect(parser).to.parse("00==", [0, 0, [], "=="], opt);
+              expect(parser).to.parse("00=~=", [0, 0, [], "=~="], opt);
+              expect(parser).to.failToParse("23", undefined, opt);
+              expect(parser).to.failToParse("23=", undefined, opt);
+              expect(parser).to.failToParse("23=~", undefined, opt);
+              expect(parser).to.failToParse("23==", undefined, opt);
+              expect(parser).to.parse("23=~=", [2, 3, ["=", "="], ""], opt);
+              expect(parser).to.parse("23=~=~", [2, 3, ["=", "="], "~"], opt);
+              expect(parser).to.parse("23=~=~=", [2, 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("23=~=~=~=~=", [2, 3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start2" + i };
+              expect(parser).to.failToParse("-", undefined, opt);
+              expect(parser).to.parse("-00", ["-", 0, 0, [], ""], opt);
+              expect(parser).to.parse("-00==", ["-", 0, 0, [], "=="], opt);
+              expect(parser).to.parse("-00=~=", ["-", 0, 0, [], "=~="], opt);
+              expect(parser).to.failToParse("-23", undefined, opt);
+              expect(parser).to.failToParse("-23=", undefined, opt);
+              expect(parser).to.failToParse("-23=~", undefined, opt);
+              expect(parser).to.failToParse("-23==", undefined, opt);
+              expect(parser).to.parse("-23=~=", ["-", 2, 3, ["=", "="], ""], opt);
+              expect(parser).to.parse("-23=~=~", ["-", 2, 3, ["=", "="], "~"], opt);
+              expect(parser).to.parse("-23=~=~=", ["-", 2, 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("-23=~=~=~=~=", ["-", 2, 3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start3" + i };
+              expect(parser).to.failToParse("-", undefined, opt);
+              expect(parser).to.parse("-00", ["-", 0, 0, [], ""], opt);
+              expect(parser).to.parse("-00==", ["-", 0, 0, [], "=="], opt);
+              expect(parser).to.parse("-00=~=", ["-", 0, 0, [], "=~="], opt);
+              expect(parser).to.failToParse("-23", undefined, opt);
+              expect(parser).to.failToParse("-23=", undefined, opt);
+              expect(parser).to.failToParse("-23=~", undefined, opt);
+              expect(parser).to.failToParse("-23==", undefined, opt);
+              expect(parser).to.parse("-23=~=", ["-", 2, 3, ["=", "="], ""], opt);
+              expect(parser).to.parse("-23=~=~", ["-", 2, 3, ["=", "="], "~"], opt);
+              expect(parser).to.parse("-23=~=~=", ["-", 2, 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("-23=~=~=~=~=", ["-", 2, 3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start4" + i };
+              expect(parser).to.failToParse("--", undefined, opt);
+              expect(parser).to.parse("--00", ["-", "-", 0, 0, [], ""], opt);
+              expect(parser).to.parse("--00==", ["-", "-", 0, 0, [], "=="], opt);
+              expect(parser).to.parse("--00=~=", ["-", "-", 0, 0, [], "=~="], opt);
+              expect(parser).to.failToParse("--23", undefined, opt);
+              expect(parser).to.failToParse("--23=", undefined, opt);
+              expect(parser).to.failToParse("--23=~", undefined, opt);
+              expect(parser).to.failToParse("--23==", undefined, opt);
+              expect(parser).to.parse("--23=~=", ["-", "-", 2, 3, ["=", "="], ""], opt);
+              expect(parser).to.parse("--23=~=~", ["-", "-", 2, 3, ["=", "="], "~"], opt);
+              expect(parser).to.parse("--23=~=~=", ["-", "-", 2, 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("--23=~=~=~=~=", ["-", "-", 2, 3, ["=", "=", "="], "~=~="], opt);
+            }
+          });
+
+          it("|val..val, delimiter| matches correctly", () => {
+            const parser = buildParser("val, '~'");
+
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start1" + i };
+              expect(parser).to.failToParse("", undefined, opt);
+              expect(parser).to.parse("0", [0, [], ""], opt);
+              expect(parser).to.parse("0==", [0, [], "=="], opt);
+              expect(parser).to.parse("0=~=", [0, [], "=~="], opt);
+              expect(parser).to.failToParse("3", undefined, opt);
+              expect(parser).to.failToParse("3=", undefined, opt);
+              expect(parser).to.failToParse("3=~", undefined, opt);
+              expect(parser).to.parse("3=~=~=", [3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("3=~=~=~", [3, ["=", "=", "="], "~"], opt);
+              expect(parser).to.parse("3=~=~=~=~=", [3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start2" + i };
+              expect(parser).to.failToParse("-", undefined, opt);
+              expect(parser).to.parse("-0", ["-", 0, [], ""], opt);
+              expect(parser).to.parse("-0==", ["-", 0, [], "=="], opt);
+              expect(parser).to.parse("-0=~=", ["-", 0, [], "=~="], opt);
+              expect(parser).to.failToParse("-3", undefined, opt);
+              expect(parser).to.failToParse("-3=", undefined, opt);
+              expect(parser).to.failToParse("-3=~", undefined, opt);
+              expect(parser).to.parse("-3=~=~=", ["-", 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("-3=~=~=~", ["-", 3, ["=", "=", "="], "~"], opt);
+              expect(parser).to.parse("-3=~=~=~=~=", ["-", 3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start3" + i };
+              expect(parser).to.failToParse("-", undefined, opt);
+              expect(parser).to.parse("-0", ["-", 0, [], ""], opt);
+              expect(parser).to.parse("-0==", ["-", 0, [], "=="], opt);
+              expect(parser).to.parse("-0=~=", ["-", 0, [], "=~="], opt);
+              expect(parser).to.failToParse("-3", undefined, opt);
+              expect(parser).to.failToParse("-3=", undefined, opt);
+              expect(parser).to.failToParse("-3=~", undefined, opt);
+              expect(parser).to.parse("-3=~=~=", ["-", 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("-3=~=~=~", ["-", 3, ["=", "=", "="], "~"], opt);
+              expect(parser).to.parse("-3=~=~=~=~=", ["-", 3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start4" + i };
+              expect(parser).to.failToParse("--", undefined, opt);
+              expect(parser).to.parse("--0", ["-", "-", 0, [], ""], opt);
+              expect(parser).to.parse("--0==", ["-", "-", 0, [], "=="], opt);
+              expect(parser).to.parse("--0=~=", ["-", "-", 0, [], "=~="], opt);
+              expect(parser).to.failToParse("--3", undefined, opt);
+              expect(parser).to.failToParse("--3=", undefined, opt);
+              expect(parser).to.failToParse("--3=~", undefined, opt);
+              expect(parser).to.parse("--3=~=~=", ["-", "-", 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("--3=~=~=~", ["-", "-", 3, ["=", "=", "="], "~"], opt);
+              expect(parser).to.parse("--3=~=~=~=~=", ["-", "-", 3, ["=", "=", "="], "~=~="], opt);
+            }
+          });
+
+          it("| exact  , delimiter| matches correctly", () => {
+            const parser = buildParser("val, '~'");
+
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start1" + i };
+              expect(parser).to.failToParse("", undefined, opt);
+              expect(parser).to.parse("0", [0, [], ""], opt);
+              expect(parser).to.parse("0==", [0, [], "=="], opt);
+              expect(parser).to.parse("0=~=", [0, [], "=~="], opt);
+              expect(parser).to.failToParse("3", undefined, opt);
+              expect(parser).to.failToParse("3=", undefined, opt);
+              expect(parser).to.failToParse("3=~", undefined, opt);
+              expect(parser).to.parse("3=~=~=", [3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("3=~=~=~", [3, ["=", "=", "="], "~"], opt);
+              expect(parser).to.parse("3=~=~=~=~=", [3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start2" + i };
+              expect(parser).to.failToParse("-", undefined, opt);
+              expect(parser).to.parse("-0", ["-", 0, [], ""], opt);
+              expect(parser).to.parse("-0==", ["-", 0, [], "=="], opt);
+              expect(parser).to.parse("-0=~=", ["-", 0, [], "=~="], opt);
+              expect(parser).to.failToParse("-3", undefined, opt);
+              expect(parser).to.failToParse("-3=", undefined, opt);
+              expect(parser).to.failToParse("-3=~", undefined, opt);
+              expect(parser).to.parse("-3=~=~=", ["-", 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("-3=~=~=~", ["-", 3, ["=", "=", "="], "~"], opt);
+              expect(parser).to.parse("-3=~=~=~=~=", ["-", 3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start3" + i };
+              expect(parser).to.failToParse("-", undefined, opt);
+              expect(parser).to.parse("-0", ["-", 0, [], ""], opt);
+              expect(parser).to.parse("-0==", ["-", 0, [], "=="], opt);
+              expect(parser).to.parse("-0=~=", ["-", 0, [], "=~="], opt);
+              expect(parser).to.failToParse("-3", undefined, opt);
+              expect(parser).to.failToParse("-3=", undefined, opt);
+              expect(parser).to.failToParse("-3=~", undefined, opt);
+              expect(parser).to.parse("-3=~=~=", ["-", 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("-3=~=~=~", ["-", 3, ["=", "=", "="], "~"], opt);
+              expect(parser).to.parse("-3=~=~=~=~=", ["-", 3, ["=", "=", "="], "~=~="], opt);
+            }
+            for (let i = 1; i <= 4; ++i) {
+              const opt = { startRule: "start4" + i };
+              expect(parser).to.failToParse("--", undefined, opt);
+              expect(parser).to.parse("--0", ["-", "-", 0, [], ""], opt);
+              expect(parser).to.parse("--0==", ["-", "-", 0, [], "=="], opt);
+              expect(parser).to.parse("--0=~=", ["-", "-", 0, [], "=~="], opt);
+              expect(parser).to.failToParse("--3", undefined, opt);
+              expect(parser).to.failToParse("--3=", undefined, opt);
+              expect(parser).to.failToParse("--3=~", undefined, opt);
+              expect(parser).to.parse("--3=~=~=", ["-", "-", 3, ["=", "=", "="], ""], opt);
+              expect(parser).to.parse("--3=~=~=~", ["-", "-", 3, ["=", "=", "="], "~"], opt);
+              expect(parser).to.parse("--3=~=~=~=~=", ["-", "-", 3, ["=", "=", "="], "~=~="], opt);
+            }
+          });
+        });
+
+        describe("with function boundaries", () => {
+          it("|{2}..   , delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|{ return 2; }.., '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("a~a",   ["a", "a"]);
+            expect(parser).to.parse("a~a~a", ["a", "a", "a"]);
+          });
+
+          it("|   ..{2}, delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|..{ return 2; }, '~'|", options);
+
+            expect(parser).to.parse("",     []);
+            expect(parser).to.parse("a",    ["a"]);
+            expect(parser).to.parse("a~a",  ["a", "a"]);
+            expect(parser).to.failToParse("a~a~a");
+          });
+
+          it("|{2}..{3}, delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|{ return 2; }..{ return 3; }, '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("a~a",   ["a", "a"]);
+            expect(parser).to.parse("a~a~a", ["a", "a", "a"]);
+            expect(parser).to.failToParse("a~a~a~a");
+          });
+
+          it("|{2}..{2}, delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|{ return 2; }..{ return 2; }, '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("a~a",  ["a", "a"]);
+            expect(parser).to.failToParse("a~a~a");
+          });
+
+          it("|{2}     , delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|{ return 2; }, '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("a~a",  ["a", "a"]);
+            expect(parser).to.failToParse("a~a~a");
+          });
+
+          it("|{3}..{2}, delimiter| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|{ return 3; }..{ return 2; }, '~'|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.failToParse("a~a");
+            expect(parser).to.failToParse("a~a~a");
+          });
+        });
+      });
+
+      describe("handle delimiter correctly", () => {
+        it("with constant boundaries", () => {
+          const parser = peg.generate("start = 'a'|2..3, '~'|", options);
+
+          expect(parser).to.failToParse("");
+          expect(parser).to.failToParse("a");
+          expect(parser).to.failToParse("aa");
+          expect(parser).to.failToParse("a~");
+          expect(parser).to.parse("a~a",   ["a", "a"]);
+          expect(parser).to.failToParse("a~a~");
+          expect(parser).to.parse("a~a~a", ["a", "a", "a"]);
+          expect(parser).to.failToParse("a~a~a~");
+          expect(parser).to.failToParse("a~a~a~a");
+        });
+
+        it("with variable boundaries", () => {
+          const parser = peg.generate([
+            "start = min:n1 max:n1 'a'|min..max, '~'|",
+            "n1 = n:$[0-9] { return parseInt(n, 10); }",
+          ].join(";\n"), options);
+
+          expect(parser).to.failToParse("23");
+          expect(parser).to.failToParse("23a");
+          expect(parser).to.failToParse("23aa");
+          expect(parser).to.failToParse("23a~");
+          expect(parser).to.parse("23a~a",   [2, 3, ["a", "a"]]);
+          expect(parser).to.failToParse("a~a~");
+          expect(parser).to.parse("23a~a~a", [2, 3, ["a", "a", "a"]]);
+          expect(parser).to.failToParse("23a~a~a~");
+          expect(parser).to.failToParse("23a~a~a~a");
+        });
+
+        it("with function boundaries", () => {
+          const parser = peg.generate("start = 'a'|{ return 2; }..{ return 3; }, '~'|", options);
+
+          expect(parser).to.failToParse("");
+          expect(parser).to.failToParse("a");
+          expect(parser).to.failToParse("aa");
+          expect(parser).to.failToParse("a~");
+          expect(parser).to.parse("a~a",   ["a", "a"]);
+          expect(parser).to.failToParse("a~a~");
+          expect(parser).to.parse("a~a~a", ["a", "a", "a"]);
+          expect(parser).to.failToParse("a~a~a~");
+          expect(parser).to.failToParse("a~a~a~a");
+        });
+      });
     });
 
     describe("text", () => {

--- a/test/behavior/generated-parser-behavior.spec.js
+++ b/test/behavior/generated-parser-behavior.spec.js
@@ -1380,6 +1380,106 @@ describe("generated parser behavior", () => {
             }
           });
         });
+
+        describe("with function boundaries", () => {
+          it("|{min}..     | matches correctly", () => {
+            const parser = peg.generate("start = 'a'|{ return 2; }..|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.parse("aaa", ["a", "a", "a"]);
+          });
+
+          it("|     ..{max}| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|..{ return 2; }|", options);
+
+            expect(parser).to.parse("",    []);
+            expect(parser).to.parse("a",   ["a"]);
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.failToParse("aaa");
+          });
+
+          it("|{min}..{max}| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|{ return 2; }..{ return 3; }|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.parse("aaa", ["a", "a", "a"]);
+            expect(parser).to.failToParse("aaaa");
+          });
+
+          it("|{val}..{val}| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|{ return 2; }..{ return 2; }|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.failToParse("aaa");
+          });
+
+          it("|  {exact}   | matches correctly", () => {
+            const parser = peg.generate("start = 'a'|{ return 2; }|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.failToParse("aaa");
+          });
+
+          describe("function called only once", () => {
+            it("in |{min}..     |", () => {
+              const parser = peg.generate(`
+                { let min = 0; }
+                start = 'a'|{ ++min; return 2; }..| { return min; }
+              `, options);
+
+              // Always one check - after the loop
+              expect(parser).to.parse("aa", 1);
+              expect(parser).to.parse("aaa", 1);
+            });
+
+            it("in |     ..{max}|", () => {
+              const parser = peg.generate(`
+                { let max = 0; }
+                start = 'a'|..{ ++max; return 3; }| { return max; }
+              `, options);
+
+              expect(parser).to.parse("aa", 1);
+              expect(parser).to.parse("aaa", 1);
+            });
+
+            it("in |{min}..{max}|", () => {
+              const parser = peg.generate(`
+                {
+                  let min = 0;
+                  let max = 0;
+                }
+                start = 'a'|
+                  { ++min; return 0; }
+                  ..
+                  { ++max; return 3; }
+                | { return [min, max]; }
+              `, options);
+
+              expect(parser).to.parse("",    [1, 1]);
+              expect(parser).to.parse("a",   [1, 1]);
+              expect(parser).to.parse("aa",  [1, 1]);
+              expect(parser).to.parse("aaa", [1, 1]);
+            });
+
+            it("in |  {exact}   |", () => {
+              const parser = peg.generate(`
+                { let count = 0; }
+                start = 'a'|{ ++count; return options.exact; }| { return count; }
+              `, options);
+
+              expect(parser).to.parse("", 1, { exact: 0 });
+              expect(parser).to.parse("aa", 1, { exact: 2 });
+            });
+          });
+        });
       });
     });
 

--- a/test/behavior/generated-parser-behavior.spec.js
+++ b/test/behavior/generated-parser-behavior.spec.js
@@ -501,6 +501,38 @@ describe("generated parser behavior", () => {
                 input: "a",
               },
               {
+                grammar: "start = (a:'a')| .. | &{ return a === 'a'; }",
+                input: "a",
+              },
+              {
+                grammar: "start = (a:'a')|0.. | &{ return a === 'a'; }",
+                input: "a",
+              },
+              {
+                grammar: "start = (a:'a')|1.. | &{ return a === 'a'; }",
+                input: "a",
+              },
+              {
+                grammar: "start = (a:'a')|2.. | &{ return a === 'a'; }",
+                input: "aa",
+              },
+              {
+                grammar: "start = (a:'a')| ..1| &{ return a === 'a'; }",
+                input: "a",
+              },
+              {
+                grammar: "start = (a:'a')| ..3| &{ return a === 'a'; }",
+                input: "a",
+              },
+              {
+                grammar: "start = (a:'a')|2..3| &{ return a === 'a'; }",
+                input: "aa",
+              },
+              {
+                grammar: "start = (a:'a')|3| &{ return a === 'a'; }",
+                input: "aaa",
+              },
+              {
                 grammar: "start = $(a:'a') &{ return a === 'a'; }",
                 input: "a",
               },
@@ -719,6 +751,38 @@ describe("generated parser behavior", () => {
                 input: "a",
               },
               {
+                grammar: "start = (a:'a')| .. | !{ return a !== 'a'; }",
+                input: "a",
+              },
+              {
+                grammar: "start = (a:'a')|0.. | !{ return a !== 'a'; }",
+                input: "a",
+              },
+              {
+                grammar: "start = (a:'a')|1.. | !{ return a !== 'a'; }",
+                input: "a",
+              },
+              {
+                grammar: "start = (a:'a')|2.. | !{ return a !== 'a'; }",
+                input: "aa",
+              },
+              {
+                grammar: "start = (a:'a')| ..1| !{ return a !== 'a'; }",
+                input: "a",
+              },
+              {
+                grammar: "start = (a:'a')| ..3| !{ return a !== 'a'; }",
+                input: "a",
+              },
+              {
+                grammar: "start = (a:'a')|2..3| !{ return a !== 'a'; }",
+                input: "aa",
+              },
+              {
+                grammar: "start = (a:'a')|3| !{ return a !== 'a'; }",
+                input: "aaa",
+              },
+              {
                 grammar: "start = $(a:'a') !{ return a !== 'a'; }",
                 input: "a",
               },
@@ -910,6 +974,109 @@ describe("generated parser behavior", () => {
           const parser = peg.generate("start = 'a'+", options);
 
           expect(parser).to.failToParse("");
+        });
+      });
+    });
+
+    describe("repeated", () => {
+      describe("without delimiter", () => {
+        describe("with constant boundaries", () => {
+          it("| .. | matches correctly", () => {
+            const parser = peg.generate("start = 'a'|..|", options);
+
+            expect(parser).to.parse("",    []);
+            expect(parser).to.parse("a",   ["a"]);
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.parse("aaa", ["a", "a", "a"]);
+          });
+
+          it("|0.. | matches correctly", () => {
+            const parser = peg.generate("start = 'a'|0..|", options);
+
+            expect(parser).to.parse("",    []);
+            expect(parser).to.parse("a",   ["a"]);
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.parse("aaa", ["a", "a", "a"]);
+          });
+
+          it("|1.. | matches correctly", () => {
+            const parser = peg.generate("start = 'a'|1..|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.parse("a",   ["a"]);
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.parse("aaa", ["a", "a", "a"]);
+          });
+
+          it("|2.. | matches correctly", () => {
+            const parser = peg.generate("start = 'a'|2..|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.parse("aaa", ["a", "a", "a"]);
+          });
+
+          it("| ..1| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|..1|", options);
+
+            expect(parser).to.parse("",    []);
+            expect(parser).to.parse("a",   ["a"]);
+            expect(parser).to.failToParse("aa");
+            expect(parser).to.failToParse("aaa");
+          });
+
+          it("| ..2| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|..2|", options);
+
+            expect(parser).to.parse("",    []);
+            expect(parser).to.parse("a",   ["a"]);
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.failToParse("aaa");
+          });
+
+          it("|2..3| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|2..3|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.parse("aaa", ["a", "a", "a"]);
+            expect(parser).to.failToParse("aaaa");
+          });
+
+          it("|2..2| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|2..2|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.failToParse("aaa");
+          });
+
+          it("| 2  | matches correctly", () => {
+            const parser = peg.generate("start = 'a'|2|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.parse("aa",  ["a", "a"]);
+            expect(parser).to.failToParse("aaa");
+          });
+
+          it("|3..2| matches correctly", () => {
+            const parser = peg.generate("start = 'a'|3..2|", options);
+
+            expect(parser).to.failToParse("");
+            expect(parser).to.failToParse("a");
+            expect(parser).to.failToParse("aa");
+            expect(parser).to.failToParse("aaa");
+          });
+
+          it("does not consume input on failure", () => {
+            const parser = peg.generate("start = 'a'|3| / 'a'|2| { return 42; }", options);
+
+            expect(parser).to.parse("aa", 42);
+          });
         });
       });
     });
@@ -1134,6 +1301,38 @@ describe("generated parser behavior", () => {
                 {
                   grammar: "start = (a:'a')+ { return a; }",
                   input: "a",
+                },
+                {
+                  grammar: "start = (a:'a')| .. | { return a; }",
+                  input: "a",
+                },
+                {
+                  grammar: "start = (a:'a')|0.. | { return a; }",
+                  input: "a",
+                },
+                {
+                  grammar: "start = (a:'a')|1.. | { return a; }",
+                  input: "a",
+                },
+                {
+                  grammar: "start = (a:'a')|2.. | { return a; }",
+                  input: "aa",
+                },
+                {
+                  grammar: "start = (a:'a')| ..1| { return a; }",
+                  input: "a",
+                },
+                {
+                  grammar: "start = (a:'a')| ..3| { return a; }",
+                  input: "a",
+                },
+                {
+                  grammar: "start = (a:'a')|2..3| { return a; }",
+                  input: "aa",
+                },
+                {
+                  grammar: "start = (a:'a')|3| { return a; }",
+                  input: "aaa",
                 },
                 {
                   grammar: "start = $(a:'a') { return a; }",

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -281,6 +281,7 @@ describe("peg.d.ts", () => {
         expectType<peggy.LocationRange>(node.location);
         expectType<peggy.ast.RepeatedBoundary | null>(node.min);
         expectType<peggy.ast.RepeatedBoundary>(node.max);
+        expectType<peggy.ast.Expression | null>(node.delimiter);
         expectType<peggy.ast.Primary>(node.expression);
         visit(node.expression);
       },

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -184,6 +184,7 @@ describe("peg.d.ts", () => {
           peggy.ast.Labeled |
           peggy.ast.Prefixed |
           peggy.ast.Suffixed |
+          peggy.ast.Repeated |
           peggy.ast.Primary>(node.expression);
         visit(node.expression);
       },
@@ -206,6 +207,7 @@ describe("peg.d.ts", () => {
         expectType<
           peggy.ast.Prefixed |
           peggy.ast.Suffixed |
+          peggy.ast.Repeated |
           peggy.ast.Primary>(node.expression);
         visit(node.expression);
       },
@@ -215,7 +217,10 @@ describe("peg.d.ts", () => {
         expectType<"text" | "simple_and" | "simple_not">(node.type);
         expect(node.type).toBe("text");
         expectType<peggy.LocationRange>(node.location);
-        expectType<peggy.ast.Suffixed | peggy.ast.Primary>(node.expression);
+        expectType<
+          peggy.ast.Suffixed |
+          peggy.ast.Repeated |
+          peggy.ast.Primary>(node.expression);
         visit(node.expression);
       },
       simple_and(node) {
@@ -224,7 +229,10 @@ describe("peg.d.ts", () => {
         expectType<"text" | "simple_and" | "simple_not">(node.type);
         expect(node.type).toBe("simple_and");
         expectType<peggy.LocationRange>(node.location);
-        expectType<peggy.ast.Suffixed | peggy.ast.Primary>(node.expression);
+        expectType<
+          peggy.ast.Suffixed |
+          peggy.ast.Repeated |
+          peggy.ast.Primary>(node.expression);
         visit(node.expression);
       },
       simple_not(node) {
@@ -232,7 +240,10 @@ describe("peg.d.ts", () => {
         expectType<peggy.ast.Prefixed>(node);
         expectType<"text" | "simple_and" | "simple_not">(node.type);
         expect(node.type).toBe("simple_not");
-        expectType<peggy.ast.Suffixed | peggy.ast.Primary>(node.expression);
+        expectType<
+          peggy.ast.Suffixed |
+          peggy.ast.Repeated |
+          peggy.ast.Primary>(node.expression);
         visit(node.expression);
       },
       optional(node) {

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -273,6 +273,17 @@ describe("peg.d.ts", () => {
         expectType<peggy.ast.Primary>(node.expression);
         visit(node.expression);
       },
+      repeated(node) {
+        add(node.type);
+        expectType<peggy.ast.Repeated>(node);
+        expectType<"repeated">(node.type);
+        expect(node.type).toBe("repeated");
+        expectType<peggy.LocationRange>(node.location);
+        expectType<peggy.ast.RepeatedBoundary | null>(node.min);
+        expectType<peggy.ast.RepeatedBoundary>(node.max);
+        expectType<peggy.ast.Primary>(node.expression);
+        visit(node.expression);
+      },
       group(node) {
         add(node.type);
         expectType<peggy.ast.Group>(node);
@@ -346,6 +357,7 @@ describe("peg.d.ts", () => {
       "named",
       "one_or_more",
       "optional",
+      "repeated",
       "rule",
       "rule_ref",
       "semantic_and",

--- a/test/unit/compiler/passes/generate-bytecode.spec.js
+++ b/test/unit/compiler/passes/generate-bytecode.spec.js
@@ -452,6 +452,236 @@ describe("compiler pass |generateBytecode|", () => {
     });
   });
 
+  describe("for repeated", () => {
+    describe("without delimiter", () => {
+      describe("| .. | (edge case -- no boundaries)", () => {
+        const grammar = "start = 'a'| .. |";
+
+        it("generates correct bytecode", () => {
+          expect(pass).to.changeAST(grammar, bytecodeDetails([
+            4,                            // PUSH_EMPTY_ARRAY
+            18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+            16, 9,                        // WHILE_NOT_ERROR
+            10,                           //   * APPEND
+            18, 0, 2, 2, 22, 0, 23, 0,    //     <expression>
+            6,                            // POP
+          ]));
+        });
+
+        it("defines correct constants", () => {
+          expect(pass).to.changeAST(grammar, constsDetails(
+            ["a"],
+            [],
+            [{ type: "literal", value: "a", ignoreCase: false }],
+            []
+          ));
+        });
+      });
+
+      describe("with constant boundaries", () => {
+        describe("| ..3| (edge case -- no min boundary)", () => {
+          const grammar = "start = 'a'| ..3|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 14,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              31, 3, 1, 8,                  //     IF_GE <3>
+              3,                            //       * PUSH_FAILED
+              18, 0, 2, 2, 22, 0, 23, 0,    //       * <expression>
+              6,                            // POP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a"],
+              [],
+              [{ type: "literal", value: "a", ignoreCase: false }],
+              []
+            ));
+          });
+        });
+
+        describe("| ..1| (edge case -- no min boundary -- same as |optional|)", () => {
+          const grammar = "start = 'a'| ..1|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 14,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              31, 1, 1, 8,                  //     IF_GE <1>
+              3,                            //       * PUSH_FAILED
+              18, 0, 2, 2, 22, 0, 23, 0,    //       * <expression>
+              6,                            // POP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a"],
+              [],
+              [{ type: "literal", value: "a", ignoreCase: false }],
+              []
+            ));
+          });
+        });
+
+        describe("|2.. | (edge case -- no max boundary)", () => {
+          const grammar = "start = 'a'|2.. |";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 9,                        // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              18, 0, 2, 2, 22, 0, 23, 0,    //     <expression>
+              6,                            // POP
+              30, 2, 3, 1,                  // IF_LT <2>
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+              9,                            //   * NIP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a"],
+              [],
+              [{ type: "literal", value: "a", ignoreCase: false }],
+              []
+            ));
+          });
+        });
+
+        describe("|0.. | (edge case -- no max boundary -- same as |zero or more|)", () => {
+          const grammar = "start = 'a'|0.. |";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 9,                        // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              18, 0, 2, 2, 22, 0, 23, 0,    //     <expression>
+              6,                            // POP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a"],
+              [],
+              [{ type: "literal", value: "a", ignoreCase: false }],
+              []
+            ));
+          });
+        });
+
+        describe("|1.. | (edge case -- no max boundary -- same as |one or more|)", () => {
+          const grammar = "start = 'a'|1.. |";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 9,                        // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              18, 0, 2, 2, 22, 0, 23, 0,    //     <expression>
+              6,                            // POP
+              30, 1, 3, 1,                  // IF_LT <1>
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+              9,                            //   * NIP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a"],
+              [],
+              [{ type: "literal", value: "a", ignoreCase: false }],
+              []
+            ));
+          });
+        });
+
+        describe("|2..3|", () => {
+          const grammar = "start = 'a'|2..3|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 14,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              31, 3, 1, 8,                  //     IF_GE <3>
+              3,                            //       * PUSH_FAILED
+              18, 0, 2, 2, 22, 0, 23, 0,    //       * <expression>
+              6,                            // POP
+              30, 2, 3, 1,                  // IF_LT <2>
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+              9,                            //   * NIP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a"],
+              [],
+              [{ type: "literal", value: "a", ignoreCase: false }],
+              []
+            ));
+          });
+        });
+
+        describe("| 42 | (edge case -- exact repetitions)", () => {
+          const grammar = "start = 'a'|42|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 14,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              31, 42, 1, 8,                 //     IF_GE <42>
+              3,                            //       * PUSH_FAILED
+              18, 0, 2, 2, 22, 0, 23, 0,    //       * <expression>
+              6,                            // POP
+              30, 42, 3, 1,                 // IF_LT <42>
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+              9,                            //   * NIP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a"],
+              [],
+              [{ type: "literal", value: "a", ignoreCase: false }],
+              []
+            ));
+          });
+        });
+      });
+    });
+  });
+
   describe("for group", () => {
     const grammar = "start = ('a')";
 

--- a/test/unit/compiler/passes/generate-bytecode.spec.js
+++ b/test/unit/compiler/passes/generate-bytecode.spec.js
@@ -906,6 +906,617 @@ describe("compiler pass |generateBytecode|", () => {
         });
       });
     });
+
+    describe("with delimiter", () => {
+      describe("| .. , delim| (edge case -- no boundaries)", () => {
+        const grammar = "start = 'a'| .. , 'b'|";
+
+        it("generates correct bytecode", () => {
+          expect(pass).to.changeAST(grammar, bytecodeDetails([
+            4,                            // PUSH_EMPTY_ARRAY
+            18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+            16, 30,                       // WHILE_NOT_ERROR
+            10,                           //   * APPEND
+            5,                            //     PUSH_CURR_POS
+            18, 1, 2, 2, 22, 1, 23, 1,    //     <delimiter>
+            15, 16, 1,                    //     IF_NOT_ERROR
+            6,                            //       * POP
+            18, 0, 2, 2, 22, 0, 23, 0,    //         <expression>
+            14, 3, 1,                     //         IF_ERROR
+            6,                            //           * POP
+            7,                            //             POP_CURR_POS
+            3,                            //             PUSH_FAILED
+            9,                            //           * NIP
+            9,                            //        * NIP
+            6,                            //     POP
+          ]));
+        });
+
+        it("defines correct constants", () => {
+          expect(pass).to.changeAST(grammar, constsDetails(
+            ["a", "b"],
+            [],
+            [
+              { type: "literal", value: "a", ignoreCase: false },
+              { type: "literal", value: "b", ignoreCase: false },
+            ],
+            []
+          ));
+        });
+      });
+
+      describe("constant boundaries", () => {
+        describe("| ..3, delim| (edge case -- no min boundary)", () => {
+          const grammar = "start = 'a'| ..3, 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 35,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              31, 3, 1, 29,                 //     IF_GE <3>
+              3,                            //       * PUSH_FAILED
+              5,                            //       * PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //         <delimiter>
+              15, 16, 1,                    //         IF_NOT_ERROR
+              6,                            //           * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //             <expression>
+              14, 3, 1,                     //             IF_ERROR
+              6,                            //               * POP
+              7,                            //                 POP_CURR_POS
+              3,                            //                 PUSH_FAILED
+              9,                            //               * NIP
+              9,                            //            * NIP
+              6,                            //     POP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              []
+            ));
+          });
+        });
+
+        describe("| ..1, delim| (edge case -- no min boundary -- same as |optional|)", () => {
+          const grammar = "start = 'a'| ..1, 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 35,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              31, 1, 1, 29,                 //     IF_GE <1>
+              3,                            //       * PUSH_FAILED
+              5,                            //       * PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //         <delimiter>
+              15, 16, 1,                    //         IF_NOT_ERROR
+              6,                            //           * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //             <expression>
+              14, 3, 1,                     //             IF_ERROR
+              6,                            //               * POP
+              7,                            //                 POP_CURR_POS
+              3,                            //                 PUSH_FAILED
+              9,                            //               * NIP
+              9,                            //            * NIP
+              6,                            //     POP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              []
+            ));
+          });
+        });
+
+        describe("|2.. , delim| (edge case -- no max boundary)", () => {
+          const grammar = "start = 'a'|2.. , 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 30,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              5,                            //     PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //     <delimiter>
+              15, 16, 1,                    //     IF_NOT_ERROR
+              6,                            //       * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //         <expression>
+              14, 3, 1,                     //         IF_ERROR
+              6,                            //           * POP
+              7,                            //             POP_CURR_POS
+              3,                            //             PUSH_FAILED
+              9,                            //           * NIP
+              9,                            //       * NIP
+              6,                            //     POP
+              30, 2, 3, 1,                  // IF_LT <2>
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+              9,                            //   * NIP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              []
+            ));
+          });
+        });
+
+        describe("|0.. , delim| (edge case -- no max boundary -- same as |zero or more|)", () => {
+          const grammar = "start = 'a'|0.. , 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 30,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              5,                            //     PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //     <delimiter>
+              15, 16, 1,                    //     IF_NOT_ERROR
+              6,                            //       * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //         <expression>
+              14, 3, 1,                     //         IF_ERROR
+              6,                            //           * POP
+              7,                            //             POP_CURR_POS
+              3,                            //             PUSH_FAILED
+              9,                            //           * NIP
+              9,                            //       * NIP
+              6,                            //     POP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              []
+            ));
+          });
+        });
+
+        describe("|1.. , delim| (edge case -- no max boundary -- same as |one or more|)", () => {
+          const grammar = "start = 'a'|1.. , 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 30,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              5,                            //     PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //     <delimiter>
+              15, 16, 1,                    //     IF_NOT_ERROR
+              6,                            //       * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //         <expression>
+              14, 3, 1,                     //         IF_ERROR
+              6,                            //           * POP
+              7,                            //             POP_CURR_POS
+              3,                            //             PUSH_FAILED
+              9,                            //           * NIP
+              9,                            //       * NIP
+              6,                            //     POP
+              30, 1, 3, 1,                  // IF_LT <1>
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+              9,                            //   * NIP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              []
+            ));
+          });
+        });
+
+        describe("|2..3, delim|", () => {
+          const grammar = "start = 'a'|2..3, 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 35,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              31, 3, 1, 29,                 //     IF_GE <3>
+              3,                            //       * PUSH_FAILED
+              5,                            //       * PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //         <delimiter>
+              15, 16, 1,                    //         IF_NOT_ERROR
+              6,                            //           * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //             <expression>
+              14, 3, 1,                     //             IF_ERROR
+              6,                            //               * POP
+              7,                            //                 POP_CURR_POS
+              3,                            //                 PUSH_FAILED
+              9,                            //               * NIP
+              9,                            //           * NIP
+              6,                            //     POP
+              30, 2, 3, 1,                  // IF_LT <2>
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+              9,                            //   * NIP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              []
+            ));
+          });
+        });
+
+        describe("| 42 , delim| (edge case -- exact repetitions)", () => {
+          const grammar = "start = 'a'|42, 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              4,                            // PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    // <expression>
+              16, 35,                       // WHILE_NOT_ERROR
+              10,                           //   * APPEND
+              31, 42, 1, 29,                //     IF_GE <42>
+              3,                            //       * PUSH_FAILED
+              5,                            //       * PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //         <delimiter>
+              15, 16, 1,                    //         IF_NOT_ERROR
+              6,                            //           * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //             <expression>
+              14, 3, 1,                     //             IF_ERROR
+              6,                            //               * POP
+              7,                            //                 POP_CURR_POS
+              3,                            //                 PUSH_FAILED
+              9,                            //               * NIP
+              9,                            //           * NIP
+              6,                            //     POP
+              30, 42, 3, 1,                 // IF_LT <42>
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+              9,                            //   * NIP
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              []
+            ));
+          });
+        });
+      });
+
+      describe("variable boundaries", () => {
+        describe("| ..x, delim| (edge case -- no min boundary)", () => {
+          const grammar = "start = max:(''{return 42;}) 'a'| ..max, 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              // ''{return 42;} - max
+              5,                            // PUSH_CURR_POS
+              35,                           // PUSH_EMPTY_STRING
+              15, 6, 0,                     // IF_NOT_ERROR
+              24, 1,                        //   * LOAD_SAVED_POS <1>
+              26, 0, 1, 0,                  //     CALL <0>, pop 1, args []
+              9,                            // NIP
+
+              15, 62, 3,                    // IF_NOT_ERROR
+              // "a"|min..max|
+              4,                            //   * PUSH_EMPTY_ARRAY
+              33, 1, 1, 8,                  //     IF_GE_DYNAMIC <1>
+              3,                            //       * PUSH_FAILED
+              18, 0, 2, 2, 22, 0, 23, 0,    //       * <expression>
+              16, 35,                       //     WHILE_NOT_ERROR
+              10,                           //       * APPEND
+              33, 1, 1, 29,                 //         IF_GE_DYNAMIC <1>
+              3,                            //           * PUSH_FAILED
+              5,                            //           * PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //             <delimiter>
+              15, 16, 1,                    //             IF_NOT_ERROR
+              6,                            //               * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //                 <expression>
+              14, 3, 1,                     //                 IF_ERROR
+              6,                            //                   * POP
+              7,                            //                     POP_CURR_POS
+              3,                            //                     PUSH_FAILED
+              9,                            //                   * NIP
+              9,                            //               * NIP
+              6,                            //     POP
+
+              15, 3, 4,                     //     IF_NOT_ERROR
+              11, 2,                        //       * WRAP <2>
+              9,                            //         NIP
+              8, 2,                         //       * POP_N <2>
+              7,                            //         POP_CURR_POS
+              3,                            //         PUSH_FAILED
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              [{ predicate: false, params: [], body: "return 42;" }]
+            ));
+          });
+        });
+
+        describe("|x.. , delim| (edge case -- no max boundary)", () => {
+          const grammar = "start = min:(''{return 42;}) 'a'|min.. , 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              // ''{return 42;} - min
+              5,                            // PUSH_CURR_POS
+              35,                           // PUSH_EMPTY_STRING
+              15, 6, 0,                     // IF_NOT_ERROR
+              24, 1,                        //   * LOAD_SAVED_POS <1>
+              26, 0, 1, 0,                  //     CALL <0>, pop 1, args []
+              9,                            // NIP
+
+              15, 61, 3,                    // IF_NOT_ERROR
+              // "a"|min..max|
+              5,                            //   * PUSH_CURR_POS
+              4,                            //     PUSH_EMPTY_ARRAY
+              18, 0, 2, 2, 22, 0, 23, 0,    //     <expression>
+              16, 30,                       //     WHILE_NOT_ERROR
+              10,                           //       * APPEND
+              5,                            //         PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //         <delimiter>
+              15, 16, 1,                    //         IF_NOT_ERROR
+              6,                            //           * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //             <expression>
+              14, 3, 1,                     //             IF_ERROR
+              6,                            //               * POP
+              7,                            //                 POP_CURR_POS
+              3,                            //                 PUSH_FAILED
+              9,                            //               * NIP
+              9,                            //           * NIP
+              6,                            //     POP
+              32, 2, 3, 1,                  //     IF_LT_DYNAMIC <2>
+              6,                            //       * POP
+              7,                            //         POP_CURR_POS
+              3,                            //         PUSH_FAILED
+              9,                            //       * NIP
+
+              15, 3, 4,                     //     IF_NOT_ERROR
+              11, 2,                        //       * WRAP <2>
+              9,                            //         NIP
+              8, 2,                         //       * POP_N <2>
+              7,                            //         POP_CURR_POS
+              3,                            //         PUSH_FAILED
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              [{ predicate: false, params: [], body: "return 42;" }]
+            ));
+          });
+        });
+
+        describe("|x..y, delim|", () => {
+          const grammar = "start = min:(''{return 42;}) max:(''{return 42;}) 'a'|min..max, 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              // ''{return 42;} - min
+              5,                            // PUSH_CURR_POS
+              35,                           // PUSH_EMPTY_STRING
+              15, 6, 0,                     // IF_NOT_ERROR
+              24, 1,                        //   * LOAD_SAVED_POS <1>
+              26, 0, 1, 0,                  //     CALL <0>, pop 1, args []
+              9,                            // NIP
+
+              15, 91, 3,                    // IF_NOT_ERROR
+              // {return 42;} - max
+              5,                            //   * PUSH_CURR_POS
+              35,                           //     PUSH_EMPTY_STRING
+              15, 7, 0,                     //     IF_NOT_ERROR
+              24, 1,                        //       * LOAD_SAVED_POS <1>
+              26, 1, 1, 1, 2,               //         CALL <1>, pop 1, args [2]
+              9,                            //     NIP
+
+              15, 71, 4,                    //     IF_NOT_ERROR
+              // "a"|min..max|
+              5,                            //       * PUSH_CURR_POS
+              4,                            //         PUSH_EMPTY_ARRAY
+              33, 2, 1, 8,                  //         IF_GE_DYNAMIC <2>
+              3,                            //           * PUSH_FAILED
+              18, 0, 2, 2, 22, 0, 23, 0,    //           * <expression>
+              16, 35,                       //         WHILE_NOT_ERROR
+              10,                           //           * APPEND
+              33, 2, 1, 29,                 //             IF_GE_DYNAMIC <2>
+              3,                            //               * PUSH_FAILED
+              5,                            //               * PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //                 <delimiter>
+              15, 16, 1,                    //                 IF_NOT_ERROR
+              6,                            //                   * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //                     <expression>
+              14, 3, 1,                     //                     IF_ERROR
+              6,                            //                       * POP
+              7,                            //                         POP_CURR_POS
+              3,                            //                         PUSH_FAILED
+              9,                            //                       * NIP
+              9,                            //                   * NIP
+              6,                            //         POP
+              32, 3, 3, 1,                  //         IF_LT_DYNAMIC <3>
+              6,                            //           * POP
+              7,                            //             POP_CURR_POS
+              3,                            //             PUSH_FAILED
+              9,                            //           * NIP
+
+              15, 3, 4,                     //         IF_NOT_ERROR
+              11, 3,                        //           * WRAP <3>
+              9,                            //             NIP
+              8, 3,                         //           * POP_N <3>
+              7,                            //             POP_CURR_POS
+              3,                            //             PUSH_FAILED
+              8, 2,                         //       * POP_N <2>
+              7,                            //         POP_CURR_POS
+              3,                            //         PUSH_FAILED
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              [
+                { predicate: false, params: [],      body: "return 42;" },
+                { predicate: false, params: ["min"], body: "return 42;" },
+              ]
+            ));
+          });
+        });
+
+        describe("|exact, delim| (edge case -- exact repetitions)", () => {
+          const grammar = "start = exact:(''{return 42;}) 'a'|exact, 'b'|";
+
+          it("generates correct bytecode", () => {
+            expect(pass).to.changeAST(grammar, bytecodeDetails([
+              5,                            // PUSH_CURR_POS
+              // ''{return 42;}
+              5,                            // PUSH_CURR_POS
+              35,                           // PUSH_EMPTY_STRING
+              15, 6, 0,                     // IF_NOT_ERROR
+              24, 1,                        //   * LOAD_SAVED_POS <1>
+              26, 0, 1, 0,                  //     CALL <0>, pop 1, args []
+              9,                            // NIP
+
+              15, 71, 3,                    // IF_NOT_ERROR
+              // "a"|exact|
+              5,                            //   * PUSH_CURR_POS
+              4,                            //     PUSH_EMPTY_ARRAY
+              33, 2, 1, 8,                  //     IF_GE_DYNAMIC <2>
+              3,                            //       * PUSH_FAILED
+              18, 0, 2, 2, 22, 0, 23, 0,    //       * <expression>
+              16, 35,                       //     WHILE_NOT_ERROR
+              10,                           //       * APPEND
+              33, 2, 1, 29,                 //         IF_GE_DYNAMIC <2>
+              3,                            //           * PUSH_FAILED
+              5,                            //           * PUSH_CURR_POS
+              18, 1, 2, 2, 22, 1, 23, 1,    //             <delimiter>
+              15, 16, 1,                    //             IF_NOT_ERROR
+              6,                            //               * POP
+              18, 0, 2, 2, 22, 0, 23, 0,    //                 <expression>
+              14, 3, 1,                     //                 IF_ERROR
+              6,                            //                   * POP
+              7,                            //                     POP_CURR_POS
+              3,                            //                     PUSH_FAILED
+              9,                            //                   * NIP
+              9,                            //               * NIP
+              6,                            //     POP
+              32, 2, 3, 1,                  //     IF_LT_DYNAMIC <2>
+              6,                            //       * POP
+              7,                            //         POP_CURR_POS
+              3,                            //         PUSH_FAILED
+              9,                            //       * NIP
+
+              15, 3, 4,                     //     IF_NOT_ERROR
+              11, 2,                        //       * WRAP <2>
+              9,                            //         NIP
+              8, 2,                         //       * POP_N <2>
+              7,                            //         POP_CURR_POS
+              3,                            //         PUSH_FAILED
+              6,                            //   * POP
+              7,                            //     POP_CURR_POS
+              3,                            //     PUSH_FAILED
+            ]));
+          });
+
+          it("defines correct constants", () => {
+            expect(pass).to.changeAST(grammar, constsDetails(
+              ["a", "b"],
+              [],
+              [
+                { type: "literal", value: "a", ignoreCase: false },
+                { type: "literal", value: "b", ignoreCase: false },
+              ],
+              [{ predicate: false, params: [], body: "return 42;" }]
+            ));
+          });
+        });
+      });
+    });
   });
 
   describe("for group", () => {

--- a/test/unit/compiler/passes/inference-match-result.spec.js
+++ b/test/unit/compiler/passes/inference-match-result.spec.js
@@ -152,6 +152,29 @@ describe("compiler pass |inferenceMatchResult|", () => {
           expect(pass).to.changeAST("start = []| 42 |", { rules: [{ match: -1 }] });
         });
       });
+
+      describe("with variable boundaries", () => {
+        it("for |   ..max| correctly", () => {
+          expect(pass).to.changeAST("start =  .|   ..max|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''|   ..max|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []|   ..max|", { rules: [{ match: 0 }] });
+        });
+        it("for |min..   | correctly", () => {
+          expect(pass).to.changeAST("start =  .|min..   |", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''|min..   |", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []|min..   |", { rules: [{ match: 0 }] });
+        });
+        it("for |min..max| correctly", () => {
+          expect(pass).to.changeAST("start =  .|min..max|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''|min..max|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []|min..max|", { rules: [{ match: 0 }] });
+        });
+        it("for | exact  | correctly", () => {
+          expect(pass).to.changeAST("start =  .|exact|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''|exact|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []|exact|", { rules: [{ match: 0 }] });
+        });
+      });
     });
   });
 

--- a/test/unit/compiler/passes/inference-match-result.spec.js
+++ b/test/unit/compiler/passes/inference-match-result.spec.js
@@ -108,6 +108,53 @@ describe("compiler pass |inferenceMatchResult|", () => {
     expect(pass).to.changeAST("start = []+", { rules: [{ match: -1 }] });
   });
 
+  describe("calculate |match| property for |repeated|", () => {
+    describe("without delimiter", () => {
+      describe("with constant boundaries", () => {
+        it("for | .. | correctly", () => {
+          expect(pass).to.changeAST("start =  .| .. |", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''| .. |", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []| .. |", { rules: [{ match:  1 }] });
+        });
+        it("for | ..1| correctly", () => {
+          expect(pass).to.changeAST("start =  .| ..1|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''| ..1|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []| ..1|", { rules: [{ match:  1 }] });
+        });
+        it("for | ..3| correctly", () => {
+          expect(pass).to.changeAST("start =  .| ..3|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''| ..3|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []| ..3|", { rules: [{ match:  1 }] });
+        });
+        it("for |0.. | correctly", () => {
+          expect(pass).to.changeAST("start =  .|0.. |", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''|0.. |", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []|0.. |", { rules: [{ match:  1 }] });
+        });
+        it("for |1.. | correctly", () => {
+          expect(pass).to.changeAST("start =  .|1.. |", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start = ''|1.. |", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []|1.. |", { rules: [{ match: -1 }] });
+        });
+        it("for |2.. | correctly", () => {
+          expect(pass).to.changeAST("start =  .|2.. |", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start = ''|2.. |", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []|2.. |", { rules: [{ match: -1 }] });
+        });
+        it("for |2..3| correctly", () => {
+          expect(pass).to.changeAST("start =  .|2..3|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start = ''|2..3|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []|2..3|", { rules: [{ match: -1 }] });
+        });
+        it("for | 42 | correctly", () => {
+          expect(pass).to.changeAST("start =  .| 42 |", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start = ''| 42 |", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []| 42 |", { rules: [{ match: -1 }] });
+        });
+      });
+    });
+  });
+
   it("calculate |match| property for |group| correctly", () => {
     expect(pass).to.changeAST("start = (.)",  { rules: [{ match:  0 }] });
     expect(pass).to.changeAST("start = ('')", { rules: [{ match:  1 }] });

--- a/test/unit/compiler/passes/inference-match-result.spec.js
+++ b/test/unit/compiler/passes/inference-match-result.spec.js
@@ -176,6 +176,170 @@ describe("compiler pass |inferenceMatchResult|", () => {
         });
       });
     });
+
+    describe("with delimiter", () => {
+      describe("with constant boundaries", () => {
+        it("for | .. , delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .| .. , .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start =  .| .. ,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start =  .| .. ,[]|", { rules: [{ match:  1 }] });
+
+          expect(pass).to.changeAST("start = ''| .. , .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''| .. ,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''| .. ,[]|", { rules: [{ match:  1 }] });
+
+          expect(pass).to.changeAST("start = []| .. , .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []| .. ,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []| .. ,[]|", { rules: [{ match:  1 }] });
+        });
+        it("for | ..1, delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .| ..1, .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start =  .| ..1,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start =  .| ..1,[]|", { rules: [{ match:  1 }] });
+
+          expect(pass).to.changeAST("start = ''| ..1, .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''| ..1,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''| ..1,[]|", { rules: [{ match:  1 }] });
+
+          expect(pass).to.changeAST("start = []| ..1, .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []| ..1,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []| ..1,[]|", { rules: [{ match:  1 }] });
+        });
+        it("for | ..3, delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .| ..3, .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start =  .| ..3,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start =  .| ..3,[]|", { rules: [{ match:  1 }] });
+
+          expect(pass).to.changeAST("start = ''| ..3, .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''| ..3,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''| ..3,[]|", { rules: [{ match:  1 }] });
+
+          expect(pass).to.changeAST("start = []| ..3, .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []| ..3,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []| ..3,[]|", { rules: [{ match:  1 }] });
+        });
+        it("for |0.. , delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .|0.. , .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start =  .|0.. ,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start =  .|0.. ,[]|", { rules: [{ match:  1 }] });
+
+          expect(pass).to.changeAST("start = ''|0.. , .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''|0.. ,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''|0.. ,[]|", { rules: [{ match:  1 }] });
+
+          expect(pass).to.changeAST("start = []|0.. , .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []|0.. ,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = []|0.. ,[]|", { rules: [{ match:  1 }] });
+        });
+        it("for |1.. , delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .|1.. , .|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start =  .|1.. ,''|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start =  .|1.. ,[]|", { rules: [{ match:  0 }] });
+
+          expect(pass).to.changeAST("start = ''|1.. , .|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''|1.. ,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''|1.. ,[]|", { rules: [{ match:  1 }] });
+
+          expect(pass).to.changeAST("start = []|1.. , .|", { rules: [{ match: -1 }] });
+          expect(pass).to.changeAST("start = []|1.. ,''|", { rules: [{ match: -1 }] });
+          expect(pass).to.changeAST("start = []|1.. ,[]|", { rules: [{ match: -1 }] });
+        });
+        it("for |2.. , delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .|2.. , .|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start =  .|2.. ,''|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start =  .|2.. ,[]|", { rules: [{ match: -1 }] });
+
+          expect(pass).to.changeAST("start = ''|2.. , .|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start = ''|2.. ,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''|2.. ,[]|", { rules: [{ match: -1 }] });
+
+          expect(pass).to.changeAST("start = []|2.. , .|", { rules: [{ match: -1 }] });
+          expect(pass).to.changeAST("start = []|2.. ,''|", { rules: [{ match: -1 }] });
+          expect(pass).to.changeAST("start = []|2.. ,[]|", { rules: [{ match: -1 }] });
+        });
+        it("for |2..3, delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .|2..3, .|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start =  .|2..3,''|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start =  .|2..3,[]|", { rules: [{ match: -1 }] });
+
+          expect(pass).to.changeAST("start = ''|2..3, .|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start = ''|2..3,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''|2..3,[]|", { rules: [{ match: -1 }] });
+
+          expect(pass).to.changeAST("start = []|2..3, .|", { rules: [{ match: -1 }] });
+          expect(pass).to.changeAST("start = []|2..3,''|", { rules: [{ match: -1 }] });
+          expect(pass).to.changeAST("start = []|2..3,[]|", { rules: [{ match: -1 }] });
+        });
+        it("for | 42 , delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .| 42 , .|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start =  .| 42 ,''|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start =  .| 42 ,[]|", { rules: [{ match: -1 }] });
+
+          expect(pass).to.changeAST("start = ''| 42 , .|", { rules: [{ match:  0 }] });
+          expect(pass).to.changeAST("start = ''| 42 ,''|", { rules: [{ match:  1 }] });
+          expect(pass).to.changeAST("start = ''| 42 ,[]|", { rules: [{ match: -1 }] });
+
+          expect(pass).to.changeAST("start = []| 42 , .|", { rules: [{ match: -1 }] });
+          expect(pass).to.changeAST("start = []| 42 ,''|", { rules: [{ match: -1 }] });
+          expect(pass).to.changeAST("start = []| 42 ,[]|", { rules: [{ match: -1 }] });
+        });
+      });
+
+      describe("with variable boundaries", () => {
+        it("for |   ..max, delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .|   ..max, .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start =  .|   ..max,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start =  .|   ..max,[]|", { rules: [{ match: 0 }] });
+
+          expect(pass).to.changeAST("start = ''|   ..max, .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''|   ..max,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''|   ..max,[]|", { rules: [{ match: 0 }] });
+
+          expect(pass).to.changeAST("start = []|   ..max, .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []|   ..max,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []|   ..max,[]|", { rules: [{ match: 0 }] });
+        });
+        it("for |min..   , delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .|min..   , .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start =  .|min..   ,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start =  .|min..   ,[]|", { rules: [{ match: 0 }] });
+
+          expect(pass).to.changeAST("start = ''|min..   , .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''|min..   ,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''|min..   ,[]|", { rules: [{ match: 0 }] });
+
+          expect(pass).to.changeAST("start = []|min..   , .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []|min..   ,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []|min..   ,[]|", { rules: [{ match: 0 }] });
+        });
+        it("for |min..max, delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .|min..max, .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start =  .|min..max,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start =  .|min..max,[]|", { rules: [{ match: 0 }] });
+
+          expect(pass).to.changeAST("start = ''|min..max, .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''|min..max,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''|min..max,[]|", { rules: [{ match: 0 }] });
+
+          expect(pass).to.changeAST("start = []|min..max, .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []|min..max,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []|min..max,[]|", { rules: [{ match: 0 }] });
+        });
+        it("for | exact  , delimiter| correctly", () => {
+          expect(pass).to.changeAST("start =  .| exact  , .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start =  .| exact  ,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start =  .| exact  ,[]|", { rules: [{ match: 0 }] });
+
+          expect(pass).to.changeAST("start = ''| exact  , .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''| exact  ,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = ''| exact  ,[]|", { rules: [{ match: 0 }] });
+
+          expect(pass).to.changeAST("start = []| exact  , .|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []| exact  ,''|", { rules: [{ match: 0 }] });
+          expect(pass).to.changeAST("start = []| exact  ,[]|", { rules: [{ match: 0 }] });
+        });
+      });
+    });
   });
 
   it("calculate |match| property for |group| correctly", () => {

--- a/test/unit/compiler/passes/report-duplicate-labels.spec.js
+++ b/test/unit/compiler/passes/report-duplicate-labels.spec.js
@@ -40,6 +40,7 @@ describe("compiler pass |reportDuplicateLabels|", () => {
       expect(pass).to.not.reportError("start = (a:'a')? a:'a'");
       expect(pass).to.not.reportError("start = (a:'a')* a:'a'");
       expect(pass).to.not.reportError("start = (a:'a')+ a:'a'");
+      expect(pass).to.not.reportError("start = (a:'a')|2..3| a:'a'");
       expect(pass).to.not.reportError("start = (a:'a') a:'a'");
     });
   });

--- a/test/unit/compiler/passes/report-duplicate-labels.spec.js
+++ b/test/unit/compiler/passes/report-duplicate-labels.spec.js
@@ -41,6 +41,7 @@ describe("compiler pass |reportDuplicateLabels|", () => {
       expect(pass).to.not.reportError("start = (a:'a')* a:'a'");
       expect(pass).to.not.reportError("start = (a:'a')+ a:'a'");
       expect(pass).to.not.reportError("start = (a:'a')|2..3| a:'a'");
+      expect(pass).to.not.reportError("start = 'a'|2..3, a:'a'| a:'a'");
       expect(pass).to.not.reportError("start = (a:'a') a:'a'");
     });
   });

--- a/test/unit/compiler/passes/report-infinite-recursion.spec.js
+++ b/test/unit/compiler/passes/report-infinite-recursion.spec.js
@@ -94,6 +94,24 @@ describe("compiler pass |reportInfiniteRecursion|", () => {
       expect(pass).to.reportError("start = ''+ start");
       expect(pass).to.not.reportError("start = 'a'+ start");
 
+      expect(pass).to.reportError("start = ''| .. | start");
+      expect(pass).to.reportError("start = ''|0.. | start");
+      expect(pass).to.reportError("start = ''|1.. | start");
+      expect(pass).to.reportError("start = ''|2.. | start");
+      expect(pass).to.reportError("start = ''| ..1| start");
+      expect(pass).to.reportError("start = ''| ..3| start");
+      expect(pass).to.reportError("start = ''|2..3| start");
+      expect(pass).to.reportError("start = ''| 42 | start");
+
+      expect(pass).to.reportError("start = 'a'| .. | start");
+      expect(pass).to.reportError("start = 'a'|0.. | start");
+      expect(pass).to.not.reportError("start = 'a'|1.. | start");
+      expect(pass).to.not.reportError("start = 'a'|2.. | start");
+      expect(pass).to.reportError("start = 'a'| ..1| start");
+      expect(pass).to.reportError("start = 'a'| ..3| start");
+      expect(pass).to.not.reportError("start = 'a'|2..3| start");
+      expect(pass).to.not.reportError("start = 'a'| 42 | start");
+
       expect(pass).to.reportError("start = ('') start");
       expect(pass).to.not.reportError("start = ('a') start");
 

--- a/test/unit/compiler/passes/report-infinite-recursion.spec.js
+++ b/test/unit/compiler/passes/report-infinite-recursion.spec.js
@@ -136,4 +136,26 @@ describe("compiler pass |reportInfiniteRecursion|", () => {
       expect(pass).to.not.reportError("start = . start");
     });
   });
+
+  describe("in repeated with delimiter", () => {
+    it("doesn't report left recursion for delimiter if expression not match empty string", () => {
+      expect(pass).to.not.reportError("start = 'a'| .. , start|");
+      expect(pass).to.not.reportError("start = 'a'|0.. , start|");
+      expect(pass).to.not.reportError("start = 'a'|1.. , start|");
+      expect(pass).to.not.reportError("start = 'a'|2.. , start|");
+      expect(pass).to.not.reportError("start = 'a'| ..3, start|");
+      expect(pass).to.not.reportError("start = 'a'|2..3, start|");
+      expect(pass).to.not.reportError("start = 'a'| 42 , start|");
+    });
+
+    it("reports left recursion for delimiter if expression match empty string", () => {
+      expect(pass).to.reportError("start = ''| .. , start|");
+      expect(pass).to.reportError("start = ''|0.. , start|");
+      expect(pass).to.reportError("start = ''|1.. , start|");
+      expect(pass).to.reportError("start = ''|2.. , start|");
+      expect(pass).to.reportError("start = ''| ..3, start|");
+      expect(pass).to.reportError("start = ''|2..3, start|");
+      expect(pass).to.reportError("start = ''| 42 , start|");
+    });
+  });
 });

--- a/test/unit/compiler/passes/report-infinite-repetition.spec.js
+++ b/test/unit/compiler/passes/report-infinite-repetition.spec.js
@@ -88,6 +88,85 @@ describe("compiler pass |reportInfiniteRepetition|", () => {
         expect(pass).to.not.reportError("start = ('')|len|");
       });
     });
+
+    describe("with empty delimiter", () => {
+      it("with constant boundaries", () => {
+        expect(pass).to.reportError("start = ('')| .., ''|", {
+          message:  "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          location: {
+            source: undefined,
+            start: { offset:  8, line: 1, column:  9 },
+            end:   { offset: 21, line: 1, column: 22 },
+          },
+        });
+        expect(pass).to.reportError("start = ('')|0.., ''|", {
+          message:  "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          location: {
+            source: undefined,
+            start: { offset:  8, line: 1, column:  9 },
+            end:   { offset: 21, line: 1, column: 22 },
+          },
+        });
+        expect(pass).to.reportError("start = ('')|1.., ''|", {
+          message:  "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          location: {
+            source: undefined,
+            start: { offset:  8, line: 1, column:  9 },
+            end:   { offset: 21, line: 1, column: 22 },
+          },
+        });
+        expect(pass).to.reportError("start = ('')|2.., ''|", {
+          message:  "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          location: {
+            source: undefined,
+            start: { offset:  8, line: 1, column:  9 },
+            end:   { offset: 21, line: 1, column: 22 },
+          },
+        });
+
+        expect(pass).to.not.reportError("start = ('')| ..1, ''|");
+        expect(pass).to.not.reportError("start = ('')| ..3, ''|");
+        expect(pass).to.not.reportError("start = ('')|2..3, ''|");
+        expect(pass).to.not.reportError("start = ('')| 42 , ''|");
+      });
+
+      it("with variable boundaries", () => {
+        expect(pass).to.reportError("start = ('')|len.., ''|", {
+          message:  "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          location: {
+            source: undefined,
+            start: { offset:  8, line: 1, column:  9 },
+            end:   { offset: 23, line: 1, column: 24 },
+          },
+        });
+
+        expect(pass).to.not.reportError("start = ('')|..len, ''|");
+        expect(pass).to.not.reportError("start = ('')|len1..len2, ''|");
+        expect(pass).to.not.reportError("start = ('')|len, ''|");
+      });
+    });
+
+    describe("with non-empty delimiter", () => {
+      it("with constant boundaries", () => {
+        expect(pass).to.not.reportError("start = ('')| .., 'a'|");
+        expect(pass).to.not.reportError("start = ('')|0.., 'a'|");
+        expect(pass).to.not.reportError("start = ('')|1.., 'a'|");
+        expect(pass).to.not.reportError("start = ('')|2.., 'a'|");
+
+        expect(pass).to.not.reportError("start = ('')| ..1, 'a'|");
+        expect(pass).to.not.reportError("start = ('')| ..3, 'a'|");
+        expect(pass).to.not.reportError("start = ('')|2..3, 'a'|");
+        expect(pass).to.not.reportError("start = ('')| 42 , 'a'|");
+      });
+
+      it("with variable boundaries", () => {
+        expect(pass).to.not.reportError("start = ('')|len.., 'a'|");
+
+        expect(pass).to.not.reportError("start = ('')|..len, 'a'|");
+        expect(pass).to.not.reportError("start = ('')|len1..len2, 'a'|");
+        expect(pass).to.not.reportError("start = ('')|len, 'a'|");
+      });
+    });
   });
 
   it("computes expressions that always consume input on success correctly", () => {

--- a/test/unit/compiler/passes/report-infinite-repetition.spec.js
+++ b/test/unit/compiler/passes/report-infinite-repetition.spec.js
@@ -31,6 +31,50 @@ describe("compiler pass |reportInfiniteRepetition|", () => {
     });
   });
 
+  describe("reports infinite loops for repeated", () => {
+    describe("without delimiter", () => {
+      it("with constant boundaries", () => {
+        expect(pass).to.reportError("start = ('')|..|", {
+          message:  "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          location: {
+            source: undefined,
+            start: { offset:  8, line: 1, column:  9 },
+            end:   { offset: 16, line: 1, column: 17 },
+          },
+        });
+        expect(pass).to.reportError("start = ('')|0..|", {
+          message:  "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          location: {
+            source: undefined,
+            start: { offset:  8, line: 1, column:  9 },
+            end:   { offset: 17, line: 1, column: 18 },
+          },
+        });
+        expect(pass).to.reportError("start = ('')|1..|", {
+          message:  "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          location: {
+            source: undefined,
+            start: { offset:  8, line: 1, column:  9 },
+            end:   { offset: 17, line: 1, column: 18 },
+          },
+        });
+        expect(pass).to.reportError("start = ('')|2..|", {
+          message:  "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          location: {
+            source: undefined,
+            start: { offset:  8, line: 1, column:  9 },
+            end:   { offset: 17, line: 1, column: 18 },
+          },
+        });
+
+        expect(pass).to.not.reportError("start = ('')| ..1|");
+        expect(pass).to.not.reportError("start = ('')| ..3|");
+        expect(pass).to.not.reportError("start = ('')|2..3|");
+        expect(pass).to.not.reportError("start = ('')| 42 |");
+      });
+    });
+  });
+
   it("computes expressions that always consume input on success correctly", () => {
     expect(pass).to.reportError([
       "start = a*",

--- a/test/unit/compiler/passes/report-infinite-repetition.spec.js
+++ b/test/unit/compiler/passes/report-infinite-repetition.spec.js
@@ -72,6 +72,21 @@ describe("compiler pass |reportInfiniteRepetition|", () => {
         expect(pass).to.not.reportError("start = ('')|2..3|");
         expect(pass).to.not.reportError("start = ('')| 42 |");
       });
+
+      it("with variable boundaries", () => {
+        expect(pass).to.reportError("start = ('')|len..|", {
+          message:  "Possible infinite loop when parsing (unbounded range repetition used with an expression that may not consume any input)",
+          location: {
+            source: undefined,
+            start: { offset:  8, line: 1, column:  9 },
+            end:   { offset: 19, line: 1, column: 20 },
+          },
+        });
+
+        expect(pass).to.not.reportError("start = ('')|..len|");
+        expect(pass).to.not.reportError("start = ('')|len1..len2|");
+        expect(pass).to.not.reportError("start = ('')|len|");
+      });
     });
   });
 


### PR DESCRIPTION
Reincarnation of the https://github.com/pegjs/pegjs/pull/209.

This is an implementation of the ranges proposal with batteries, i.e.:

- ability to use numeric constants to specify minimum, maximum or exact repetition count:
  ```pegjs
  more2 = "a"|2..|;
  upTo3 = "a"|..3|;
  ```
- ability to use preceding label as a range boundary:
  ```pegjs
  list = count:n5 @n5|count|;
  n5 = n:[0-9]|5| { return parseInt(n); };
  ```
- ability to use function as a boundary:
  ```pegjs
  list = "a"|{ return options.listSize; }|;
  ```

The syntax chosen saves the `<` and `>` characters for the template definitions where their are more natural.
`[` and `]` already used for character class definitions and 
`(` and `)` already used for grouping.

I not rush you to include this to 1.3.0 -- there are pretty big PR and I feel that you tries to release soon.
But I make this PR now so if you think that you have enough time to review, we can include it. If not, then no.