### PR TITLE
Fix an error in the code generator for "repeated" node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Released: TBD
 - [#347](https://github.com/peggyjs/peggy/issues/347) Disallow '$' as an initial
   character in identifiers.  This is not a breaking change because no grammar
   could have successfully used these in the past.  From @hildjj.
+- [#364](https://github.com/peggyjs/peggy/issues/364) Fix passing an incorrect
+  external label to the expression inside the `repeated` node.  From @Mingun.
 
 3.0.0
 -----

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -897,11 +897,19 @@ function generateBytecode(ast, options) {
         : { pre: [], post: [], sp: context.sp };
       const maxCode = buildRangeCall(node.max, context.env, minCode.sp, offset);
 
-      const expressionCode = generate(node.expression, {
+      const firstExpressionCode = generate(node.expression, {
         sp: maxCode.sp + offset,
         env: cloneEnv(context.env),
         action: null,
       });
+      const expressionCode = node.delimiter !== null
+        ? generate(node.expression, {
+          // +1 for the saved position before parsing the `delimiter elem` pair
+          sp: maxCode.sp + offset + 1,
+          env: cloneEnv(context.env),
+          action: null,
+        })
+        : firstExpressionCode;
       const bodyCode = buildRangeBody(
         node.delimiter,
         node.expression.match | 0,
@@ -914,8 +922,8 @@ function generateBytecode(ast, options) {
       // For dynamic high boundary we need check the first iteration, because the result can be
       // empty. Constant boundaries does not require that check, because they are always >=1
       const firstElemCode = hasBoundedMax
-        ? buildCheckMax(expressionCode, node.max)
-        : expressionCode;
+        ? buildCheckMax(firstExpressionCode, node.max)
+        : firstExpressionCode;
       const mainLoopCode = buildSequence(
         // If the low boundary present, then backtracking is possible, so save the current pos
         hasMin ? [op.PUSH_CURR_POS] : [], // var savedPos = curPos;   stack:[ pos ]

--- a/test/behavior/generated-parser-behavior.spec.js
+++ b/test/behavior/generated-parser-behavior.spec.js
@@ -1112,6 +1112,24 @@ describe("generated parser behavior", () => {
 
             expect(parser).to.parse("aa", 42);
           });
+
+          // Regression tests for https://github.com/peggyjs/peggy/issues/364
+          it("correctly pass external references to labels to repeated expression", () => {
+            let parser = peg.generate("start = ref:'a' ('b' &{ return ref === 'a'; })|..|", options);
+            expect(parser).to.parse("abb", ["a", [["b", undefined], ["b", undefined]]]);
+
+            parser = peg.generate("start = ref:'a' ('b' &{ return ref === 'a'; })|2..|", options);
+            expect(parser).to.parse("abb", ["a", [["b", undefined], ["b", undefined]]]);
+
+            parser = peg.generate("start = ref:'a' ('b' &{ return ref === 'a'; })|..3|", options);
+            expect(parser).to.parse("abb", ["a", [["b", undefined], ["b", undefined]]]);
+
+            parser = peg.generate("start = ref:'a' ('b' &{ return ref === 'a'; })|2..3|", options);
+            expect(parser).to.parse("abb", ["a", [["b", undefined], ["b", undefined]]]);
+
+            parser = peg.generate("start = ref:'a' ('b' &{ return ref === 'a'; })|2|", options);
+            expect(parser).to.parse("abb", ["a", [["b", undefined], ["b", undefined]]]);
+          });
         });
 
         describe("with variable boundaries", () => {
@@ -1478,6 +1496,21 @@ describe("generated parser behavior", () => {
               expect(parser).to.parse("aa", 1, { exact: 2 });
             });
           });
+
+          // Regression tests for https://github.com/peggyjs/peggy/issues/364
+          it("correctly pass external references to labels to boundary expression", () => {
+            let parser = peg.generate("start = ref:'a' 'b'|{ return ref === 'a' ? 2 : 0; }..|", options);
+            expect(parser).to.parse("abb", ["a", ["b", "b"]]);
+
+            parser = peg.generate("start = ref:'a' 'b'|..{ return ref === 'a' ? 3 : 0; }|", options);
+            expect(parser).to.parse("abb", ["a", ["b", "b"]]);
+
+            parser = peg.generate("start = ref:'a' 'b'|{ return ref === 'a' ? 2 : 0; }..{ return ref === 'a' ? 3 : 0; }|", options);
+            expect(parser).to.parse("abb", ["a", ["b", "b"]]);
+
+            parser = peg.generate("start = ref:'a' 'b'|{ return ref === 'a' ? 2 : 0; }|", options);
+            expect(parser).to.parse("abb", ["a", ["b", "b"]]);
+          });
         });
       });
 
@@ -1572,6 +1605,27 @@ describe("generated parser behavior", () => {
             expect(parser).to.failToParse("a");
             expect(parser).to.failToParse("a~a");
             expect(parser).to.failToParse("a~a~a");
+          });
+
+          // Regression tests for https://github.com/peggyjs/peggy/issues/364
+          it("correctly pass external references to labels to repeated expression", () => {
+            let parser = peg.generate("start = ref:'a' ('b' &{ return ref === 'a'; })|.., ' '|", options);
+            expect(parser).to.parse("ab b", ["a", [["b", undefined], ["b", undefined]]]);
+
+            parser = peg.generate("start = ref:'a' ('b' &{ return ref === 'a'; })|2.., ' '|", options);
+            expect(parser).to.parse("ab b", ["a", [["b", undefined], ["b", undefined]]]);
+
+            parser = peg.generate("start = ref:'a' ('b' &{ return ref === 'a'; })|..3, ' '|", options);
+            expect(parser).to.parse("ab b", ["a", [["b", undefined], ["b", undefined]]]);
+
+            parser = peg.generate("start = ref:'a' ('b' &{ return ref === 'a'; })|2..3, ' '|", options);
+            expect(parser).to.parse("ab b", ["a", [["b", undefined], ["b", undefined]]]);
+
+            parser = peg.generate("start = ref:'a' ('b' &{ return ref === 'a'; })|2, ' '|", options);
+            expect(parser).to.parse("ab b", ["a", [["b", undefined], ["b", undefined]]]);
+
+            parser = peg.generate("start = ref:'a' 'b'|{ return ref === 'a' ? 2 : 0; }, ' '|", options);
+            expect(parser).to.parse("ab b", ["a", ["b", "b"]]);
           });
         });
 
@@ -1967,6 +2021,21 @@ describe("generated parser behavior", () => {
             expect(parser).to.failToParse("a");
             expect(parser).to.failToParse("a~a");
             expect(parser).to.failToParse("a~a~a");
+          });
+
+          // Regression tests for https://github.com/peggyjs/peggy/issues/364
+          it("correctly pass external references to labels to boundary expression", () => {
+            let parser = peg.generate("start = ref:'a' 'b'|{ return ref === 'a' ? 2 : 0; }.., ' '|", options);
+            expect(parser).to.parse("ab b", ["a", ["b", "b"]]);
+
+            parser = peg.generate("start = ref:'a' 'b'|..{ return ref === 'a' ? 3 : 0; }, ' '|", options);
+            expect(parser).to.parse("ab b", ["a", ["b", "b"]]);
+
+            parser = peg.generate("start = ref:'a' 'b'|{ return ref === 'a' ? 2 : 0; }..{ return ref === 'a' ? 3 : 0; }, ' '|", options);
+            expect(parser).to.parse("ab b", ["a", ["b", "b"]]);
+
+            parser = peg.generate("start = ref:'a' 'b'|{ return ref === 'a' ? 2 : 0; }, ' '|", options);
+            expect(parser).to.parse("ab b", ["a", ["b", "b"]]);
           });
         });
       });


### PR DESCRIPTION
The problem only with repeated expressions with delimiter. We cannot use the same bytecode for the 1st and the others repetitions, because after the first element the saved position is present in the variables stack. The stack in the append loop looks like:
```
stack: [arr]
stack: [arr element]
stack: [arr+] -- append the first element

Start loop
stack: [arr pos] -- this `pos` shifts all external label indexes in `expression` by 1
stack: [arr pos delimiter]
stack: [arr pos delimiter element]
stack: [arr+] -- append the others elements
Go to start of loop
```

Fixes #364.