### PR TITLE
Sourcemap url

### DIFF
--- a/bin/peggy-cli.mjs
+++ b/bin/peggy-cli.mjs
@@ -166,7 +166,7 @@ export class PeggyCLI extends Command {
       )
       .option(
         "-m, --source-map [mapfile]",
-        "Generate a source map. If name is not specified, the source map will be named \"<input_file>.map\" if input is a file and \"source.map\" if input is a standard input. If the special filename 'inline' is given, the sourcemap will be embedded in the output file as a data URI.  If the filename is prefixed with `hidden`, no mapping URL will be included so that the mapping can be specified with an HTTP SourceMap: header.  This option conflicts with the `-t/--test` and `-T/--test-file` options unless `-o/--output` is also specified"
+        "Generate a source map. If name is not specified, the source map will be named \"<input_file>.map\" if input is a file and \"source.map\" if input is a standard input. If the special filename `inline` is given, the sourcemap will be embedded in the output file as a data URI.  If the filename is prefixed with `hidden:`, no mapping URL will be included so that the mapping can be specified with an HTTP SourceMap: header.  This option conflicts with the `-t/--test` and `-T/--test-file` options unless `-o/--output` is also specified"
       )
       .option(
         "-t, --test <text>",

--- a/bin/peggy.js
+++ b/bin/peggy.js
@@ -3069,7 +3069,7 @@ class PeggyCLI extends commander.exports.Command {
       )
       .option(
         "-m, --source-map [mapfile]",
-        "Generate a source map. If name is not specified, the source map will be named \"<input_file>.map\" if input is a file and \"source.map\" if input is a standard input. If the special filename 'inline' is given, the sourcemap will be embedded in the output file as a data URI.  If the filename is prefixed with `hidden`, no mapping URL will be included so that the mapping can be specified with an HTTP SourceMap: header.  This option conflicts with the `-t/--test` and `-T/--test-file` options unless `-o/--output` is also specified"
+        "Generate a source map. If name is not specified, the source map will be named \"<input_file>.map\" if input is a file and \"source.map\" if input is a standard input. If the special filename `inline` is given, the sourcemap will be embedded in the output file as a data URI.  If the filename is prefixed with `hidden:`, no mapping URL will be included so that the mapping can be specified with an HTTP SourceMap: header.  This option conflicts with the `-t/--test` and `-T/--test-file` options unless `-o/--output` is also specified"
       )
       .option(
         "-t, --test <text>",

--- a/bin/peggy.js
+++ b/bin/peggy.js
@@ -3069,7 +3069,7 @@ class PeggyCLI extends commander.exports.Command {
       )
       .option(
         "-m, --source-map [mapfile]",
-        "Generate a source map. If name is not specified, the source map will be named \"<input_file>.map\" if input is a file and \"source.map\" if input is a standard input. This option conflicts with the `-t/--test` and `-T/--test-file` options unless `-o/--output` is also specified"
+        "Generate a source map. If name is not specified, the source map will be named \"<input_file>.map\" if input is a file and \"source.map\" if input is a standard input. If the special filename 'inline' is given, the sourcemap will be embedded in the output file as a data URI.  This option conflicts with the `-t/--test` and `-T/--test-file` options unless `-o/--output` is also specified"
       )
       .option(
         "-t, --test <text>",
@@ -3179,6 +3179,8 @@ class PeggyCLI extends commander.exports.Command {
               : "-";
           } else {
             this.outputFile = "-";
+            // Synthetic
+            this.outputJS = path__default["default"].join(process.cwd(), "stdout.js");
           }
         }
         // If CLI parameter was defined, enable source map generation
@@ -3341,11 +3343,12 @@ class PeggyCLI extends commander.exports.Command {
         return;
       }
 
-      const mapDir = path__default["default"].dirname(this.progOptions.sourceMap);
+      const inline = this.progOptions.sourceMap === "inline";
+      const mapDir = inline
+        ? path__default["default"].dirname(this.outputJS)
+        : path__default["default"].dirname(this.progOptions.sourceMap);
 
-      const file = (this.outputFile === "-")
-        ? null
-        : path__default["default"].relative(mapDir, this.outputFile);
+      const file = path__default["default"].relative(mapDir, this.outputJS);
       const sourceMap = source.toStringWithSourceMap({ file });
 
       // According to specifications, paths in the "sources" array should be
@@ -3356,18 +3359,27 @@ class PeggyCLI extends commander.exports.Command {
         src => (src === null) ? null : path__default["default"].relative(mapDir, src)
       );
 
-      fs__default["default"].writeFile(
-        this.progOptions.sourceMap,
-        JSON.stringify(json),
-        "utf8",
-        err => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(sourceMap.code);
+      if (inline) {
+        const buf = Buffer.from(JSON.stringify(json));
+        resolve(sourceMap.code + `\
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,${buf.toString("base64")}
+`);
+      } else {
+        fs__default["default"].writeFile(
+          this.progOptions.sourceMap,
+          JSON.stringify(json),
+          "utf8",
+          err => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(sourceMap.code + `\
+//# sourceMappingURL=${path__default["default"].relative(path__default["default"].dirname(this.outputJS), this.progOptions.sourceMap)}
+`);
+            }
           }
-        }
-      );
+        );
+      }
     });
   }
 
@@ -3403,13 +3415,12 @@ class PeggyCLI extends commander.exports.Command {
     if (typeof this.testText === "string") {
       this.verbose("TEST TEXT:", this.testText);
 
-      const filename = this.outputJS
-        ? path__default["default"].resolve(this.outputJS)
-        : path__default["default"].join(process.cwd(), "stdout.js"); // Synthetic
-
       // Create a module that exports the parser, then load it from the
       // correct directory, so that any modules that the parser requires will
       // be loaded from the correct place.
+      const filename = this.outputJS
+        ? path__default["default"].resolve(this.outputJS)
+        : path__default["default"].join(process.cwd(), "stdout.js"); // Synthetic
       const dirname = path__default["default"].dirname(filename);
       const m = new module$1.Module(filename, module);
       // This is the function that will be called by `require()` in the parser.

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -160,6 +160,10 @@ override this using the <code>--format</code> option.</p>
   followed by a colon.  If no name is given, the module name will also be used
   for the variable name.</dd>
 
+  <dt><code>-D</code>, <code>--dependencies &lt;json&gt;</code></dt>
+  <dd>Dependencies, in JSON object format with variable:module pairs. (Can be
+  specified multiple times).</dd>
+
   <dt><code>-e</code>, <code>--export-var &lt;variable&gt;</code></dt>
   <dd>Name of a global variable into which the parser object is assigned to when
   no module loader is detected.</dd>
@@ -168,7 +172,7 @@ override this using the <code>--format</code> option.</p>
   <dd>Additional options (in JSON format, as an object) to pass to
   <code>peg.generate</code>.</dd>
 
-  <dt><code>--extra-options-file &lt;file&gt;</code></dt>
+  <dt><code>-c</code>, <code>--extra-options-file &lt;file&gt;</code></dt>
   <dd>File with additional options (in JSON format, as an object) to pass to
   <code>peg.generate</code>.</dd>
 
@@ -184,8 +188,16 @@ override this using the <code>--format</code> option.</p>
   <dd>Makes Peggy use a specified plugin (can be specified multiple
   times).</dd>
 
-  <dt><code>--source-map &lt;file&gt;</code></dt>
-  <dd>Generate a source map file with an optionally specified name</dd>
+  <dt><code>-m</code>, <code>--source-map &lt;file&gt;</code></dt>
+  <dd>Generate a source map. If name is not specified, the source map will be
+  named "&lt;input_file&gt;.map" if input is a file and "source.map" if input
+  is a standard input. If the special filename <code>inline</code> is given,
+  the sourcemap will be embedded in the output file as a data URI.  If the
+  filename is prefixed with <code>hidden:</code>, no mapping URL will be
+  included so that the mapping can be specified with an HTTP SourceMap:
+  header. This option conflicts with the <code>-t/--test</code> and
+  <code>-T/--test-file</code> options unless <code>-o/--output</code> is also
+  specified</dd>
 
   <dt><code>-t</code>, <code>--test &lt;text&gt;</code></dt>
   <dd>Test the parser with the given text, outputting the result of running
@@ -209,11 +221,12 @@ override this using the <code>--format</code> option.</p>
 </dl>
 
 <p>
-If you specify options using `-c &lt;file&gt;` or `--extra-options-file &lt;file&gt;`, you
-will need to ensure you are using the correct types.  In particular, you may
-specify "plugin" as a string, or "plugins" as an array of objects that have a
-`use` method.  Always use the long (two-dash) form of the option.  Options
-that contain dashes should be specified in camel case. You may also specify an
+If you specify options using <code>-c &lt;file&gt;</code> or
+<code>--extra-options-file &lt;file&gt;</code>, you will need to ensure you
+are using the correct types.  In particular, you may specify "plugin" as a
+string, or "plugins" as an array of objects that have a <code>use</code>
+method.  Always use the long (two-dash) form of the option.  Options that
+contain dashes should be specified in camel case. You may also specify an
 "input" field instead of using the command line.  For example:
 </p>
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,6 @@ module.exports = {
   "coverageReporters": ["lcov", "text"],
   "coveragePathIgnorePatterns": [
     "<rootDir>/node_modules/",
-    "<rootDir>/lib/parser.js",
     "<rootDir>/test",
   ],
   "roots": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "terser:bench": "terser -c passes=2 -m --sequences 40 --module build/rollup/benchmark.umd.js -o build/benchmark-bundle.min.js",
     "headers": "node ./tools/header.js build/peggy.min.js build/benchmark-bundle.min.js build/test-bundle.min.js",
     "deploy": "npm run deploy:peggy && npm run deploy:tests && npm run deploy:bench",
-    "coverage": "PEGGY_CLI_DEBUG=1 npm run rollup && npm run parser -- -m inline && jest run.spec.ts",
+    "coverage": "PEGGY_CLI_DEBUG=1 npm run rollup && npm run parser -- -m inline && npm test",
     "deploy:peggy": "copyfiles build/peggy.min.js docs/vendor/peggy/ && copyfiles build/peggy.min.js browser/",
     "deploy:tests": "copyfiles build/test-bundle.min.js docs/js/",
     "deploy:bench": "copyfiles build/benchmark-bundle.min.js docs/js/",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "terser:bench": "terser -c passes=2 -m --sequences 40 --module build/rollup/benchmark.umd.js -o build/benchmark-bundle.min.js",
     "headers": "node ./tools/header.js build/peggy.min.js build/benchmark-bundle.min.js build/test-bundle.min.js",
     "deploy": "npm run deploy:peggy && npm run deploy:tests && npm run deploy:bench",
-    "coverage:bin": "PEGGY_CLI_DEBUG=1 npm run rollup && jest run.spec.ts",
+    "coverage": "PEGGY_CLI_DEBUG=1 npm run rollup && npm run parser -- -m inline && jest run.spec.ts",
     "deploy:peggy": "copyfiles build/peggy.min.js docs/vendor/peggy/ && copyfiles build/peggy.min.js browser/",
     "deploy:tests": "copyfiles build/test-bundle.min.js docs/js/",
     "deploy:bench": "copyfiles build/benchmark-bundle.min.js docs/js/",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -69,6 +69,7 @@ const cli_config = {
 
 if (process.env.PEGGY_CLI_DEBUG) {
   cli_config.output.sourcemap = "inline";
+  cli_config.output.sourcemapExcludeSources = true;
 }
 
 /**

--- a/test/cli/run.spec.ts
+++ b/test/cli/run.spec.ts
@@ -325,10 +325,10 @@ Options:
                                    specified, the source map will be named
                                    "<input_file>.map" if input is a file and
                                    "source.map" if input is a standard input.
-                                   If the special filename 'inline' is given,
+                                   If the special filename \`inline\` is given,
                                    the sourcemap will be embedded in the output
                                    file as a data URI.  If the filename is
-                                   prefixed with \`hidden\`, no mapping URL will
+                                   prefixed with \`hidden:\`, no mapping URL will
                                    be included so that the mapping can be
                                    specified with an HTTP SourceMap: header.
                                    This option conflicts with the \`-t/--test\`

--- a/test/cli/run.spec.ts
+++ b/test/cli/run.spec.ts
@@ -327,10 +327,13 @@ Options:
                                    "source.map" if input is a standard input.
                                    If the special filename 'inline' is given,
                                    the sourcemap will be embedded in the output
-                                   file as a data URI.  This option conflicts
-                                   with the \`-t/--test\` and \`-T/--test-file\`
-                                   options unless \`-o/--output\` is also
-                                   specified
+                                   file as a data URI.  If the filename is
+                                   prefixed with \`hidden\`, no mapping URL will
+                                   be included so that the mapping can be
+                                   specified with an HTTP SourceMap: header.
+                                   This option conflicts with the \`-t/--test\`
+                                   and \`-T/--test-file\` options unless
+                                   \`-o/--output\` is also specified
   -t, --test <text>                Test the parser with the given text,
                                    outputting the result of running the parser
                                    instead of the parser itself. If the input
@@ -823,6 +826,27 @@ Options:
         expect(fs.statSync(testOutput)).toBeInstanceOf(fs.Stats);
         fs.unlinkSync(testOutput);
       });
+
+      it("emits an error with hidden:inline", async() => {
+        await expect(exec({
+          args: ["-m", "hidden:inline", "-o", testOutput],
+          stdin: "foo = '1' { return 42; }",
+          errorCode: "peggy.invalidArgument",
+          exitCode: 1,
+          error: "hidden + inline sourceMap makes no sense.",
+        }));
+      });
+
+      it("hides sourceMap with hidden:", async() => {
+        await checkSourceMap(
+          sourceMap,
+          ["-o", testOutput, "-m", "hidden:" + sourceMap]
+        );
+        expect(fs.statSync(testOutput)).toBeInstanceOf(fs.Stats);
+        const output = fs.readFileSync(testOutput, "utf8");
+        expect(output).not.toMatch(/# sourceMappingURL=/);
+        fs.unlinkSync(testOutput);
+      });
     });
 
     describe("with specified name", () => {
@@ -869,6 +893,17 @@ Options:
           // Make sure the file isn't there
           fs.statSync(sourceMap);
         }).toThrow();
+      });
+    });
+
+    describe("with inline map", () => {
+      it("generates map inline", async() => {
+        await exec({
+          args: ["-m", "inline"],
+          stdin: "foo = '1'",
+          // eslint-disable-next-line max-len
+          expected: /^\/\/# sourceMappingURL=data:application\/json;charset=utf-8;base64,./m,
+        });
       });
     });
   });

--- a/test/cli/run.spec.ts
+++ b/test/cli/run.spec.ts
@@ -325,9 +325,12 @@ Options:
                                    specified, the source map will be named
                                    "<input_file>.map" if input is a file and
                                    "source.map" if input is a standard input.
-                                   This option conflicts with the \`-t/--test\`
-                                   and \`-T/--test-file\` options unless
-                                   \`-o/--output\` is also specified
+                                   If the special filename 'inline' is given,
+                                   the sourcemap will be embedded in the output
+                                   file as a data URI.  This option conflicts
+                                   with the \`-t/--test\` and \`-T/--test-file\`
+                                   options unless \`-o/--output\` is also
+                                   specified
   -t, --test <text>                Test the parser with the given text,
                                    outputting the result of running the parser
                                    instead of the parser itself. If the input


### PR DESCRIPTION
Add `//# sourceMappingURL=` to generated JS files from the CLI only.  Use the magic filename `inline` to get an inline sourceMap, like rollup does.

For the infrequent use case when people want to use an HTTP `SourceMap:` header, prefix the output file with `hidden:`.