### PR TITLE
Remove unnecessary reserved words introduced in 3.0.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Julian Aubourg <j@ubourg.net> (https://github.com/jaubourg)
 Justin Blank <justin.blank@gmail.com> (https://github.com/hyperpape/)
 Marco Baumgartl <marco.baumgartl@boerse-go.de>
 Mingun <alexander_sergey@mail.ru> (https://github.com/Mingun/)
+Rene Saarsoo <nene@triin.net> (https://github.com/nene/)
 Tony Lukasavage <anthony.lukasavage@gmail.com> (https://github.com/tonylukasavage/)
 chunpu <fengtong@mail.ustc.edu.cn> (https://github.com/chunpu/)
 fatfisz <fatfisz@gmail.com> (https://github.com/fatfisz/)

--- a/lib/peg.js
+++ b/lib/peg.js
@@ -64,35 +64,41 @@ const RESERVED_WORDS = [
   // The following are only reserved when they are found in module code:
   "await",
 
-  // The following are reserved as future keywords by older ECMAScript
-  // specifications
-  "abstract",
-  "boolean",
-  "byte",
-  "char",
-  "double",
-  "final",
-  "float",
-  "goto",
-  "int",
-  "long",
-  "native",
-  "short",
-  "synchronized",
-  "throws",
-  "transient",
-  "volatile",
+  // The following are reserved as future keywords by ECMAScript 1..3
+  // specifications, but not any more in modern ECMAScript. We don't need these
+  // because the code-generation of Peggy only targets ECMAScript >= 5.
+  //
+  // - abstract
+  // - boolean
+  // - byte
+  // - char
+  // - double
+  // - final
+  // - float
+  // - goto
+  // - int
+  // - long
+  // - native
+  // - short
+  // - synchronized
+  // - throws
+  // - transient
+  // - volatile
+
+  // These are not reserved keywords, but using them as variable names is problematic.
+  "arguments", // Conflicts with a special variable available inside functions.
+  "eval", // Redeclaring eval() is prohibited in strict mode
 
   // A few identifiers have a special meaning in some contexts without being
-  // reserved words of any kind. They include:
-  "arguments",
-  "as",
-  "async",
-  "eval",
-  "from",
-  "get",
-  "of",
-  "set",
+  // reserved words of any kind. These we don't need to worry about as they can
+  // all be safely used as variable names.
+  //
+  // - as
+  // - async
+  // - from
+  // - get
+  // - of
+  // - set
 ];
 
 const peg = {

--- a/test/api/pegjs-api.spec.js
+++ b/test/api/pegjs-api.spec.js
@@ -245,7 +245,7 @@ describe("Peggy API", () => {
         }
       });
 
-      describe("does not throws an exception on reserved JS words used as a rule name", () => {
+      describe("does not throw an exception on reserved JS words used as a rule name", () => {
         for (const rule of peg.RESERVED_WORDS) {
           it(rule, () => {
             expect(() => {

--- a/test/api/pegjs-api.spec.js
+++ b/test/api/pegjs-api.spec.js
@@ -235,10 +235,11 @@ describe("Peggy API", () => {
         ];
         for (const label of nonReserved) {
           it(label, () => {
-            peg.generate([
-              "start = " + label + ":end",
+            const source = peg.generate([
+              "start = " + label + ":end { return " + label + "; }",
               "end = 'a'",
             ].join("\n"), { output: "source" });
+            expect(eval(source).parse("a")).to.equal("a");
           });
         }
       });
@@ -246,10 +247,11 @@ describe("Peggy API", () => {
       describe("does not throw an exception on reserved JS words used as a rule name", () => {
         for (const rule of peg.RESERVED_WORDS) {
           it(rule, () => {
-            peg.generate([
+            const source = peg.generate([
               "start = " + rule,
               rule + " = 'a'",
             ].join("\n"), { output: "source" });
+            expect(eval(source).parse("a")).to.equal("a");
           });
         }
       });

--- a/test/api/pegjs-api.spec.js
+++ b/test/api/pegjs-api.spec.js
@@ -235,12 +235,10 @@ describe("Peggy API", () => {
         ];
         for (const label of nonReserved) {
           it(label, () => {
-            expect(() => {
-              peg.generate([
-                "start = " + label + ":end",
-                "end = 'a'",
-              ].join("\n"), { output: "source" });
-            }).to.not.throw(peg.parser.SyntaxError);
+            peg.generate([
+              "start = " + label + ":end",
+              "end = 'a'",
+            ].join("\n"), { output: "source" });
           });
         }
       });
@@ -248,12 +246,10 @@ describe("Peggy API", () => {
       describe("does not throw an exception on reserved JS words used as a rule name", () => {
         for (const rule of peg.RESERVED_WORDS) {
           it(rule, () => {
-            expect(() => {
-              peg.generate([
-                "start = " + rule,
-                rule + " = 'a'",
-              ].join("\n"), { output: "source" });
-            }).to.not.throw(peg.parser.SyntaxError);
+            peg.generate([
+              "start = " + rule,
+              rule + " = 'a'",
+            ].join("\n"), { output: "source" });
           });
         }
       });

--- a/test/api/pegjs-api.spec.js
+++ b/test/api/pegjs-api.spec.js
@@ -206,6 +206,45 @@ describe("Peggy API", () => {
         }
       });
 
+      describe("does not throw an exception on special non-reserved JS words used as a label", () => {
+        const nonReserved = [
+          // Reserved in old ECMAScript versions
+          "abstract",
+          "boolean",
+          "byte",
+          "char",
+          "double",
+          "final",
+          "float",
+          "goto",
+          "int",
+          "long",
+          "native",
+          "short",
+          "synchronized",
+          "throws",
+          "transient",
+          "volatile",
+          // Never reserved, but used in special language constructs
+          "as",
+          "async",
+          "from",
+          "get",
+          "of",
+          "set",
+        ];
+        for (const label of nonReserved) {
+          it(label, () => {
+            expect(() => {
+              peg.generate([
+                "start = " + label + ":end",
+                "end = 'a'",
+              ].join("\n"), { output: "source" });
+            }).to.not.throw(peg.parser.SyntaxError);
+          });
+        }
+      });
+
       describe("does not throws an exception on reserved JS words used as a rule name", () => {
         for (const rule of peg.RESERVED_WORDS) {
           it(rule, () => {


### PR DESCRIPTION
- Document why they aren't needed to avoid similar mistakes in the future.
- Add test to check that these words can now be safely used as labels.

@hildjj I added test to another file than the one you suggested. Found `pegjs-api.spec.js` which already contained tests for the reserved keywords, thought it makes sense to keep all these tests together. Also, didn't manage to figure out how I could make the use of reserved words make the `parser.spec.js` fail. (I suppose that test only deals with parsing and the keywords are checked for in some other pass which isn't activated in the context of that test).

Fixes #359