### PR TITLE
(feat) add semver.org example

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Balázs Kutil <bkutil@users.noreply.github.com> (https://github.com/bkutil/)
 Caleb Hearon <crh0872@gmail.com> (https://github.com/chearon/)
 Charles Pick <charles@codemix.com> (https://github.com/phpnode/)
 Christian Flach <github@christianflach.de> (https://github.com/cmfcmf/)
+Dan Selman <danscode@selman.org> (https://github.com/dselman)
 David Berneda <david@steema.com>
 Futago-za Ryuu <futagoza.ryuu@gmail.com> (https://github.com/futagoza/)
 Jakub Vrana <jakub@vrana.cz> (https://github.com/vrana/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file documents all notable changes to Peggy.
 Unreleased
 ----------
 
+- [#299](https://github.com/peggyjs/peggy/issues/299) Add example grammar for a
+  [SemVer.org](https://semver.org) semantic version string
+
 Released: TBD
 
 ### Major Changes

--- a/examples/semver.peggy
+++ b/examples/semver.peggy
@@ -1,0 +1,60 @@
+/**
+ * SemVer.org v2
+ * https://semver.org/spec/v2.0.0.html
+ * For unit tests see: https://github.com/dselman/peggy-semver
+ */
+semver
+  = versionCore:versionCore
+    pre:('-' @preRelease)?
+    build:('+' @build)?
+  {
+    return { versionCore, pre, build };
+  }
+
+versionCore
+  = major:$numericIdentifier '.' minor:$numericIdentifier '.' patch:$numericIdentifier
+  {
+    return {
+      major: parseInt(major, 10),
+      minor: parseInt(minor, 10),
+      patch: parseInt(patch, 10),
+    };
+  }
+
+preRelease
+  = head:$preReleaseIdentifier tail:('.' @$preReleaseIdentifier)*
+  {
+    return [head, ...tail];
+  }
+
+build
+  = head:$buildIdentifier tail:('.' @$buildIdentifier)*
+  {
+    return [head, ...tail];
+  }
+
+preReleaseIdentifier
+  = alphanumericIdentifier
+  / numericIdentifier
+
+buildIdentifier
+  = alphanumericIdentifier
+  / digit+
+
+alphanumericIdentifier
+  = digit* nonDigit identifierChar*
+
+numericIdentifier
+  = '0' / (positiveDigit digit*)
+
+identifierChar
+  = [a-z0-9-]i
+
+nonDigit
+  = [a-z-]i
+
+digit
+  = [0-9]
+
+positiveDigit
+  = [1-9]


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

Adds an example grammar that describes a SemVer.org v2 semantic version.