### PR TITLE
Require grammar source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Released: TBD
 - [#280](https://github.com/peggyjs/peggy/issues/280) new output type
   `source-with-inline-map`, which generates source text with an inline map,
   from @hildjj
+- [#285](https://github.com/peggyjs/peggy/issues/285) Require that a non-empty
+  string be given as a grammarSource if you are generating a source map, from
+  @hildjj
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,9 @@ Released: 2022-05-28
   definition of SyntaxError, from @cmfcmf
 - [#220](https://github.com/peggyjs/peggy/issues/220): Fix rollup warnings,
   from @hildjj
+- [#285](https://github.com/peggyjs/peggy/issues/285): Work around source-map
+  bug by throwing an exception if no grammarSource is given when generating
+  source maps, from @hildjj.
 
 1.2.0
 -----

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -414,15 +414,14 @@ supported:</p>
     </ul>
     <p>(default: <code>"parser"</code>)</p>
     <blockquote>
-      <p><strong>Note</strong>: because of bug <a
-      href="https://github.com/mozilla/source-map/issues/444">source-map/444</a>
-      you should also set <code>grammarSource</code> to a not-empty string if
-      you set this value to <code>"source-and-map"</code> or
-      <code>"source-with-inline-map"</code>.  The path should be relative to
-      the location where the generated parser code will be stored.  For
-      example, if you are generating <code>lib/parser.js</code> from
-      <code>src/parser.peggy</code>, then your options should be:
-      <code>{ grammarSource: "../src/parser.peggy" }</code></p>
+      <p><strong>Note</strong>: You should also set <code>grammarSource</code>
+        to a not-empty string if you set this value to
+        <code>"source-and-map"</code> or
+        <code>"source-with-inline-map"</code>.  The path should be relative to
+        the location where the generated parser code will be stored.  For
+        example, if you are generating <code>lib/parser.js</code> from
+        <code>src/parser.peggy</code>, then your options should be:
+        <code>{ grammarSource: "../src/parser.peggy" }</code></p>
     </blockquote>
   </dd>
 

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -93,11 +93,13 @@ const compiler = {
         }
       }
     }
+    // Due to https://github.com/mozilla/source-map/issues/444
+    // grammarSource is required
     if (((options.output === "source-and-map")
          || (options.output === "source-with-inline-map"))
         && ((typeof options.grammarSource !== "string")
             || (options.grammarSource.length === 0))) {
-      throw new Error("Must provide grammarSource in order to generate source maps");
+      throw new Error("Must provide grammarSource (as a string) in order to generate source maps");
     }
 
     const session = new Session(options);

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -93,6 +93,12 @@ const compiler = {
         }
       }
     }
+    if (((options.output === "source-and-map")
+         || (options.output === "source-with-inline-map"))
+        && ((typeof options.grammarSource !== "string")
+            || (options.grammarSource.length === 0))) {
+      throw new Error("Must provide grammarSource in order to generate source maps");
+    }
 
     const session = new Session(options);
     Object.keys(passes).forEach(stage => {

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -110,13 +110,22 @@ describe("peg.d.ts", () => {
     const p1 = peggy.generate(src, { output: "source" });
     expectType<string>(p1);
 
-    const p2 = peggy.generate(src, { output: "source-and-map" });
+    const p2 = peggy.generate(src, {
+      output: "source-and-map",
+      grammarSource: "src.peggy",
+    });
     expectType<SourceNode>(p2);
 
-    const p3 = peggy.generate(src, { output: true as boolean ? "source-and-map" : "source" });
+    const p3 = peggy.generate(src, {
+      output: true as boolean ? "source-and-map" : "source",
+      grammarSource: "src.peggy",
+    });
     expectType<string | SourceNode>(p3);
 
-    const p4 = peggy.generate(src, { output: "source-with-inline-map" });
+    const p4 = peggy.generate(src, {
+      output: "source-with-inline-map",
+      grammarSource: "src.peggy",
+    });
     expectType<string>(p4);
   });
 
@@ -134,21 +143,27 @@ describe("peg.d.ts", () => {
     const p2 = peggy.compiler.compile(
       ast,
       peggy.compiler.passes,
-      { output: "source-and-map" }
+      { output: "source-and-map", grammarSource: "src.peggy" }
     );
     expectType<SourceNode>(p2);
 
     const p3 = peggy.compiler.compile(
       ast,
       peggy.compiler.passes,
-      { output: true as boolean ? "source-and-map" : "source" }
+      {
+        output: true as boolean ? "source-and-map" : "source",
+        grammarSource: "src.peggy",
+      }
     );
     expectType<string | SourceNode>(p3);
 
     const p4 = peggy.compiler.compile(
       ast,
       peggy.compiler.passes,
-      { output: "source-with-inline-map" }
+      {
+        output: "source-with-inline-map",
+        grammarSource: "src.peggy",
+      }
     );
     expectType<string>(p4);
   });

--- a/test/unit/compiler.spec.js
+++ b/test/unit/compiler.spec.js
@@ -58,4 +58,23 @@ describe("Peggy compiler", () => {
       /* eslint-enable no-undef */
     }
   });
+
+  it("requires grammarSource with source-map", () => {
+    const ast = parser.parse("foo='1'");
+    expect(ast).to.be.an("object");
+    expect(() => compiler.compile(ast, compiler.passes, {
+      output: "source-and-map",
+    })).to.throw("Must provide grammarSource (as a string) in order to generate source maps");
+    expect(() => compiler.compile(ast, compiler.passes, {
+      output: "source-and-map",
+      grammarSource: "",
+    })).to.throw("Must provide grammarSource (as a string) in order to generate source maps");
+    // Don't run on old IE
+    if (typeof TextEncoder === "function") {
+      expect(() => compiler.compile(ast, compiler.passes, {
+        output: "source-with-inline-map",
+        grammarSource: { toString() { return ""; } },
+      })).to.throw("Must provide grammarSource (as a string) in order to generate source maps");
+    }
+  });
 });

--- a/test/unit/compiler.spec.js
+++ b/test/unit/compiler.spec.js
@@ -39,6 +39,7 @@ describe("Peggy compiler", () => {
     if (typeof TextEncoder === "function") {
       expect(compiler.compile(ast, compiler.passes, {
         output: "source-with-inline-map",
+        grammarSource: "src.peggy",
       })).to.match(
         /^\/\/# sourceMappingURL=data:application\/json;charset=utf-8;base64,/m
       );
@@ -50,6 +51,7 @@ describe("Peggy compiler", () => {
         delete globalThis.TextEncoder;
         expect(() => compiler.compile(ast, compiler.passes, {
           output: "source-with-inline-map",
+          grammarSource: "src.peggy",
         })).to.throw("TextEncoder is not supported by this platform");
         globalThis.TextEncoder = TE;
       }


### PR DESCRIPTION
Stacked on top of #282.

This is a proposed work-around for https://github.com/mozilla/source-map/issues/444.  Is this adequate?