### PR TITLE
Fall back on console.log when node-inspect-extracted fails

### DIFF
--- a/docs/js/online.js
+++ b/docs/js/online.js
@@ -30,6 +30,14 @@ $(document).ready(function() {
     return problems;
   });
 
+  function inspect(obj, opts) {
+    if (typeof util === 'object') {
+      return util.inspect(obj, opts);
+    }
+    console.warn("node-util-inspect not supported on this browser")
+    console.log(obj)
+    return String(obj) + "     // See browser console"
+  }
   function convertLocation(location) {
     return CodeMirror.Pos(location.line - 1, location.column - 1);
   }
@@ -165,7 +173,7 @@ $(document).ready(function() {
           newInput.length,
           timeAfter - timeBefore
         ));
-      $("#output").removeClass("disabled").text(util.inspect(output, {
+      $("#output").removeClass("disabled").text(inspect(output, {
         depth: Infinity,
         color: false,
         maxArrayLength: Infinity,

--- a/docs/online.html
+++ b/docs/online.html
@@ -9,9 +9,9 @@ stylesheets: [
   "/vendor/codemirror/lint.css"
 ]
 scripts: [
-  "https://unpkg.com/jquery@1.12.4/dist/jquery.min.js",
-  "https://unpkg.com/file-saver@2.0.2/dist/FileSaver.min.js",
-  "https://unpkg.com/node-inspect-extracted@1.1.0/dist/inspect.js",
+  "https://unpkg.com/jquery@3.6.3/dist/jquery.js",
+  "https://unpkg.com/file-saver@2.0.5/dist/FileSaver.min.js",
+  "https://unpkg.com/node-inspect-extracted@2.0.0/dist/inspect.js",
   "/vendor/peggy/peggy.min.js",
   "/vendor/codemirror/codemirror.js",
   "/vendor/codemirror/lint.js",


### PR DESCRIPTION
Fixes #371, but not really.