### PR TITLE
uncaught exception in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Released: TBD
 
 ### Bug Fixes
 
+- [#374](https://github.com/peggyjs/peggy/issues/374) CLI throws exception
+  on grammar errors. From @hildjj
+
 3.0.1
 -----
 

--- a/bin/peggy-cli.js
+++ b/bin/peggy-cli.js
@@ -655,18 +655,22 @@ class PeggyCLI extends Command {
         await this.test(mappedSource);
       }
     } catch (error) {
+      const sources = [{
+        source: this.argv.grammarSource,
+        text: input,
+      }];
+      if (this.testGrammarSource) {
+        sources.push({
+          source: this.testGrammarSource,
+          text: this.testText,
+        });
+      }
       // Will either exit or throw.
       this.error(errorText, {
         error,
         exitCode,
         code: "peggy.cli",
-        sources: [{
-          source: this.argv.grammarSource,
-          text: input,
-        }, {
-          source: this.testGrammarSource,
-          text: this.testText,
-        }],
+        sources,
       });
     }
     return 0;

--- a/lib/grammar-error.js
+++ b/lib/grammar-error.js
@@ -85,7 +85,7 @@ class GrammarError extends Error {
   format(sources) {
     const srcLines = sources.map(({ source, text }) => ({
       source,
-      text: text.split(/\r\n|\n|\r/g),
+      text: text ? String(text).split(/\r\n|\n|\r/g) : [],
     }));
 
     /**

--- a/lib/grammar-error.js
+++ b/lib/grammar-error.js
@@ -85,7 +85,9 @@ class GrammarError extends Error {
   format(sources) {
     const srcLines = sources.map(({ source, text }) => ({
       source,
-      text: text ? String(text).split(/\r\n|\n|\r/g) : [],
+      text: (text !== null && text !== undefined)
+        ? String(text).split(/\r\n|\n|\r/g)
+        : [],
     }));
 
     /**

--- a/test/cli/run.spec.ts
+++ b/test/cli/run.spec.ts
@@ -1132,4 +1132,19 @@ Error: Expected "1" but end of input found.
       expected: "[ 'zazzy' ]\n",
     });
   });
+
+  it("handles grammar errors", async() => {
+    await exec({
+      stdin: "foo=unknownRule",
+      errorCode: "peggy.cli",
+      exitCode: 1,
+      error: `\
+Error parsing grammar
+error: Rule "unknownRule" is not defined
+ --> stdin:1:5
+  |
+1 | foo=unknownRule
+  |     ^^^^^^^^^^^`,
+    });
+  });
 });

--- a/test/unit/grammar-error.spec.js
+++ b/test/unit/grammar-error.spec.js
@@ -147,6 +147,15 @@ error: message
 warning: Warning message
  at foo.peggy:1:6
  at foo.peggy:1:6: Warning Subinfo`);
+
+          expect(e.format([{ source: null, text: undefined }])).to.equal(`\
+error: message
+ at foo.peggy:1:1
+ at foo.peggy:1:6: Subinfo
+
+warning: Warning message
+ at foo.peggy:1:6
+ at foo.peggy:1:6: Warning Subinfo`);
         });
 
         it("with source", () => {

--- a/test/unit/grammar-error.spec.js
+++ b/test/unit/grammar-error.spec.js
@@ -138,6 +138,17 @@ error: message
           [],
         ]);
 
+        it("null source text", () => {
+          expect(e.format([{ source: null, text: null }])).to.equal(`\
+error: message
+ at foo.peggy:1:1
+ at foo.peggy:1:6: Subinfo
+
+warning: Warning message
+ at foo.peggy:1:6
+ at foo.peggy:1:6: Warning Subinfo`);
+        });
+
         it("with source", () => {
           expect(e.format([source])).to.equal(`\
 error: message


### PR DESCRIPTION
Fixes #374.  
CLI was throwing exception on grammar errors without a CLI test also being specified.