### PR TITLE
Fixes #329

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ Released: TBD
 
 ### Minor Changes
 
+- [#329](https://github.com/peggyjs/peggy/issues/329)] Allow plugin options in
+  generate.  This change loosens type checking strictness to allow for options
+  unknown to Peggy, but used by plugins such as ts-pegjs.  From @hildjj.
+
 ### Bug Fixes
 
-- [[#359](https://github.com/peggyjs/peggy/issues/359)] Do not treat as many
+- [#359](https://github.com/peggyjs/peggy/issues/359)] Do not treat as many
   words as reserved.  Clarify the documentation about identifiers.  Ensure
   that it is more clear that the target language being generated determines
   what words are reserved.  Clarify that reserved word checking is only

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -1186,6 +1186,12 @@ export interface BuildOptionsBase {
 
 export interface ParserBuildOptions extends BuildOptionsBase {
   /**
+   * Extensions may need to the caller to pass in otherwise-unknown options.
+   * ts-pegjs has an example in its README.md.
+   */
+  [extensionOpts: string]: any;
+
+  /**
    * If set to `"parser"`, the method will return generated parser object;
    * if set to `"source"`, it will return parser source code as a string;
    * if set to `"source-and-map"`, it will return a `SourceNode` object

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -57,6 +57,9 @@ describe("peg.d.ts", () => {
 
     res = parser.parse("buzz\n11\nfizz\n", { start: 10 });
     expect(res).toStrictEqual(["buzz", 11, "fizz"]);
+
+    res = peggy.generate("foo='a'", { unknown: { more: 12 } });
+    expectType<peggy.Parser>(parser);
   });
 
   it("types SyntaxError correctly", () => {


### PR DESCRIPTION
I'd like someone with more TypeScript intuition to think about how much this breaks things.  I realize that it means that we're not going to get as good type checking on known parameters, but this is what we get for having inherited an API.