### PR TITLE
Bytecode optimizer

### DIFF
--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const generateBytecode = require("./passes/generate-bytecode");
+const optimizeBytecode = require("./passes/optimize-bytecode");
 const generateJS = require("./passes/generate-js");
 const inferenceMatchResult = require("./passes/inference-match-result");
 const removeProxyRules = require("./passes/remove-proxy-rules");
@@ -62,6 +63,7 @@ const compiler = {
     ],
     generate: [
       generateBytecode,
+      optimizeBytecode,
       generateJS,
     ],
   },

--- a/lib/compiler/index.js
+++ b/lib/compiler/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const generateBytecode = require("./passes/generate-bytecode");
-const optimizeBytecode = require("./passes/optimize-bytecode");
+const { optimizeBytecode } = require("./passes/optimize-bytecode");
 const generateJS = require("./passes/generate-js");
 const inferenceMatchResult = require("./passes/inference-match-result");
 const removeProxyRules = require("./passes/remove-proxy-rules");

--- a/lib/compiler/interp-state.js
+++ b/lib/compiler/interp-state.js
@@ -1,0 +1,893 @@
+// @ts-check
+"use strict";
+
+const op = require("./opcodes");
+
+const TypeTag = {
+  UNDEFINED: 0b0000001,
+  NULL:      0b0000010,
+  FAILED:    0b0000100,
+  OFFSET:    0b0001000,
+  ARRAY:     0b0010000,
+  STRING:    0b0100000,
+  ANY:       0b1111111,
+};
+
+/**
+ * A synthetic type, representing values in the interpreter.
+ * @typedef {object}        InterpType
+ * @property {number}       type
+ * @property {string | {}}  [value]
+ */
+
+/**
+ * A description of modifications to be made to the bytecode
+ * @typedef {object}        BytecodeMods
+ * @property {number}       startOffset
+ * @property {number}       length
+ * @property {number[]}     replacements
+ */
+
+/**
+ * Description of the effects of an interp step
+ * @typedef {object}        InterpResult
+ * @property {number}       ip - the next bytecode offset
+ *      were made without changing the state.
+ * @property {InterpState}  [thenState]
+ *    - for conditionals, the state at the end of the then block
+ * @property {InterpState}  [elseState]
+ *    - for conditionals, the state at the end of the else block
+ * @property {BytecodeMods | null} [bytecodeMods]
+ *    - any modificationss requested by this step.
+ */
+
+/**
+ * @callback PreInterp
+ * @param {number[]}        bc
+ * @param {number}          ip
+ * @returns {InterpResult | null}
+ */
+
+/**
+ * @callback PostInterp
+ * @param {number[]}        bc
+ * @param {number}          ip
+ * @param {InterpResult}    result
+ * @returns {InterpResult}
+ */
+
+/**
+ * @callback PreRun
+ * @param {number[]}        bc
+ */
+
+/**
+ * @callback PostRun
+ * @param {number[]}        bc
+ */
+
+/**
+ * @callback InterpCondCallback
+ * @param {InterpType}      top
+ * @param {boolean}         forThen
+ * @returns {[boolean, InterpType]}
+ */
+
+class InterpState {
+  /**
+   * Constructs a helper for tracking the state in the bytecode for the purposes
+   * of optimizing it.
+   *
+   * @param {string} ruleName The name of rule that will be used in error messages
+   */
+  constructor(ruleName) {
+    this.ruleName       = ruleName;
+    /** @type {PreInterp | null} */
+    this.preInterp      = null;
+    /** @type {PostInterp | null} */
+    this.postInterp     = null;
+    /** @type {PreRun | null} */
+    this.preRun         = null;
+    /** @type {PostRun | null} */
+    this.postRun        = null;
+    this.looping        = 0;
+
+    /**
+     * Symbolic stack.
+     * @type {InterpType[]}
+     */
+    this.stack          = [];
+    /** @type {InterpType} */
+    this.currPos        = { type: TypeTag.OFFSET, value: {} };
+    this.silentFails    = 0;
+  }
+
+  /**
+   * Make this a copy of from
+   *
+   * @param {InterpState} from
+   */
+  copy(from) {
+    this.stack = from.stack.slice();
+    this.currPos = from.currPos;
+    this.silentFails = from.silentFails;
+    this.looping = from.looping;
+    this.preInterp = from.preInterp;
+    this.postInterp = from.postInterp;
+    this.preRun = from.preRun;
+    this.postRun = from.postRun;
+  }
+
+  /**
+   * Clone this.
+   *
+   * @returns InterpState
+   */
+  clone() {
+    const clone = new InterpState(this.ruleName);
+    clone.copy(this);
+    return clone;
+  }
+
+  /**
+   * Merge from into this (at a join point)
+   *
+   * @param {InterpState} from
+   */
+  merge(from) {
+    if (this.stack.length !== from.stack.length) {
+      throw new Error(
+        `Rule '${this.ruleName}': Merging states with mis-matched stacks.`
+      );
+    }
+    if (this.silentFails !== from.silentFails) {
+      throw new Error(
+        `Rule '${this.ruleName}': Merging states with mis-matched silentFails.`
+      );
+    }
+    for (let i = this.stack.length; i--;) {
+      this.stack[i] = InterpState.union(this.stack[i], from.stack[i]);
+    }
+    this.setCurrPos(InterpState.union(this.currPos, from.currPos));
+  }
+
+  /**
+   *
+   * @param {InterpState} from
+   * @returns boolean
+   */
+  equal(from) {
+    if (this.stack.length !== from.stack.length) {
+      return false;
+    }
+    if (this.silentFails !== from.silentFails) {
+      return false;
+    }
+    for (let i = this.stack.length; i--;) {
+      if (!InterpState.equalType(this.stack[i], from.stack[i])) {
+        return false;
+      }
+    }
+    // Don't check currPos; its likely to change on each iteration of a loop,
+    // but doesn't mean that the state didn't converge
+    return true;
+  }
+
+  /**
+   * Determine whether two InterpTypes are equal
+   *
+   * @param {InterpType} a
+   * @param {InterpType} b
+   * @returns {boolean}
+   */
+  static equalType(a, b) {
+    if (a.type !== b.type) {
+      return false;
+    }
+    return a.value === b.value;
+  }
+
+  /**
+   * Compute the union of two InterpTypes
+   *
+   * @param {InterpType} a
+   * @param {InterpType} b
+   * @returns {InterpType}
+   */
+  static union(a, b) {
+    const utype = a.type | b.type;
+    if (a.value !== undefined
+        && a.value === b.value
+        && !(utype & (utype - 1))) {
+      return { type: utype, value: a.value };
+    }
+    return { type: utype };
+  }
+
+  /**
+   * Determine whether t could be one of types
+   *
+   * @param {InterpType} t
+   * @param {number} types
+   * @returns {boolean}
+   */
+  static couldBe(t, types) {
+    return (t.type & types) !== 0;
+  }
+
+  /**
+   * Determine whether t must be one of types
+   *
+   * @param {InterpType} t
+   * @param {number} types
+   * @returns {boolean}
+   */
+  static mustBe(t, types) {
+    return (t.type & ~types) === 0 && t.type !== 0;
+  }
+
+  /**
+   * Determine whether an InterpType must be truish
+   *
+   * @param {InterpType} t
+   * @returns {boolean}
+   */
+  static mustBeTrue(t) {
+    // ARRAY and FAILED always test true, anything else
+    // could be false.
+    return InterpState.mustBe(t, TypeTag.ARRAY | TypeTag.FAILED);
+  }
+
+  /**
+   * Determine whether an InterpType must be falsish
+   *
+   * @param {InterpType} t
+   * @returns {boolean}
+   */
+  static mustBeFalse(t) {
+    // NULL and UNDEFINED always test false, anything else
+    // could be true.
+    return InterpState.mustBe(t, TypeTag.NULL | TypeTag.UNDEFINED);
+  }
+
+  /**
+   * Given one of the "conditional" bytecodes, return the number
+   * of arguments it consumes.
+   *
+   * @param {number} bc
+   * @returns number
+   */
+  static getConditionalArgCount(bc) {
+    switch (bc) {
+      case op.IF:
+      case op.IF_ERROR:
+      case op.IF_NOT_ERROR:
+      case op.MATCH_ANY:
+        return 0;
+      case op.IF_GE:
+      case op.IF_GE_DYNAMIC:
+      case op.IF_LT:
+      case op.IF_LT_DYNAMIC:
+      case op.MATCH_STRING:
+      case op.MATCH_STRING_IC:
+      case op.MATCH_CHAR_CLASS:
+        return 1;
+      default:
+        throw new Error(`Expected a conditional bytecode, but got: ${bc}.`);
+    }
+  }
+
+  /**
+   * Given a reference to a conditional bytecode, return the
+   * then and else bytecodes as a tuple.
+   *
+   * As a special case return the entire loop for
+   * WHILE_NOT_ERROR.
+   *
+   * @param {number[]} bc
+   * @param {number} ip
+   * @returns {[number[], number[], number]}
+   */
+  static getConditionalCode(bc, ip) {
+    if (bc[ip] === op.WHILE_NOT_ERROR) {
+      const length = bc[ip + 1] + 2;
+      const loopCode = bc.slice(ip, ip + length);
+      return [loopCode, [], length];
+    }
+    const argCount = InterpState.getConditionalArgCount(bc[ip]);
+    const baseLength = 3 + argCount;
+    const thenLength = bc[ip + baseLength - 2];
+    const elseLength = bc[ip + baseLength - 1];
+    const thenCode = bc.slice(
+      ip + baseLength, ip + baseLength + thenLength
+    );
+    const elseCode = bc.slice(
+      ip + baseLength + thenLength,
+      ip + baseLength + thenLength + elseLength
+    );
+    return [thenCode, elseCode, baseLength + thenLength + elseLength];
+  }
+
+  /** @param {InterpType} value */
+  push(value) {
+    this.stack.push(value);
+  }
+
+  /** @returns {InterpType} */
+  pop() {
+    const value = this.stack.pop();
+    if (!value) {
+      throw new RangeError(
+        `Rule '${this.ruleName}': Trying to pop from an empty stack.`
+      );
+    }
+    return value;
+  }
+
+  /** @returns {InterpType} */
+  top() {
+    const value = this.stack.slice(-1).pop();
+    if (!value) {
+      throw new RangeError(
+        `Rule '${this.ruleName}': Trying to access the top of an empty stack.`
+      );
+    }
+    return value;
+  }
+
+  /**
+   *
+   * @param {number} depth
+   * @returns {InterpType}
+   */
+  inspect(depth) {
+    const value = this.stack.slice(-1 - depth).pop();
+    if (!value) {
+      throw new RangeError(
+        `Rule '${this.ruleName}': Trying to inspect element ${
+          depth
+        } in a stack of size ${this.stack.length}.`
+      );
+    }
+    return value;
+  }
+
+  /**
+   * Remove n elements from the stack, that are expected to be thrown away.
+   *
+   * @param {number} n
+   * @returns {InterpType[]}
+   */
+  discard(n) {
+    if (this.stack.length < n) {
+      throw new RangeError(
+        `Rule '${this.ruleName}': Trying to pop ${n} elements, but only ${this.stack.length} available.`
+      );
+    }
+    if (n < 0) {
+      throw new RangeError(
+        `Rule '${this.ruleName}': Trying to discard ${n} elements.`
+      );
+    }
+    return n ? this.stack.splice(-n) : [];
+  }
+
+  /**
+   * Remove n elements from the stack, but (todo) mark them used.
+   *
+   * @param {number} n
+   * @returns {InterpType[]}
+   */
+  popn(n) {
+    return this.discard(n);
+  }
+
+  /**
+   * Assign value to currPos.
+   *
+   * @param {InterpType} value
+   */
+  setCurrPos(value) {
+    if (value.type !== TypeTag.OFFSET) {
+      throw new Error(
+        `Rule '${this.ruleName}': Invalid value assigned to currPos.`
+      );
+    }
+    if (!value.value) {
+      value = { type: TypeTag.OFFSET, value: {} };
+    }
+    this.currPos = value;
+  }
+
+  /**
+   * Interpret one bytecode. This may result in a callback to
+   * |run| for the then and else clauses of a conditional, or
+   * the body of a loop.
+   *
+   * @param {number[]} bc
+   * @param {number} ip
+   * @returns {InterpResult}
+   */
+  interp(bc, ip) {
+    switch (bc[ip]) {
+      case op.PUSH_EMPTY_STRING:  // PUSH_EMPTY_STRING
+        this.push({ type: TypeTag.STRING });
+        ip++;
+        break;
+
+      case op.PUSH_CURR_POS:      // PUSH_CURR_POS
+        this.push(this.currPos);
+        ip++;
+        break;
+
+      case op.PUSH_UNDEFINED:     // PUSH_UNDEFINED
+        this.push({ type: TypeTag.UNDEFINED });
+        ip++;
+        break;
+
+      case op.PUSH_NULL:          // PUSH_NULL
+        this.push({ type: TypeTag.NULL });
+        ip++;
+        break;
+
+      case op.PUSH_FAILED:        // PUSH_FAILED
+        this.push({ type: TypeTag.FAILED });
+        ip++;
+        break;
+
+      case op.PUSH_EMPTY_ARRAY:   // PUSH_EMPTY_ARRAY
+        this.push({ type: TypeTag.ARRAY, value: [] });
+        ip++;
+        break;
+
+      case op.POP:                // POP
+        this.discard(1);
+        ip++;
+        break;
+
+      case op.POP_CURR_POS:       // POP_CURR_POS
+        this.setCurrPos(this.pop());
+        ip++;
+        break;
+
+      case op.POP_N:              // POP_N n
+        this.popn(bc[ip + 1]);
+        ip += 2;
+        break;
+
+      case op.NIP: {              // NIP
+        const value = this.pop();
+        this.discard(1);
+        this.push(value);
+        ip++;
+        break;
+      }
+
+      case op.APPEND: {           // APPEND
+        this.pop();
+        const top = this.top();
+        if (top.type !== TypeTag.ARRAY) {
+          throw new Error(
+            `Rule '${this.ruleName}': Attempting to append to a non-array.`
+          );
+        }
+        ip++;
+        break;
+      }
+
+      case op.WRAP:                // WRAP n
+        this.push({ type: TypeTag.ARRAY, value: this.popn(bc[ip + 1]) });
+        ip += 2;
+        break;
+
+      case op.TEXT: {             // TEXT
+        const offset = this.pop();
+        if (offset.type !== TypeTag.OFFSET) {
+          throw new Error(
+            `Rule '${this.ruleName}': TEXT bytecode got an incorrect type: ${offset.type}.`
+          );
+        }
+        this.push({ type: TypeTag.STRING });
+        ip++;
+        break;
+      }
+
+      case op.PLUCK: {            // PLUCK n, k, p1, ..., pK
+        const baseLength = 3;
+        const paramsLength = bc[ip + baseLength - 1];
+        const n = baseLength + paramsLength;
+        const indices = bc.slice(ip + baseLength, ip + n);
+        const result = paramsLength === 1
+          ? this.inspect(indices[0])
+          : {
+              type: TypeTag.ARRAY,
+              value: indices.map(p => this.inspect(p)),
+            };
+
+        this.popn(bc[ip + 1]);
+        this.push(result);
+        ip += n;
+        break;
+      }
+
+      case op.IF:                 // IF t, f
+        return this.interpCondition(bc, ip, 0, (top, forThen) => {
+          if (forThen) {
+            const type = {
+              type: top.type & ~(TypeTag.UNDEFINED | TypeTag.NULL),
+            };
+            return [InterpState.mustBeTrue(top), type];
+          } else {
+            const type = { type: top.type & ~(TypeTag.FAILED | TypeTag.ARRAY) };
+            return [InterpState.mustBeFalse(top), type];
+          }
+        });
+
+      case op.IF_ERROR:           // IF_ERROR t, f
+        return this.interpCondition(bc, ip, 0, (top, forThen) => {
+          if (forThen) {
+            return [top.type === TypeTag.FAILED, { type: TypeTag.FAILED }];
+          } else {
+            const type = { type: top.type & ~TypeTag.FAILED };
+            return [!InterpState.couldBe(top, TypeTag.FAILED), type];
+          }
+        });
+
+      case op.IF_NOT_ERROR:       // IF_NOT_ERROR t, f
+        return this.interpCondition(bc, ip, 0, (top, forThen) => {
+          if (!forThen) {
+            return [top.type === TypeTag.FAILED, { type: TypeTag.FAILED }];
+          } else {
+            const type = { type: top.type & ~TypeTag.FAILED };
+            return [!InterpState.couldBe(top, TypeTag.FAILED), type];
+          }
+        });
+
+      case op.IF_LT:              // IF_LT min, t, f
+        return this.interpCondition(bc, ip, 1, null);
+
+      case op.IF_GE:              // IF_GE max, t, f
+        return this.interpCondition(bc, ip, 1, null);
+
+      case op.IF_LT_DYNAMIC:      // IF_LT_DYNAMIC min, t, f
+        return this.interpCondition(bc, ip, 1, null);
+
+      case op.IF_GE_DYNAMIC:      // IF_GE_DYNAMIC max, t, f
+        return this.interpCondition(bc, ip, 1, null);
+
+      case op.WHILE_NOT_ERROR:    // WHILE_NOT_ERROR b
+        return this.interpLoop(bc, ip);
+
+      case op.MATCH_ANY:          // MATCH_ANY a, f, ...
+        return this.interpCondition(bc, ip, 0, null);
+
+      case op.MATCH_STRING:       // MATCH_STRING s, a, f, ...
+        return this.interpCondition(bc, ip, 1, null);
+
+      case op.MATCH_STRING_IC:    // MATCH_STRING_IC s, a, f, ...
+        return this.interpCondition(bc, ip, 1, null);
+
+      case op.MATCH_CHAR_CLASS:   // MATCH_CHAR_CLASS c, a, f, ...
+        return this.interpCondition(bc, ip, 1, null);
+
+      case op.ACCEPT_N:           // ACCEPT_N n
+        this.push({ type: TypeTag.STRING });
+        this.currPos = { type: TypeTag.OFFSET, value: {} };
+        ip += 2;
+        break;
+
+      case op.ACCEPT_STRING:      // ACCEPT_STRING s
+        this.push({ type: TypeTag.STRING });
+        this.currPos = { type: TypeTag.OFFSET, value: {} };
+        ip += 2;
+        break;
+
+      case op.FAIL:               // FAIL e
+        this.push({ type: TypeTag.FAILED });
+        ip += 2;
+        break;
+
+      case op.LOAD_SAVED_POS:     // LOAD_SAVED_POS p
+        this.inspect(bc[ip + 1]);
+        ip += 2;
+        break;
+
+      case op.UPDATE_SAVED_POS:   // UPDATE_SAVED_POS
+        ip++;
+        break;
+
+      case op.CALL: {              // CALL f, n, pc, p1, p2, ..., pN
+        this.push(this.interpCall(bc, ip, 4));
+        this.currPos = { type: TypeTag.OFFSET, value: {} };
+        ip += 4 + bc[ip + 3];
+        break;
+      }
+
+      case op.RULE:               // RULE r
+        this.push({ type: TypeTag.ANY });
+        this.currPos = { type: TypeTag.OFFSET, value: {} };
+        ip += 2;
+        break;
+
+      case op.SILENT_FAILS_ON:    // SILENT_FAILS_ON
+        this.silentFails++;
+        ip++;
+        break;
+
+      case op.SILENT_FAILS_OFF:   // SILENT_FAILS_OFF
+        this.silentFails--;
+        ip++;
+        break;
+
+      case op.SOURCE_MAP_PUSH:
+        ip += 2;
+        break;
+
+      case op.SOURCE_MAP_POP: {
+        ip++;
+        break;
+      }
+
+      case op.SOURCE_MAP_LABEL_PUSH:
+        ip += 4;
+        break;
+
+      case op.SOURCE_MAP_LABEL_POP:
+        ip += 2;
+        break;
+
+      // istanbul ignore next Because we never generate invalid bytecode we cannot reach this branch
+      default:
+        throw new Error(`${this.ruleName}: Invalid opcode: ${bc[ip]}.`);
+    }
+    return { ip };
+  }
+
+  /**
+   * Interpret a conditional expression.
+   *
+   * The check callback should be passed if the condition depends
+   * on the value on the top of the stack. It is called once for
+   * the then clause (with forThen === true), and once for the else
+   * clause (with forThen === false). It returns a tuple indicating
+   * whether the specified clause can be statically determined to
+   * execute, and what we know about the type of the top element on
+   * the stack if it does execute (eg in the then clause of an IF_FAILED
+   * we know that the top of stack is the "failed" token).
+   *
+   * @param {number[]} bc
+   * @param {number} ip
+   * @param {number} argCount
+   * @param {InterpCondCallback | null} check
+   *
+   * @returns {InterpResult}
+   */
+  interpCondition(bc, ip, argCount, check) {
+    const baseLength = argCount + 3;
+    const thenLength = bc[ip + baseLength - 2];
+    const elseLength = bc[ip + baseLength - 1];
+
+    const thenState = this.clone();
+    const [thenOnly, thenType] = check
+      ? check(thenState.top(), true)
+      : [false, null];
+    const [elseOnly, elseType] = check
+      ? check(this.top(), false)
+      : [false, null];
+    const length = baseLength + thenLength + elseLength;
+    const thenSlice = bc.slice(ip + baseLength, ip + baseLength + thenLength);
+    const elseSlice = bc.slice(ip + baseLength + thenLength, ip + length);
+    if (thenOnly || elseOnly) {
+      if (thenOnly && elseOnly) {
+        throw new Error(
+          `Rule '${
+            this.ruleName
+          }': Conditional cannot be both always true and always false.`
+        );
+      }
+      const slice = thenOnly ? thenSlice : elseSlice;
+      return {
+        ip: ip + length,
+        bytecodeMods: {
+          startOffset: ip,
+          length,
+          replacements: this.run(slice) || slice,
+        },
+      };
+    }
+    if (thenType) {
+      thenState.pop();
+      thenState.push(thenType);
+    }
+    if (elseType) {
+      this.pop();
+      this.push(elseType);
+    }
+    const thenResult = thenState.run(thenSlice);
+    const elseResult = this.run(elseSlice);
+    const elseState = this.clone();
+    if (!elseLength) {
+      if (thenState.stack.length > this.stack.length) {
+        thenState.stack.splice(this.stack.length);
+      }
+    }
+    let bytecodeMods = null;
+    if (thenResult || elseResult) {
+      const rep = bc.slice(ip, ip + baseLength);
+      bytecodeMods = {
+        startOffset: ip,
+        length: elseResult ? length : length - elseLength,
+        replacements: rep,
+      };
+      if (thenResult) {
+        rep.push(...thenResult);
+        rep[baseLength - 2] = thenResult.length;
+      } else {
+        rep.push(...thenSlice);
+      }
+      if (elseResult) {
+        rep.push(...elseResult);
+        rep[baseLength - 1] = elseResult.length;
+      }
+    }
+    ip += length;
+    this.merge(thenState);
+    return { ip, thenState, elseState, bytecodeMods };
+  }
+
+  /**
+   *
+   * @param {number[]} bc
+   * @param {number} ip
+   * @returns {InterpResult}
+   */
+  interpLoop(bc, ip) {
+    const baseLength = 2;
+    const bodyLength = bc[ip + baseLength - 1];
+
+    if (InterpState.mustBe(this.top(), TypeTag.FAILED)) {
+      return {
+        ip: ip + baseLength + bodyLength,
+        bytecodeMods: {
+          startOffset: ip,
+          length: bodyLength + baseLength,
+          replacements: [],
+        },
+      };
+    }
+
+    this.looping++;
+    const state = this.clone();
+    const slice = bc.slice(
+      ip + baseLength, ip + baseLength + bodyLength
+    );
+    for (;;) {
+      this.run(slice);
+      this.merge(state);
+      if (this.equal(state)) {
+        break;
+      }
+      state.copy(this);
+    }
+    this.looping--;
+    const bodyResult = this.run(slice);
+    let bytecodeMods = null;
+    if (bodyResult) {
+      bytecodeMods = {
+        startOffset: ip,
+        length: baseLength + bodyLength,
+        replacements: [bc[ip], bodyResult.length].concat(bodyResult),
+      };
+    }
+    ip += baseLength + bodyLength;
+    return { ip, bytecodeMods };
+  }
+
+  /**
+   *
+   * @param {number[]} bc
+   * @param {number} ip
+   * @param {number} baseLength
+   * @returns {InterpType}
+   */
+  interpCall(bc, ip, baseLength) {
+    const paramsLength = bc[ip + baseLength - 1];
+    bc.slice(ip + baseLength, ip + baseLength + paramsLength).map(
+      p => this.inspect(p)
+    );
+    this.discard(bc[ip + baseLength - 2]);
+    return { type: TypeTag.ANY };
+  }
+
+  /**
+   *
+   * @param {number[]}  bc
+   * @returns {number[] | null};
+   */
+  run(bc) {
+    let ip = 0;
+    const original = bc;
+    if (!this.looping && this.preRun) {
+      this.preRun(bc);
+    }
+    /** @param {InterpResult} result */
+    const applyMods = result => {
+      if (result.bytecodeMods && !this.looping) {
+        if (bc === original) {
+          bc = bc.slice();
+        }
+        bc.splice(
+          result.bytecodeMods.startOffset,
+          result.bytecodeMods.length,
+          ...result.bytecodeMods.replacements
+        );
+        if (result.ip >= result.bytecodeMods.startOffset
+            + result.bytecodeMods.length) {
+          result.ip += result.bytecodeMods.replacements.length
+            - result.bytecodeMods.length;
+        }
+        delete result.bytecodeMods;
+      }
+    };
+    while (ip < bc.length) {
+      let result = this.preInterp && !this.looping && this.preInterp(bc, ip);
+      if (!result) {
+        result = this.interp(bc, ip);
+        if (!this.looping && this.postInterp) {
+          applyMods(result);
+          result = this.postInterp(bc, ip, result);
+        }
+      }
+      applyMods(result);
+      ip = result.ip;
+    }
+    if (!this.looping && this.postRun) {
+      this.postRun(bc);
+    }
+    return bc !== original ? bc : null;
+  }
+
+  /**
+   *
+   * @param {number[]} bc
+   * @param {string} name
+   */
+  static print(bc, name) {
+    let indent = -2;
+    /** @type {string[]} */
+    const parts = [];
+    const map = Object.create(null);
+    Object.entries(op).forEach(([key, value]) => {
+      if (!/^(PUSH|MATCH_REGEXP)$/.test(key)) {
+        map[value] = key;
+      }
+    });
+    const state = new InterpState(name);
+    state.preRun = function() {
+      indent += 2;
+    };
+    state.postRun = function() {
+      if (indent > 0) {
+        parts.push(`${" ".repeat(indent)} --`);
+      }
+      indent -= 2;
+    };
+    state.preInterp = function(bc, ip) {
+      const name = map[bc[ip]];
+      const i = parts.push(`${" ".repeat(indent)} ${name} stack: ${this.stack.length}`);
+      const result = this.interp(bc, ip);
+      if (i === parts.length) {
+        parts[i - 1] += ` => ${this.stack.length}`;
+      }
+      delete result.bytecodeMods;
+      return result;
+    };
+    state.run(bc);
+    return parts.join("\n");
+  }
+}
+
+module.exports = {
+  TypeTag,
+  InterpState,
+};

--- a/lib/compiler/interp-state.js
+++ b/lib/compiler/interp-state.js
@@ -308,6 +308,37 @@ class InterpState {
     return [thenCode, elseCode, baseLength + thenLength + elseLength];
   }
 
+  /**
+   *
+   * @param {number[]} bc
+   * @param {number} ip
+   * @returns {boolean}
+   */
+  static killsCurrPos(bc, ip) {
+    for (;;) {
+      switch (bc[ip]) {
+        case op.POP_CURR_POS:
+          return true;
+        case op.POP:
+        case op.PUSH_NULL:
+        case op.PUSH_FAILED:
+        case op.PUSH_UNDEFINED:
+        case op.PUSH_EMPTY_STRING:
+        case op.PUSH_EMPTY_ARRAY:
+        case op.SILENT_FAILS_ON:
+        case op.SILENT_FAILS_OFF:
+          ip++;
+          break;
+        case op.FAIL:
+        case op.POP_N:
+          ip += 2;
+          break;
+        default:
+          return false;
+      }
+    }
+  }
+
   /** @param {InterpType} value */
   push(value) {
     this.stack.push(value);

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -320,6 +320,10 @@ function generateJS(ast, options) {
       const parts = [];
       let value = undefined;
 
+      function isDiscard(opcode) {
+        return opcode === op.POP || opcode === op.POP_N;
+      }
+
       function compileCondition(cond, argCount) {
         const baseLength = argCount + 3;
         const thenLength = bc[ip + baseLength - 2];
@@ -534,12 +538,15 @@ function generateJS(ast, options) {
             );
             break;
 
-          case op.ACCEPT_N:           // ACCEPT_N n
-            parts.push(stack.push(
+          case op.ACCEPT_N: {         // ACCEPT_N n
+            const result = stack.push(
               bc[ip + 1] > 1
                 ? "input.substr(peg$currPos, " + bc[ip + 1] + ")"
                 : "input.charAt(peg$currPos)"
-            ));
+            );
+            if (!isDiscard(bc[ip + 2])) {
+              parts.push(result);
+            }
             parts.push(
               bc[ip + 1] > 1
                 ? "peg$currPos += " + bc[ip + 1] + ";"
@@ -547,6 +554,7 @@ function generateJS(ast, options) {
             );
             ip += 2;
             break;
+          }
 
           case op.ACCEPT_STRING:      // ACCEPT_STRING s
             parts.push(stack.push(l(bc[ip + 1])));
@@ -558,11 +566,15 @@ function generateJS(ast, options) {
             ip += 2;
             break;
 
-          case op.FAIL:               // FAIL e
-            parts.push(stack.push("peg$FAILED"));
+          case op.FAIL: {             // FAIL e
+            const result = stack.push("peg$FAILED");
+            if (!isDiscard(bc[ip + 2])) {
+              parts.push(result);
+            }
             parts.push("if (peg$silentFails === 0) { peg$fail(" + e(bc[ip + 1]) + "); }");
             ip += 2;
             break;
+          }
 
           case op.LOAD_SAVED_POS:     // LOAD_SAVED_POS p
             parts.push("peg$savedPos = " + stack.index(bc[ip + 1]) + ";");
@@ -625,7 +637,7 @@ function generateJS(ast, options) {
 
           // istanbul ignore next Because we never generate invalid bytecode we cannot reach this branch
           default:
-            throw new Error("Invalid opcode: " + bc[ip] + ".", { rule: rule.name, bytecode: bc });
+            throw new Error(`Processing '${rule.name}': Invalid opcode: ${bc[ip]}.`, { rule: rule.name, bytecode: bc });
         }
       }
 

--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -3,6 +3,7 @@
 const asts = require("../asts");
 const op = require("../opcodes");
 const Stack = require("../stack");
+const { InterpState } = require("../interp-state");
 const VERSION = require("../../version");
 const { stringEscape, regexpClassEscape } = require("../utils");
 const { SourceNode } = require("source-map-generator");
@@ -547,24 +548,32 @@ function generateJS(ast, options) {
             if (!isDiscard(bc[ip + 2])) {
               parts.push(result);
             }
-            parts.push(
-              bc[ip + 1] > 1
-                ? "peg$currPos += " + bc[ip + 1] + ";"
-                : "peg$currPos++;"
-            );
+            if (!InterpState.killsCurrPos(bc, ip + 2)) {
+              parts.push(
+                bc[ip + 1] > 1
+                  ? "peg$currPos += " + bc[ip + 1] + ";"
+                  : "peg$currPos++;"
+              );
+            }
             ip += 2;
             break;
           }
 
-          case op.ACCEPT_STRING:      // ACCEPT_STRING s
-            parts.push(stack.push(l(bc[ip + 1])));
-            parts.push(
-              ast.literals[bc[ip + 1]].length > 1
-                ? "peg$currPos += " + ast.literals[bc[ip + 1]].length + ";"
-                : "peg$currPos++;"
-            );
+          case op.ACCEPT_STRING: {    // ACCEPT_STRING s
+            const result = stack.push(l(bc[ip + 1]));
+            if (!isDiscard(bc[ip + 2])) {
+              parts.push(result);
+            }
+            if (!InterpState.killsCurrPos(bc, ip + 2)) {
+              parts.push(
+                ast.literals[bc[ip + 1]].length > 1
+                  ? "peg$currPos += " + ast.literals[bc[ip + 1]].length + ";"
+                  : "peg$currPos++;"
+              );
+            }
             ip += 2;
             break;
+          }
 
           case op.FAIL: {             // FAIL e
             const result = stack.push("peg$FAILED");

--- a/lib/compiler/passes/optimize-bytecode.js
+++ b/lib/compiler/passes/optimize-bytecode.js
@@ -5,10 +5,14 @@ const op = require("../opcodes");
 const { InterpState, TypeTag } = require("../interp-state");
 
 /**
+ * @typedef {import("../../peg")} PEG
+ */
+
+/**
  * Optimizes the bytecode.
  *
- * @param {import("../../peg").ast.Grammar} ast
- * @param {import("../../peg").parser.Options} options
+ * @param {PEG.ast.Grammar} ast
+ * @param {PEG.SourceBuildOptions<PEG.SourceOutputs>} options
  */
 function optimizeBytecode(ast, options) {
   if (options.output === "source-and-map"
@@ -21,7 +25,7 @@ function optimizeBytecode(ast, options) {
 
   /**
    *
-   * @param {import("../../peg").ast.Rule} rule
+   * @param {PEG.ast.Rule} rule
    */
   function optimize(rule) {
     if (!rule.bytecode) {

--- a/lib/compiler/passes/optimize-bytecode.js
+++ b/lib/compiler/passes/optimize-bytecode.js
@@ -4,6 +4,8 @@
 const op = require("../opcodes");
 const { InterpState, TypeTag } = require("../interp-state");
 
+const logging = false;
+
 /**
  * @typedef {import("../../peg")} PEG
  * @typedef {import("../interp-state").InterpResult} InterpResult
@@ -116,6 +118,18 @@ function optimizeBytecode(ast, options) {
           }
           break;
         }
+        case op.WHILE_NOT_ERROR: {
+          // If one branch of the if/else is guaranteed to result in
+          // FAILED, we can pull the while into the other branch.
+          const thenType = result.thenState.top();
+          const elseType = result.elseState.top();
+          if (InterpState.mustBe(elseType, TypeTag.FAILED)) {
+            swap = false;
+          } else if (InterpState.mustBe(thenType, TypeTag.FAILED)) {
+            swap = true;
+          }
+          break;
+        }
         default:
           break;
       }
@@ -194,6 +208,12 @@ function optimizeBytecode(ast, options) {
       const bc = state.run(rule.bytecode);
       if (!bc) {
         break;
+      }
+      if (logging) {
+        console.log("Before >>>");
+        console.log(InterpState.print(rule.bytecode, rule.name));
+        console.log("After >>>");
+        console.log(InterpState.print(bc, rule.name));
       }
       rule.bytecode = bc;
     }

--- a/lib/compiler/passes/optimize-bytecode.js
+++ b/lib/compiler/passes/optimize-bytecode.js
@@ -72,8 +72,7 @@ function optimizeBytecode(ast, options) {
         return result;
       }
       case op.POP_CURR_POS: {
-        const next = bc[result.ip];
-        if (next === op.POP_CURR_POS) {
+        if (InterpState.killsCurrPos(bc, result.ip)) {
           result.bytecodeMods = {
             startOffset: ip,
             length: result.ip - ip,

--- a/lib/compiler/passes/optimize-bytecode.js
+++ b/lib/compiler/passes/optimize-bytecode.js
@@ -69,7 +69,17 @@ function optimizeBytecode(ast, options) {
         }
         return result;
       }
-
+      case op.POP_CURR_POS: {
+        const next = bc[result.ip];
+        if (next === op.POP_CURR_POS) {
+          result.bytecodeMods = {
+            startOffset: ip,
+            length: result.ip - ip,
+            replacements: [op.POP],
+          };
+        }
+        return result;
+      }
       default:
         break;
     }

--- a/lib/compiler/passes/optimize-bytecode.js
+++ b/lib/compiler/passes/optimize-bytecode.js
@@ -1,0 +1,106 @@
+// @ts-check
+"use strict";
+
+const op = require("../opcodes");
+const { InterpState, TypeTag } = require("../interp-state");
+
+/**
+ * Optimizes the bytecode.
+ *
+ * @param {import("../../peg").ast.Grammar} ast
+ * @param {import("../../peg").parser.Options} options
+ */
+function optimizeBytecode(ast, options) {
+  if (options.output === "source-and-map"
+      || options.output === "source-with-inline-map") {
+    // The optimizations are not very effective with source maps
+    // turned on, and any optimizations are likely to make the
+    // source mapping worse.
+    return;
+  }
+
+  /**
+   *
+   * @param {import("../../peg").ast.Rule} rule
+   */
+  function optimize(rule) {
+    if (!rule.bytecode) {
+      return;
+    }
+    const state = new InterpState(rule.name);
+    state.postInterp = function(bc, ip, result) {
+      if (result.thenState
+          && result.elseState
+          && result.ip !== undefined
+          && result.thenState.stack.length === result.elseState.stack.length) {
+        let swap = null;
+        switch (bc[result.ip]) {
+          case op.IF_ERROR:
+          case op.IF_NOT_ERROR: {
+            const thenType = result.thenState.top();
+            const elseType = result.elseState.top();
+            if (InterpState.mustBe(elseType, TypeTag.FAILED)
+                && !InterpState.couldBe(
+                  thenType, TypeTag.FAILED
+                )) {
+              swap = bc[result.ip] === op.IF_ERROR;
+            } else if (InterpState.mustBe(thenType, TypeTag.FAILED)
+                && !InterpState.couldBe(elseType, TypeTag.FAILED)) {
+              swap = bc[result.ip] === op.IF_NOT_ERROR;
+            }
+            break;
+          }
+          case op.IF: {
+            const thenType = result.thenState.top();
+            const elseType = result.elseState.top();
+            if (InterpState.mustBeTrue(thenType)
+                && InterpState.mustBeFalse(elseType)) {
+              swap = false;
+            } else if (InterpState.mustBeTrue(elseType)
+                && InterpState.mustBeFalse(thenType)) {
+              swap = true;
+            }
+            break;
+          }
+          default:
+            break;
+        }
+        if (swap !== null) {
+          const [thenCode, elseCode, length]
+            = InterpState.getConditionalCode(bc, result.ip);
+          const argCount = InterpState.getConditionalArgCount(bc[ip]);
+          const baseLength = 3 + argCount;
+          const thenLength = bc[ip + baseLength - 2];
+          const replacements = bc.slice(ip, result.ip);
+          const bytecodeMods = {
+            startOffset: ip,
+            length: result.ip - ip + length,
+            replacements,
+          };
+          let [t, e] = swap ? [elseCode, thenCode] : [thenCode, elseCode];
+          t = result.thenState.run(t) || t;
+          e = result.elseState.run(e) || e;
+          replacements.splice(baseLength + thenLength, 0, ...t);
+          replacements.push(...e);
+          replacements[baseLength - 2] += t.length;
+          replacements[baseLength - 1] += e.length;
+          result.bytecodeMods = bytecodeMods;
+          result.ip += length;
+          this.copy(result.thenState);
+          this.merge(result.elseState);
+        }
+      }
+      return result;
+    };
+    const bc = state.run(rule.bytecode);
+    if (bc) {
+      rule.bytecode = bc;
+    }
+  }
+
+  ast.rules.forEach(rule => {
+    optimize(rule);
+  });
+}
+
+module.exports = optimizeBytecode;

--- a/lib/compiler/passes/optimize-bytecode.js
+++ b/lib/compiler/passes/optimize-bytecode.js
@@ -82,6 +82,25 @@ function optimizeBytecode(ast, options) {
         }
         return result;
       }
+      case op.SILENT_FAILS_ON:
+        if (this.silentFails > 1) {
+          result.bytecodeMods = {
+            startOffset: ip,
+            length: 1,
+            replacements: [],
+          };
+        }
+        break;
+      case op.SILENT_FAILS_OFF:
+        if (this.silentFails) {
+          result.bytecodeMods = {
+            startOffset: ip,
+            length: 1,
+            replacements: [],
+          };
+        }
+        break;
+
       default:
         break;
     }

--- a/lib/compiler/passes/optimize-bytecode.js
+++ b/lib/compiler/passes/optimize-bytecode.js
@@ -6,6 +6,7 @@ const { InterpState, TypeTag } = require("../interp-state");
 
 /**
  * @typedef {import("../../peg")} PEG
+ * @typedef {import("../interp-state").InterpResult} InterpResult
  */
 
 /**
@@ -25,79 +26,132 @@ function optimizeBytecode(ast, options) {
 
   /**
    *
+   * @this {InterpState}
+   * @param {number[]} bc
+   * @param {number} ip
+   * @param {InterpResult} result
+   * @returns {InterpResult}
+   */
+  function postInterp(bc, ip, result) {
+    switch (bc[ip]) {
+      case op.FAIL:
+        if (!this.silentFails) {
+          break;
+        }
+      // Fallthrough
+      case op.PUSH_EMPTY_ARRAY:
+      case op.PUSH_EMPTY_STRING:
+      case op.PUSH_FAILED:
+      case op.PUSH_NULL:
+      case op.PUSH_UNDEFINED: {
+        const next = bc[result.ip];
+        if (next === op.POP || next === op.POP_N) {
+          const npops = next === op.POP_N ? bc[result.ip + 1] : 1;
+          const replacements = [];
+          if (npops > 1) {
+            replacements.push(
+              ...(npops > 2 ? [op.POP_N, npops - 1] : [op.POP])
+            );
+          }
+          result.ip += next === op.POP_N ? 2 : 1;
+          result.bytecodeMods = {
+            startOffset: ip,
+            length: result.ip - ip,
+            replacements,
+          };
+          this.discard(npops);
+        } else if (bc[ip] === op.FAIL) {
+          result.bytecodeMods = {
+            startOffset: ip,
+            length: result.ip - ip,
+            replacements: [op.PUSH_FAILED],
+          };
+        }
+        return result;
+      }
+
+      default:
+        break;
+    }
+    if (result.thenState
+        && result.elseState
+        && result.ip !== undefined
+        && result.thenState.stack.length === result.elseState.stack.length) {
+      let swap = null;
+      switch (bc[result.ip]) {
+        case op.IF_ERROR:
+        case op.IF_NOT_ERROR: {
+          const thenType = result.thenState.top();
+          const elseType = result.elseState.top();
+          if (InterpState.mustBe(elseType, TypeTag.FAILED)
+              && !InterpState.couldBe(
+                thenType, TypeTag.FAILED
+              )) {
+            swap = bc[result.ip] === op.IF_ERROR;
+          } else if (InterpState.mustBe(thenType, TypeTag.FAILED)
+              && !InterpState.couldBe(elseType, TypeTag.FAILED)) {
+            swap = bc[result.ip] === op.IF_NOT_ERROR;
+          }
+          break;
+        }
+        case op.IF: {
+          const thenType = result.thenState.top();
+          const elseType = result.elseState.top();
+          if (InterpState.mustBeTrue(thenType)
+              && InterpState.mustBeFalse(elseType)) {
+            swap = false;
+          } else if (InterpState.mustBeTrue(elseType)
+              && InterpState.mustBeFalse(thenType)) {
+            swap = true;
+          }
+          break;
+        }
+        default:
+          break;
+      }
+      if (swap !== null) {
+        const [thenCode, elseCode, length]
+          = InterpState.getConditionalCode(bc, result.ip);
+        const argCount = InterpState.getConditionalArgCount(bc[ip]);
+        const baseLength = 3 + argCount;
+        const thenLength = bc[ip + baseLength - 2];
+        const replacements = bc.slice(ip, result.ip);
+        const bytecodeMods = {
+          startOffset: ip,
+          length: result.ip - ip + length,
+          replacements,
+        };
+        let [t, e] = swap ? [elseCode, thenCode] : [thenCode, elseCode];
+        t = result.thenState.run(t) || t;
+        e = result.elseState.run(e) || e;
+        replacements.splice(baseLength + thenLength, 0, ...t);
+        replacements.push(...e);
+        replacements[baseLength - 2] += t.length;
+        replacements[baseLength - 1] += e.length;
+        result.bytecodeMods = bytecodeMods;
+        result.ip += length;
+        this.copy(result.thenState);
+        this.merge(result.elseState);
+      }
+    }
+    return result;
+  }
+
+  /**
+   *
    * @param {PEG.ast.Rule} rule
    */
   function optimize(rule) {
     if (!rule.bytecode) {
       return;
     }
-    const state = new InterpState(rule.name);
-    state.postInterp = function(bc, ip, result) {
-      if (result.thenState
-          && result.elseState
-          && result.ip !== undefined
-          && result.thenState.stack.length === result.elseState.stack.length) {
-        let swap = null;
-        switch (bc[result.ip]) {
-          case op.IF_ERROR:
-          case op.IF_NOT_ERROR: {
-            const thenType = result.thenState.top();
-            const elseType = result.elseState.top();
-            if (InterpState.mustBe(elseType, TypeTag.FAILED)
-                && !InterpState.couldBe(
-                  thenType, TypeTag.FAILED
-                )) {
-              swap = bc[result.ip] === op.IF_ERROR;
-            } else if (InterpState.mustBe(thenType, TypeTag.FAILED)
-                && !InterpState.couldBe(elseType, TypeTag.FAILED)) {
-              swap = bc[result.ip] === op.IF_NOT_ERROR;
-            }
-            break;
-          }
-          case op.IF: {
-            const thenType = result.thenState.top();
-            const elseType = result.elseState.top();
-            if (InterpState.mustBeTrue(thenType)
-                && InterpState.mustBeFalse(elseType)) {
-              swap = false;
-            } else if (InterpState.mustBeTrue(elseType)
-                && InterpState.mustBeFalse(thenType)) {
-              swap = true;
-            }
-            break;
-          }
-          default:
-            break;
-        }
-        if (swap !== null) {
-          const [thenCode, elseCode, length]
-            = InterpState.getConditionalCode(bc, result.ip);
-          const argCount = InterpState.getConditionalArgCount(bc[ip]);
-          const baseLength = 3 + argCount;
-          const thenLength = bc[ip + baseLength - 2];
-          const replacements = bc.slice(ip, result.ip);
-          const bytecodeMods = {
-            startOffset: ip,
-            length: result.ip - ip + length,
-            replacements,
-          };
-          let [t, e] = swap ? [elseCode, thenCode] : [thenCode, elseCode];
-          t = result.thenState.run(t) || t;
-          e = result.elseState.run(e) || e;
-          replacements.splice(baseLength + thenLength, 0, ...t);
-          replacements.push(...e);
-          replacements[baseLength - 2] += t.length;
-          replacements[baseLength - 1] += e.length;
-          result.bytecodeMods = bytecodeMods;
-          result.ip += length;
-          this.copy(result.thenState);
-          this.merge(result.elseState);
-        }
+    for (;;) {
+      const state = new InterpState(rule.name);
+      state.postInterp = postInterp;
+      const bc = state.run(rule.bytecode);
+      if (!bc) {
+        break;
       }
-      return result;
-    };
-    const bc = state.run(rule.bytecode);
-    if (bc) {
       rule.bytecode = bc;
     }
   }

--- a/lib/compiler/passes/optimize-bytecode.js
+++ b/lib/compiler/passes/optimize-bytecode.js
@@ -149,6 +149,38 @@ function optimizeBytecode(ast, options) {
 
   /**
    *
+   * @this {InterpState}
+   * @param {number[]} bc
+   * @param {number} ip
+   * @returns {InterpResult | null}
+   */
+  function preInterp(bc, ip) {
+    switch (bc[ip]) {
+      case op.POP_CURR_POS: {
+        const top = this.top();
+        if (top.type === TypeTag.OFFSET
+            && top.value
+            && top.value === this.currPos.value) {
+          this.pop();
+          return {
+            ip: ip + 1,
+            bytecodeMods: {
+              startOffset: ip,
+              length: 1,
+              replacements: [op.POP],
+            },
+          };
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    return null;
+  }
+
+  /**
+   *
    * @param {PEG.ast.Rule} rule
    */
   function optimize(rule) {
@@ -158,6 +190,7 @@ function optimizeBytecode(ast, options) {
     for (;;) {
       const state = new InterpState(rule.name);
       state.postInterp = postInterp;
+      state.preInterp = preInterp;
       const bc = state.run(rule.bytecode);
       if (!bc) {
         break;

--- a/lib/compiler/passes/optimize-bytecode.js
+++ b/lib/compiler/passes/optimize-bytecode.js
@@ -4,12 +4,226 @@
 const op = require("../opcodes");
 const { InterpState, TypeTag } = require("../interp-state");
 
+/** @type {boolean|string} */
 const logging = false;
 
 /**
  * @typedef {import("../../peg")} PEG
  * @typedef {import("../interp-state").InterpResult} InterpResult
  */
+
+/**
+ *
+ * @this {InterpState}
+ * @param {number[]} bc
+ * @param {number} ip
+ * @param {InterpResult} result
+ * @returns {InterpResult}
+ */
+function postInterp(bc, ip, result) {
+  switch (bc[ip]) {
+    case op.FAIL:
+      if (!this.silentFails) {
+        break;
+      }
+    // Fallthrough
+    case op.PUSH_EMPTY_ARRAY:
+    case op.PUSH_EMPTY_STRING:
+    case op.PUSH_FAILED:
+    case op.PUSH_NULL:
+    case op.PUSH_UNDEFINED: {
+      const next = bc[result.ip];
+      if (next === op.POP || next === op.POP_N) {
+        const npops = next === op.POP_N ? bc[result.ip + 1] : 1;
+        const replacements = [];
+        if (npops > 1) {
+          replacements.push(
+            ...(npops > 2 ? [op.POP_N, npops - 1] : [op.POP])
+          );
+        }
+        result.ip += next === op.POP_N ? 2 : 1;
+        result.bytecodeMods = {
+          startOffset: ip,
+          length: result.ip - ip,
+          replacements,
+        };
+        this.discard(npops);
+      } else if (bc[ip] === op.FAIL) {
+        result.bytecodeMods = {
+          startOffset: ip,
+          length: result.ip - ip,
+          replacements: [op.PUSH_FAILED],
+        };
+      }
+      return result;
+    }
+    case op.POP_CURR_POS: {
+      if (InterpState.killsCurrPos(bc, result.ip)) {
+        result.bytecodeMods = {
+          startOffset: ip,
+          length: result.ip - ip,
+          replacements: [op.POP],
+        };
+      }
+      return result;
+    }
+    case op.SILENT_FAILS_ON:
+      if (this.silentFails > 1) {
+        result.bytecodeMods = {
+          startOffset: ip,
+          length: 1,
+          replacements: [],
+        };
+      }
+      break;
+    case op.SILENT_FAILS_OFF:
+      if (this.silentFails) {
+        result.bytecodeMods = {
+          startOffset: ip,
+          length: 1,
+          replacements: [],
+        };
+      }
+      break;
+
+    default:
+      break;
+  }
+  if (result.thenState
+        && result.elseState
+        && result.ip !== undefined
+        && result.thenState.stack.length === result.elseState.stack.length) {
+    let swap = null;
+    switch (bc[result.ip]) {
+      case op.IF_ERROR:
+      case op.IF_NOT_ERROR: {
+        const thenType = result.thenState.top();
+        const elseType = result.elseState.top();
+        if (InterpState.mustBe(elseType, TypeTag.FAILED)
+              && !InterpState.couldBe(
+                thenType, TypeTag.FAILED
+              )) {
+          swap = bc[result.ip] === op.IF_ERROR;
+        } else if (InterpState.mustBe(thenType, TypeTag.FAILED)
+              && !InterpState.couldBe(elseType, TypeTag.FAILED)) {
+          swap = bc[result.ip] === op.IF_NOT_ERROR;
+        }
+        break;
+      }
+      case op.IF: {
+        const thenType = result.thenState.top();
+        const elseType = result.elseState.top();
+        if (InterpState.mustBeTrue(thenType)
+              && InterpState.mustBeFalse(elseType)) {
+          swap = false;
+        } else if (InterpState.mustBeTrue(elseType)
+              && InterpState.mustBeFalse(thenType)) {
+          swap = true;
+        }
+        break;
+      }
+      case op.WHILE_NOT_ERROR: {
+        // If one branch of the if/else is guaranteed to result in
+        // FAILED, we can pull the while into the other branch.
+        const thenType = result.thenState.top();
+        const elseType = result.elseState.top();
+        if (InterpState.mustBe(elseType, TypeTag.FAILED)) {
+          swap = false;
+        } else if (InterpState.mustBe(thenType, TypeTag.FAILED)) {
+          swap = true;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    if (swap !== null) {
+      const [thenCode, elseCode, length]
+          = InterpState.getConditionalCode(bc, result.ip);
+      const argCount = InterpState.getConditionalArgCount(bc[ip]);
+      const baseLength = 3 + argCount;
+      const thenLength = bc[ip + baseLength - 2];
+      const replacements = bc.slice(ip, result.ip);
+      const bytecodeMods = {
+        startOffset: ip,
+        length: result.ip - ip + length,
+        replacements,
+      };
+      let [t, e] = swap ? [elseCode, thenCode] : [thenCode, elseCode];
+      t = result.thenState.run(t) || t;
+      e = result.elseState.run(e) || e;
+      replacements.splice(baseLength + thenLength, 0, ...t);
+      replacements.push(...e);
+      replacements[baseLength - 2] += t.length;
+      replacements[baseLength - 1] += e.length;
+      result.bytecodeMods = bytecodeMods;
+      result.ip += length;
+      this.copy(result.thenState);
+      this.merge(result.elseState);
+    }
+  }
+  return result;
+}
+
+/**
+ *
+ * @this {InterpState}
+ * @param {number[]} bc
+ * @param {number} ip
+ * @returns {InterpResult | null}
+ */
+function preInterp(bc, ip) {
+  switch (bc[ip]) {
+    case op.POP_CURR_POS: {
+      const top = this.top();
+      if (top.type === TypeTag.OFFSET
+            && top.value
+            && top.value === this.currPos.value) {
+        this.pop();
+        return {
+          ip: ip + 1,
+          bytecodeMods: {
+            startOffset: ip,
+            length: 1,
+            replacements: [op.POP],
+          },
+        };
+      }
+      break;
+    }
+    default:
+      break;
+  }
+  return null;
+}
+
+/**
+ *
+ * @param {number[]} bytecode - The bytecode to optimize
+ * @param {string}   name - Name for error reporting purposes
+ * @param {boolean}  [log] - Whether to report changes to the bytecode
+ * @returns {number[]}
+ */
+function optimizeBlock(bytecode, name, log) {
+  const dolog = log || logging;
+  for (;;) {
+    const state = new InterpState(name);
+    state.postInterp = postInterp;
+    state.preInterp = preInterp;
+    const bc = state.run(bytecode);
+    if (!bc) {
+      break;
+    }
+    if (dolog === true || dolog === name) {
+      console.log("Before >>>");
+      console.log(InterpState.print(bytecode, name));
+      console.log("After >>>");
+      console.log(InterpState.print(bc, name));
+    }
+    bytecode = bc;
+  }
+  return bytecode;
+}
 
 /**
  * Optimizes the bytecode.
@@ -26,220 +240,14 @@ function optimizeBytecode(ast, options) {
     return;
   }
 
-  /**
-   *
-   * @this {InterpState}
-   * @param {number[]} bc
-   * @param {number} ip
-   * @param {InterpResult} result
-   * @returns {InterpResult}
-   */
-  function postInterp(bc, ip, result) {
-    switch (bc[ip]) {
-      case op.FAIL:
-        if (!this.silentFails) {
-          break;
-        }
-      // Fallthrough
-      case op.PUSH_EMPTY_ARRAY:
-      case op.PUSH_EMPTY_STRING:
-      case op.PUSH_FAILED:
-      case op.PUSH_NULL:
-      case op.PUSH_UNDEFINED: {
-        const next = bc[result.ip];
-        if (next === op.POP || next === op.POP_N) {
-          const npops = next === op.POP_N ? bc[result.ip + 1] : 1;
-          const replacements = [];
-          if (npops > 1) {
-            replacements.push(
-              ...(npops > 2 ? [op.POP_N, npops - 1] : [op.POP])
-            );
-          }
-          result.ip += next === op.POP_N ? 2 : 1;
-          result.bytecodeMods = {
-            startOffset: ip,
-            length: result.ip - ip,
-            replacements,
-          };
-          this.discard(npops);
-        } else if (bc[ip] === op.FAIL) {
-          result.bytecodeMods = {
-            startOffset: ip,
-            length: result.ip - ip,
-            replacements: [op.PUSH_FAILED],
-          };
-        }
-        return result;
-      }
-      case op.POP_CURR_POS: {
-        if (InterpState.killsCurrPos(bc, result.ip)) {
-          result.bytecodeMods = {
-            startOffset: ip,
-            length: result.ip - ip,
-            replacements: [op.POP],
-          };
-        }
-        return result;
-      }
-      case op.SILENT_FAILS_ON:
-        if (this.silentFails > 1) {
-          result.bytecodeMods = {
-            startOffset: ip,
-            length: 1,
-            replacements: [],
-          };
-        }
-        break;
-      case op.SILENT_FAILS_OFF:
-        if (this.silentFails) {
-          result.bytecodeMods = {
-            startOffset: ip,
-            length: 1,
-            replacements: [],
-          };
-        }
-        break;
-
-      default:
-        break;
-    }
-    if (result.thenState
-        && result.elseState
-        && result.ip !== undefined
-        && result.thenState.stack.length === result.elseState.stack.length) {
-      let swap = null;
-      switch (bc[result.ip]) {
-        case op.IF_ERROR:
-        case op.IF_NOT_ERROR: {
-          const thenType = result.thenState.top();
-          const elseType = result.elseState.top();
-          if (InterpState.mustBe(elseType, TypeTag.FAILED)
-              && !InterpState.couldBe(
-                thenType, TypeTag.FAILED
-              )) {
-            swap = bc[result.ip] === op.IF_ERROR;
-          } else if (InterpState.mustBe(thenType, TypeTag.FAILED)
-              && !InterpState.couldBe(elseType, TypeTag.FAILED)) {
-            swap = bc[result.ip] === op.IF_NOT_ERROR;
-          }
-          break;
-        }
-        case op.IF: {
-          const thenType = result.thenState.top();
-          const elseType = result.elseState.top();
-          if (InterpState.mustBeTrue(thenType)
-              && InterpState.mustBeFalse(elseType)) {
-            swap = false;
-          } else if (InterpState.mustBeTrue(elseType)
-              && InterpState.mustBeFalse(thenType)) {
-            swap = true;
-          }
-          break;
-        }
-        case op.WHILE_NOT_ERROR: {
-          // If one branch of the if/else is guaranteed to result in
-          // FAILED, we can pull the while into the other branch.
-          const thenType = result.thenState.top();
-          const elseType = result.elseState.top();
-          if (InterpState.mustBe(elseType, TypeTag.FAILED)) {
-            swap = false;
-          } else if (InterpState.mustBe(thenType, TypeTag.FAILED)) {
-            swap = true;
-          }
-          break;
-        }
-        default:
-          break;
-      }
-      if (swap !== null) {
-        const [thenCode, elseCode, length]
-          = InterpState.getConditionalCode(bc, result.ip);
-        const argCount = InterpState.getConditionalArgCount(bc[ip]);
-        const baseLength = 3 + argCount;
-        const thenLength = bc[ip + baseLength - 2];
-        const replacements = bc.slice(ip, result.ip);
-        const bytecodeMods = {
-          startOffset: ip,
-          length: result.ip - ip + length,
-          replacements,
-        };
-        let [t, e] = swap ? [elseCode, thenCode] : [thenCode, elseCode];
-        t = result.thenState.run(t) || t;
-        e = result.elseState.run(e) || e;
-        replacements.splice(baseLength + thenLength, 0, ...t);
-        replacements.push(...e);
-        replacements[baseLength - 2] += t.length;
-        replacements[baseLength - 1] += e.length;
-        result.bytecodeMods = bytecodeMods;
-        result.ip += length;
-        this.copy(result.thenState);
-        this.merge(result.elseState);
-      }
-    }
-    return result;
-  }
-
-  /**
-   *
-   * @this {InterpState}
-   * @param {number[]} bc
-   * @param {number} ip
-   * @returns {InterpResult | null}
-   */
-  function preInterp(bc, ip) {
-    switch (bc[ip]) {
-      case op.POP_CURR_POS: {
-        const top = this.top();
-        if (top.type === TypeTag.OFFSET
-            && top.value
-            && top.value === this.currPos.value) {
-          this.pop();
-          return {
-            ip: ip + 1,
-            bytecodeMods: {
-              startOffset: ip,
-              length: 1,
-              replacements: [op.POP],
-            },
-          };
-        }
-        break;
-      }
-      default:
-        break;
-    }
-    return null;
-  }
-
-  /**
-   *
-   * @param {PEG.ast.Rule} rule
-   */
-  function optimize(rule) {
-    if (!rule.bytecode) {
-      return;
-    }
-    for (;;) {
-      const state = new InterpState(rule.name);
-      state.postInterp = postInterp;
-      state.preInterp = preInterp;
-      const bc = state.run(rule.bytecode);
-      if (!bc) {
-        break;
-      }
-      if (logging) {
-        console.log("Before >>>");
-        console.log(InterpState.print(rule.bytecode, rule.name));
-        console.log("After >>>");
-        console.log(InterpState.print(bc, rule.name));
-      }
-      rule.bytecode = bc;
-    }
-  }
-
   ast.rules.forEach(rule => {
-    optimize(rule);
+    if (rule.bytecode) {
+      rule.bytecode = optimizeBlock(rule.bytecode, rule.name);
+    }
   });
 }
 
-module.exports = optimizeBytecode;
+module.exports = {
+  optimizeBytecode,
+  optimizeBlock,
+};

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -770,13 +770,10 @@ function peg$parse(input, options) {
           s5 = peg$FAILED;
         }
       }
-    } else {
-      s4 = peg$FAILED;
-    }
-    if (s4 !== peg$FAILED) {
       peg$savedPos = s0;
       s0 = peg$f0(s2, s3, s4);
     } else {
+      s4 = peg$FAILED;
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -791,21 +788,11 @@ function peg$parse(input, options) {
     if (input.charCodeAt(peg$currPos) === 123) {
       s1 = peg$c0;
       peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e0); }
-    }
-    if (s1 !== peg$FAILED) {
       s2 = peg$parseCodeBlock();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 125) {
           s3 = peg$c1;
           peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e1); }
-        }
-        if (s3 !== peg$FAILED) {
           s4 = peg$parseEOS();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -815,6 +802,7 @@ function peg$parse(input, options) {
             s0 = peg$FAILED;
           }
         } else {
+          if (peg$silentFails === 0) { peg$fail(peg$e1); }
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
@@ -823,6 +811,7 @@ function peg$parse(input, options) {
         s0 = peg$FAILED;
       }
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e0); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -874,11 +863,6 @@ function peg$parse(input, options) {
       if (input.charCodeAt(peg$currPos) === 61) {
         s4 = peg$c2;
         peg$currPos++;
-      } else {
-        s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e2); }
-      }
-      if (s4 !== peg$FAILED) {
         s5 = peg$parse__();
         s6 = peg$parseChoiceExpression();
         if (s6 !== peg$FAILED) {
@@ -895,6 +879,7 @@ function peg$parse(input, options) {
           s0 = peg$FAILED;
         }
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e2); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -918,11 +903,6 @@ function peg$parse(input, options) {
       if (input.charCodeAt(peg$currPos) === 47) {
         s5 = peg$c3;
         peg$currPos++;
-      } else {
-        s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e3); }
-      }
-      if (s5 !== peg$FAILED) {
         s6 = peg$parse__();
         s7 = peg$parseActionExpression();
         if (s7 !== peg$FAILED) {
@@ -932,6 +912,7 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e3); }
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -942,11 +923,6 @@ function peg$parse(input, options) {
         if (input.charCodeAt(peg$currPos) === 47) {
           s5 = peg$c3;
           peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e3); }
-        }
-        if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
           s7 = peg$parseActionExpression();
           if (s7 !== peg$FAILED) {
@@ -956,6 +932,7 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
+          if (peg$silentFails === 0) { peg$fail(peg$e3); }
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -984,8 +961,6 @@ function peg$parse(input, options) {
       } else {
         peg$currPos = s2;
         s2 = peg$FAILED;
-      }
-      if (s2 === peg$FAILED) {
         s2 = null;
       }
       peg$savedPos = s0;
@@ -1090,13 +1065,11 @@ function peg$parse(input, options) {
     if (input.charCodeAt(peg$currPos) === 64) {
       s1 = peg$c4;
       peg$currPos++;
+      peg$savedPos = s0;
+      s1 = peg$f9();
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e4); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f9();
     }
     s0 = s1;
 
@@ -1113,14 +1086,10 @@ function peg$parse(input, options) {
       if (input.charCodeAt(peg$currPos) === 58) {
         s3 = peg$c5;
         peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e5); }
-      }
-      if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
         s0 = peg$f10(s1);
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e5); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -1165,18 +1134,12 @@ function peg$parse(input, options) {
       s0 = peg$c6;
       peg$currPos++;
     } else {
-      s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e6); }
-    }
-    if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 38) {
         s0 = peg$c7;
         peg$currPos++;
       } else {
-        s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e7); }
-      }
-      if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
           s0 = peg$c8;
           peg$currPos++;
@@ -1226,18 +1189,12 @@ function peg$parse(input, options) {
       s0 = peg$c9;
       peg$currPos++;
     } else {
-      s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e9); }
-    }
-    if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 42) {
         s0 = peg$c10;
         peg$currPos++;
       } else {
-        s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e10); }
-      }
-      if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 43) {
           s0 = peg$c11;
           peg$currPos++;
@@ -1261,11 +1218,6 @@ function peg$parse(input, options) {
       if (input.charCodeAt(peg$currPos) === 124) {
         s3 = peg$c12;
         peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e12); }
-      }
-      if (s3 !== peg$FAILED) {
         s4 = peg$parse__();
         s5 = peg$parseBoundaries();
         if (s5 !== peg$FAILED) {
@@ -1274,11 +1226,6 @@ function peg$parse(input, options) {
           if (input.charCodeAt(peg$currPos) === 44) {
             s8 = peg$c13;
             peg$currPos++;
-          } else {
-            s8 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e13); }
-          }
-          if (s8 !== peg$FAILED) {
             s9 = peg$parse__();
             s10 = peg$parseChoiceExpression();
             if (s10 !== peg$FAILED) {
@@ -1289,6 +1236,7 @@ function peg$parse(input, options) {
               s7 = peg$FAILED;
             }
           } else {
+            if (peg$silentFails === 0) { peg$fail(peg$e13); }
             peg$currPos = s7;
             s7 = peg$FAILED;
           }
@@ -1298,14 +1246,10 @@ function peg$parse(input, options) {
           if (input.charCodeAt(peg$currPos) === 124) {
             s8 = peg$c12;
             peg$currPos++;
-          } else {
-            s8 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e12); }
-          }
-          if (s8 !== peg$FAILED) {
             peg$savedPos = s0;
             s0 = peg$f13(s1, s5, s7);
           } else {
+            if (peg$silentFails === 0) { peg$fail(peg$e12); }
             peg$currPos = s0;
             s0 = peg$FAILED;
           }
@@ -1314,6 +1258,7 @@ function peg$parse(input, options) {
           s0 = peg$FAILED;
         }
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e12); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -1337,11 +1282,6 @@ function peg$parse(input, options) {
     if (input.substr(peg$currPos, 2) === peg$c14) {
       s3 = peg$c14;
       peg$currPos += 2;
-    } else {
-      s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e14); }
-    }
-    if (s3 !== peg$FAILED) {
       s4 = peg$parse__();
       s5 = peg$parseBoundary();
       if (s5 === peg$FAILED) {
@@ -1350,6 +1290,7 @@ function peg$parse(input, options) {
       peg$savedPos = s0;
       s0 = peg$f14(s1, s5);
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e14); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -1415,11 +1356,6 @@ function peg$parse(input, options) {
               if (input.charCodeAt(peg$currPos) === 40) {
                 s1 = peg$c15;
                 peg$currPos++;
-              } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e15); }
-              }
-              if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
                 s3 = peg$parseChoiceExpression();
                 if (s3 !== peg$FAILED) {
@@ -1427,14 +1363,10 @@ function peg$parse(input, options) {
                   if (input.charCodeAt(peg$currPos) === 41) {
                     s5 = peg$c16;
                     peg$currPos++;
-                  } else {
-                    s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$e16); }
-                  }
-                  if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
                     s0 = peg$f19(s3);
                   } else {
+                    if (peg$silentFails === 0) { peg$fail(peg$e16); }
                     peg$currPos = s0;
                     s0 = peg$FAILED;
                   }
@@ -1443,6 +1375,7 @@ function peg$parse(input, options) {
                   s0 = peg$FAILED;
                 }
               } else {
+                if (peg$silentFails === 0) { peg$fail(peg$e15); }
                 peg$currPos = s0;
                 s0 = peg$FAILED;
               }
@@ -1474,35 +1407,26 @@ function peg$parse(input, options) {
       } else {
         peg$currPos = s5;
         s5 = peg$FAILED;
-      }
-      if (s5 === peg$FAILED) {
         s5 = null;
       }
       if (input.charCodeAt(peg$currPos) === 61) {
         s6 = peg$c2;
         peg$currPos++;
-      } else {
-        s6 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e2); }
-      }
-      if (s6 !== peg$FAILED) {
         s4 = [s4, s5, s6];
         s3 = s4;
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e2); }
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
       peg$silentFails--;
       if (s3 === peg$FAILED) {
         s2 = undefined;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
         s0 = peg$f20(s1);
       } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -1544,10 +1468,7 @@ function peg$parse(input, options) {
       s0 = peg$c7;
       peg$currPos++;
     } else {
-      s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e7); }
-    }
-    if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 33) {
         s0 = peg$c8;
         peg$currPos++;
@@ -1582,50 +1503,32 @@ function peg$parse(input, options) {
       s0 = peg$c17;
       peg$currPos++;
     } else {
-      s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e19); }
-    }
-    if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
         s0 = peg$c18;
         peg$currPos++;
       } else {
-        s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e20); }
-      }
-      if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
           s0 = peg$c19;
           peg$currPos++;
         } else {
-          s0 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$e21); }
-        }
-        if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
             s0 = peg$c20;
             peg$currPos++;
           } else {
-            s0 = peg$FAILED;
             if (peg$silentFails === 0) { peg$fail(peg$e22); }
-          }
-          if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
               s0 = peg$c21;
               peg$currPos++;
             } else {
-              s0 = peg$FAILED;
               if (peg$silentFails === 0) { peg$fail(peg$e23); }
-            }
-            if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
                 s0 = peg$c22;
                 peg$currPos++;
               } else {
-                s0 = peg$FAILED;
                 if (peg$silentFails === 0) { peg$fail(peg$e24); }
-              }
-              if (s0 === peg$FAILED) {
                 s0 = peg$parseZs();
               }
             }
@@ -1664,34 +1567,22 @@ function peg$parse(input, options) {
       s0 = peg$c23;
       peg$currPos++;
     } else {
-      s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e27); }
-    }
-    if (s0 === peg$FAILED) {
       if (input.substr(peg$currPos, 2) === peg$c24) {
         s0 = peg$c24;
         peg$currPos += 2;
       } else {
-        s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e28); }
-      }
-      if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 13) {
           s0 = peg$c25;
           peg$currPos++;
         } else {
-          s0 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$e29); }
-        }
-        if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 8232) {
             s0 = peg$c26;
             peg$currPos++;
           } else {
-            s0 = peg$FAILED;
             if (peg$silentFails === 0) { peg$fail(peg$e30); }
-          }
-          if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 8233) {
               s0 = peg$c27;
               peg$currPos++;
@@ -1736,11 +1627,6 @@ function peg$parse(input, options) {
     if (input.substr(peg$currPos, 2) === peg$c28) {
       s1 = peg$c28;
       peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e33); }
-    }
-    if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
@@ -1755,11 +1641,6 @@ function peg$parse(input, options) {
       peg$silentFails--;
       if (s5 === peg$FAILED) {
         s4 = undefined;
-      } else {
-        peg$currPos = s4;
-        s4 = peg$FAILED;
-      }
-      if (s4 !== peg$FAILED) {
         s5 = peg$parseSourceCharacter();
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -1769,6 +1650,8 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
+        peg$currPos = s4;
+        s4 = peg$FAILED;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -1787,11 +1670,6 @@ function peg$parse(input, options) {
         peg$silentFails--;
         if (s5 === peg$FAILED) {
           s4 = undefined;
-        } else {
-          peg$currPos = s4;
-          s4 = peg$FAILED;
-        }
-        if (s4 !== peg$FAILED) {
           s5 = peg$parseSourceCharacter();
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -1801,6 +1679,8 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
+          peg$currPos = s4;
+          s4 = peg$FAILED;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -1808,18 +1688,15 @@ function peg$parse(input, options) {
       if (input.substr(peg$currPos, 2) === peg$c29) {
         s3 = peg$c29;
         peg$currPos += 2;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e34); }
-      }
-      if (s3 !== peg$FAILED) {
         s1 = [s1, s2, s3];
         s0 = s1;
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e34); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e33); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -1834,11 +1711,6 @@ function peg$parse(input, options) {
     if (input.substr(peg$currPos, 2) === peg$c28) {
       s1 = peg$c28;
       peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e33); }
-    }
-    if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
@@ -1847,20 +1719,12 @@ function peg$parse(input, options) {
         s5 = peg$c29;
         peg$currPos += 2;
       } else {
-        s5 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e34); }
-      }
-      if (s5 === peg$FAILED) {
         s5 = peg$parseLineTerminator();
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
         s4 = undefined;
-      } else {
-        peg$currPos = s4;
-        s4 = peg$FAILED;
-      }
-      if (s4 !== peg$FAILED) {
         s5 = peg$parseSourceCharacter();
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -1870,6 +1734,8 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
+        peg$currPos = s4;
+        s4 = peg$FAILED;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -1882,20 +1748,12 @@ function peg$parse(input, options) {
           s5 = peg$c29;
           peg$currPos += 2;
         } else {
-          s5 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$e34); }
-        }
-        if (s5 === peg$FAILED) {
           s5 = peg$parseLineTerminator();
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
           s4 = undefined;
-        } else {
-          peg$currPos = s4;
-          s4 = peg$FAILED;
-        }
-        if (s4 !== peg$FAILED) {
           s5 = peg$parseSourceCharacter();
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -1905,6 +1763,8 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
+          peg$currPos = s4;
+          s4 = peg$FAILED;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -1912,18 +1772,15 @@ function peg$parse(input, options) {
       if (input.substr(peg$currPos, 2) === peg$c29) {
         s3 = peg$c29;
         peg$currPos += 2;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e34); }
-      }
-      if (s3 !== peg$FAILED) {
         s1 = [s1, s2, s3];
         s0 = s1;
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e34); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e33); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -1938,11 +1795,6 @@ function peg$parse(input, options) {
     if (input.substr(peg$currPos, 2) === peg$c30) {
       s1 = peg$c30;
       peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e35); }
-    }
-    if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
@@ -1951,11 +1803,6 @@ function peg$parse(input, options) {
       peg$silentFails--;
       if (s5 === peg$FAILED) {
         s4 = undefined;
-      } else {
-        peg$currPos = s4;
-        s4 = peg$FAILED;
-      }
-      if (s4 !== peg$FAILED) {
         s5 = peg$parseSourceCharacter();
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -1965,6 +1812,8 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
+        peg$currPos = s4;
+        s4 = peg$FAILED;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -1977,11 +1826,6 @@ function peg$parse(input, options) {
         peg$silentFails--;
         if (s5 === peg$FAILED) {
           s4 = undefined;
-        } else {
-          peg$currPos = s4;
-          s4 = peg$FAILED;
-        }
-        if (s4 !== peg$FAILED) {
           s5 = peg$parseSourceCharacter();
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -1991,6 +1835,8 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
+          peg$currPos = s4;
+          s4 = peg$FAILED;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -1998,6 +1844,7 @@ function peg$parse(input, options) {
       s1 = [s1, s2];
       s0 = s1;
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e35); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -2042,19 +1889,11 @@ function peg$parse(input, options) {
         s0 = peg$c31;
         peg$currPos++;
       } else {
-        s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e37); }
-      }
-      if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
           s1 = peg$c32;
           peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e38); }
-        }
-        if (s1 !== peg$FAILED) {
           s2 = peg$parseUnicodeEscapeSequence();
           if (s2 !== peg$FAILED) {
             s0 = s2;
@@ -2063,6 +1902,7 @@ function peg$parse(input, options) {
             s0 = peg$FAILED;
           }
         } else {
+          if (peg$silentFails === 0) { peg$fail(peg$e38); }
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
@@ -2081,10 +1921,7 @@ function peg$parse(input, options) {
         s0 = peg$c6;
         peg$currPos++;
       } else {
-        s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e6); }
-      }
-      if (s0 === peg$FAILED) {
         s0 = peg$parseUnicodeCombiningMark();
         if (s0 === peg$FAILED) {
           s0 = peg$parseNd();
@@ -2095,10 +1932,7 @@ function peg$parse(input, options) {
                 s0 = peg$c33;
                 peg$currPos++;
               } else {
-                s0 = peg$FAILED;
                 if (peg$silentFails === 0) { peg$fail(peg$e39); }
-              }
-              if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 8205) {
                   s0 = peg$c34;
                   peg$currPos++;
@@ -2161,10 +1995,7 @@ function peg$parse(input, options) {
         s2 = peg$c35;
         peg$currPos++;
       } else {
-        s2 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e42); }
-      }
-      if (s2 === peg$FAILED) {
         s2 = null;
       }
       peg$savedPos = s0;
@@ -2190,11 +2021,6 @@ function peg$parse(input, options) {
     if (input.charCodeAt(peg$currPos) === 34) {
       s1 = peg$c36;
       peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e44); }
-    }
-    if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$parseDoubleStringCharacter();
       while (s3 !== peg$FAILED) {
@@ -2204,18 +2030,15 @@ function peg$parse(input, options) {
       if (input.charCodeAt(peg$currPos) === 34) {
         s3 = peg$c36;
         peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e44); }
-      }
-      if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
         s0 = peg$f24(s2);
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e44); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e44); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -2224,11 +2047,6 @@ function peg$parse(input, options) {
       if (input.charCodeAt(peg$currPos) === 39) {
         s1 = peg$c37;
         peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e45); }
-      }
-      if (s1 !== peg$FAILED) {
         s2 = [];
         s3 = peg$parseSingleStringCharacter();
         while (s3 !== peg$FAILED) {
@@ -2238,18 +2056,15 @@ function peg$parse(input, options) {
         if (input.charCodeAt(peg$currPos) === 39) {
           s3 = peg$c37;
           peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e45); }
-        }
-        if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s0 = peg$f25(s2);
         } else {
+          if (peg$silentFails === 0) { peg$fail(peg$e45); }
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e45); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -2274,29 +2089,18 @@ function peg$parse(input, options) {
       s3 = peg$c36;
       peg$currPos++;
     } else {
-      s3 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e44); }
-    }
-    if (s3 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
         s3 = peg$c32;
         peg$currPos++;
       } else {
-        s3 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e38); }
-      }
-      if (s3 === peg$FAILED) {
         s3 = peg$parseLineTerminator();
       }
     }
     peg$silentFails--;
     if (s3 === peg$FAILED) {
       s2 = undefined;
-    } else {
-      peg$currPos = s2;
-      s2 = peg$FAILED;
-    }
-    if (s2 !== peg$FAILED) {
       s3 = peg$parseSourceCharacter();
       if (s3 !== peg$FAILED) {
         s2 = [s2, s3];
@@ -2306,6 +2110,8 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2313,17 +2119,10 @@ function peg$parse(input, options) {
       s0 = input.substring(s0, peg$currPos);
     } else {
       s0 = s1;
-    }
-    if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
         s1 = peg$c32;
         peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e38); }
-      }
-      if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           s0 = s2;
@@ -2332,6 +2131,7 @@ function peg$parse(input, options) {
           s0 = peg$FAILED;
         }
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e38); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -2354,29 +2154,18 @@ function peg$parse(input, options) {
       s3 = peg$c37;
       peg$currPos++;
     } else {
-      s3 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e45); }
-    }
-    if (s3 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
         s3 = peg$c32;
         peg$currPos++;
       } else {
-        s3 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e38); }
-      }
-      if (s3 === peg$FAILED) {
         s3 = peg$parseLineTerminator();
       }
     }
     peg$silentFails--;
     if (s3 === peg$FAILED) {
       s2 = undefined;
-    } else {
-      peg$currPos = s2;
-      s2 = peg$FAILED;
-    }
-    if (s2 !== peg$FAILED) {
       s3 = peg$parseSourceCharacter();
       if (s3 !== peg$FAILED) {
         s2 = [s2, s3];
@@ -2386,6 +2175,8 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2393,17 +2184,10 @@ function peg$parse(input, options) {
       s0 = input.substring(s0, peg$currPos);
     } else {
       s0 = s1;
-    }
-    if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
         s1 = peg$c32;
         peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e38); }
-      }
-      if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           s0 = s2;
@@ -2412,6 +2196,7 @@ function peg$parse(input, options) {
           s0 = peg$FAILED;
         }
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e38); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -2431,19 +2216,11 @@ function peg$parse(input, options) {
     if (input.charCodeAt(peg$currPos) === 91) {
       s1 = peg$c38;
       peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e47); }
-    }
-    if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 94) {
         s2 = peg$c39;
         peg$currPos++;
       } else {
-        s2 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e48); }
-      }
-      if (s2 === peg$FAILED) {
         s2 = null;
       }
       s3 = [];
@@ -2461,28 +2238,22 @@ function peg$parse(input, options) {
       if (input.charCodeAt(peg$currPos) === 93) {
         s4 = peg$c40;
         peg$currPos++;
-      } else {
-        s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e49); }
-      }
-      if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 105) {
           s5 = peg$c35;
           peg$currPos++;
         } else {
-          s5 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$e42); }
-        }
-        if (s5 === peg$FAILED) {
           s5 = null;
         }
         peg$savedPos = s0;
         s0 = peg$f26(s2, s3, s5);
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e49); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e47); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -2504,11 +2275,6 @@ function peg$parse(input, options) {
       if (input.charCodeAt(peg$currPos) === 45) {
         s2 = peg$c41;
         peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e50); }
-      }
-      if (s2 !== peg$FAILED) {
         s3 = peg$parseClassCharacter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -2518,6 +2284,7 @@ function peg$parse(input, options) {
           s0 = peg$FAILED;
         }
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e50); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -2540,29 +2307,18 @@ function peg$parse(input, options) {
       s3 = peg$c40;
       peg$currPos++;
     } else {
-      s3 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e49); }
-    }
-    if (s3 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
         s3 = peg$c32;
         peg$currPos++;
       } else {
-        s3 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e38); }
-      }
-      if (s3 === peg$FAILED) {
         s3 = peg$parseLineTerminator();
       }
     }
     peg$silentFails--;
     if (s3 === peg$FAILED) {
       s2 = undefined;
-    } else {
-      peg$currPos = s2;
-      s2 = peg$FAILED;
-    }
-    if (s2 !== peg$FAILED) {
       s3 = peg$parseSourceCharacter();
       if (s3 !== peg$FAILED) {
         s2 = [s2, s3];
@@ -2572,6 +2328,8 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2579,17 +2337,10 @@ function peg$parse(input, options) {
       s0 = input.substring(s0, peg$currPos);
     } else {
       s0 = s1;
-    }
-    if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
         s1 = peg$c32;
         peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e38); }
-      }
-      if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           s0 = s2;
@@ -2598,6 +2349,7 @@ function peg$parse(input, options) {
           s0 = peg$FAILED;
         }
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e38); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -2616,11 +2368,6 @@ function peg$parse(input, options) {
     if (input.charCodeAt(peg$currPos) === 92) {
       s1 = peg$c32;
       peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e38); }
-    }
-    if (s1 !== peg$FAILED) {
       s2 = peg$parseLineTerminatorSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -2630,6 +2377,7 @@ function peg$parse(input, options) {
         s0 = peg$FAILED;
       }
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e38); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -2646,29 +2394,22 @@ function peg$parse(input, options) {
       if (input.charCodeAt(peg$currPos) === 48) {
         s1 = peg$c42;
         peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e51); }
-      }
-      if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         s3 = peg$parseDecimalDigit();
         peg$silentFails--;
         if (s3 === peg$FAILED) {
           s2 = undefined;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
           s0 = peg$f29();
         } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e51); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -2701,37 +2442,26 @@ function peg$parse(input, options) {
       s0 = peg$c37;
       peg$currPos++;
     } else {
-      s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e45); }
-    }
-    if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
         s0 = peg$c36;
         peg$currPos++;
       } else {
-        s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$e44); }
-      }
-      if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
           s0 = peg$c32;
           peg$currPos++;
         } else {
-          s0 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$e38); }
-        }
-        if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
             s1 = peg$c43;
             peg$currPos++;
+            peg$savedPos = s0;
+            s1 = peg$f30();
           } else {
             s1 = peg$FAILED;
             if (peg$silentFails === 0) { peg$fail(peg$e52); }
-          }
-          if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$f30();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -2739,13 +2469,11 @@ function peg$parse(input, options) {
             if (input.charCodeAt(peg$currPos) === 102) {
               s1 = peg$c44;
               peg$currPos++;
+              peg$savedPos = s0;
+              s1 = peg$f31();
             } else {
               s1 = peg$FAILED;
               if (peg$silentFails === 0) { peg$fail(peg$e53); }
-            }
-            if (s1 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$f31();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
@@ -2753,13 +2481,11 @@ function peg$parse(input, options) {
               if (input.charCodeAt(peg$currPos) === 110) {
                 s1 = peg$c45;
                 peg$currPos++;
+                peg$savedPos = s0;
+                s1 = peg$f32();
               } else {
                 s1 = peg$FAILED;
                 if (peg$silentFails === 0) { peg$fail(peg$e54); }
-              }
-              if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$f32();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
@@ -2767,13 +2493,11 @@ function peg$parse(input, options) {
                 if (input.charCodeAt(peg$currPos) === 114) {
                   s1 = peg$c46;
                   peg$currPos++;
+                  peg$savedPos = s0;
+                  s1 = peg$f33();
                 } else {
                   s1 = peg$FAILED;
                   if (peg$silentFails === 0) { peg$fail(peg$e55); }
-                }
-                if (s1 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$f33();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
@@ -2781,13 +2505,11 @@ function peg$parse(input, options) {
                   if (input.charCodeAt(peg$currPos) === 116) {
                     s1 = peg$c47;
                     peg$currPos++;
+                    peg$savedPos = s0;
+                    s1 = peg$f34();
                   } else {
                     s1 = peg$FAILED;
                     if (peg$silentFails === 0) { peg$fail(peg$e56); }
-                  }
-                  if (s1 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$f34();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
@@ -2795,13 +2517,11 @@ function peg$parse(input, options) {
                     if (input.charCodeAt(peg$currPos) === 118) {
                       s1 = peg$c48;
                       peg$currPos++;
+                      peg$savedPos = s0;
+                      s1 = peg$f35();
                     } else {
                       s1 = peg$FAILED;
                       if (peg$silentFails === 0) { peg$fail(peg$e57); }
-                    }
-                    if (s1 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$f35();
                     }
                     s0 = s1;
                   }
@@ -2830,11 +2550,6 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s3 === peg$FAILED) {
       s2 = undefined;
-    } else {
-      peg$currPos = s2;
-      s2 = peg$FAILED;
-    }
-    if (s2 !== peg$FAILED) {
       s3 = peg$parseSourceCharacter();
       if (s3 !== peg$FAILED) {
         s2 = [s2, s3];
@@ -2844,6 +2559,8 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2867,10 +2584,7 @@ function peg$parse(input, options) {
           s0 = peg$c49;
           peg$currPos++;
         } else {
-          s0 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$e58); }
-        }
-        if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 117) {
             s0 = peg$c50;
             peg$currPos++;
@@ -2892,11 +2606,6 @@ function peg$parse(input, options) {
     if (input.charCodeAt(peg$currPos) === 120) {
       s1 = peg$c49;
       peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e58); }
-    }
-    if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       s3 = peg$currPos;
       s4 = peg$parseHexDigit();
@@ -2915,17 +2624,15 @@ function peg$parse(input, options) {
       }
       if (s3 !== peg$FAILED) {
         s2 = input.substring(s2, peg$currPos);
-      } else {
-        s2 = s3;
-      }
-      if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
         s0 = peg$f36(s2);
       } else {
+        s2 = s3;
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e58); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -2940,11 +2647,6 @@ function peg$parse(input, options) {
     if (input.charCodeAt(peg$currPos) === 117) {
       s1 = peg$c50;
       peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e59); }
-    }
-    if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       s3 = peg$currPos;
       s4 = peg$parseHexDigit();
@@ -2975,17 +2677,15 @@ function peg$parse(input, options) {
       }
       if (s3 !== peg$FAILED) {
         s2 = input.substring(s2, peg$currPos);
-      } else {
-        s2 = s3;
-      }
-      if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
         s0 = peg$f37(s2);
       } else {
+        s2 = s3;
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e59); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -3028,13 +2728,11 @@ function peg$parse(input, options) {
     if (input.charCodeAt(peg$currPos) === 46) {
       s1 = peg$c51;
       peg$currPos++;
+      peg$savedPos = s0;
+      s1 = peg$f38();
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e62); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f38();
     }
     s0 = s1;
 
@@ -3049,26 +2747,18 @@ function peg$parse(input, options) {
     if (input.charCodeAt(peg$currPos) === 123) {
       s1 = peg$c0;
       peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e0); }
-    }
-    if (s1 !== peg$FAILED) {
       s2 = peg$parseBareCodeBlock();
       if (input.charCodeAt(peg$currPos) === 125) {
         s3 = peg$c1;
         peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e1); }
-      }
-      if (s3 !== peg$FAILED) {
         s0 = s2;
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e1); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e0); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -3112,11 +2802,6 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s5 === peg$FAILED) {
       s4 = undefined;
-    } else {
-      peg$currPos = s4;
-      s4 = peg$FAILED;
-    }
-    if (s4 !== peg$FAILED) {
       s5 = peg$parseSourceCharacter();
       if (s5 !== peg$FAILED) {
         s4 = [s4, s5];
@@ -3126,6 +2811,8 @@ function peg$parse(input, options) {
         s3 = peg$FAILED;
       }
     } else {
+      peg$currPos = s4;
+      s4 = peg$FAILED;
       peg$currPos = s3;
       s3 = peg$FAILED;
     }
@@ -3145,11 +2832,6 @@ function peg$parse(input, options) {
         peg$silentFails--;
         if (s5 === peg$FAILED) {
           s4 = undefined;
-        } else {
-          peg$currPos = s4;
-          s4 = peg$FAILED;
-        }
-        if (s4 !== peg$FAILED) {
           s5 = peg$parseSourceCharacter();
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3159,39 +2841,31 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
+          peg$currPos = s4;
+          s4 = peg$FAILED;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
       }
     } else {
       s2 = peg$FAILED;
-    }
-    if (s2 === peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
         s3 = peg$c0;
         peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e0); }
-      }
-      if (s3 !== peg$FAILED) {
         s4 = peg$parseCode();
         if (input.charCodeAt(peg$currPos) === 125) {
           s5 = peg$c1;
           peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e1); }
-        }
-        if (s5 !== peg$FAILED) {
           s3 = [s3, s4, s5];
           s2 = s3;
         } else {
+          if (peg$silentFails === 0) { peg$fail(peg$e1); }
           peg$currPos = s2;
           s2 = peg$FAILED;
         }
       } else {
+        if (peg$silentFails === 0) { peg$fail(peg$e0); }
         peg$currPos = s2;
         s2 = peg$FAILED;
       }
@@ -3212,11 +2886,6 @@ function peg$parse(input, options) {
       peg$silentFails--;
       if (s5 === peg$FAILED) {
         s4 = undefined;
-      } else {
-        peg$currPos = s4;
-        s4 = peg$FAILED;
-      }
-      if (s4 !== peg$FAILED) {
         s5 = peg$parseSourceCharacter();
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
@@ -3226,6 +2895,8 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
+        peg$currPos = s4;
+        s4 = peg$FAILED;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -3245,11 +2916,6 @@ function peg$parse(input, options) {
           peg$silentFails--;
           if (s5 === peg$FAILED) {
             s4 = undefined;
-          } else {
-            peg$currPos = s4;
-            s4 = peg$FAILED;
-          }
-          if (s4 !== peg$FAILED) {
             s5 = peg$parseSourceCharacter();
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -3259,39 +2925,31 @@ function peg$parse(input, options) {
               s3 = peg$FAILED;
             }
           } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
             peg$currPos = s3;
             s3 = peg$FAILED;
           }
         }
       } else {
         s2 = peg$FAILED;
-      }
-      if (s2 === peg$FAILED) {
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 123) {
           s3 = peg$c0;
           peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e0); }
-        }
-        if (s3 !== peg$FAILED) {
           s4 = peg$parseCode();
           if (input.charCodeAt(peg$currPos) === 125) {
             s5 = peg$c1;
             peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e1); }
-          }
-          if (s5 !== peg$FAILED) {
             s3 = [s3, s4, s5];
             s2 = s3;
           } else {
+            if (peg$silentFails === 0) { peg$fail(peg$e1); }
             peg$currPos = s2;
             s2 = peg$FAILED;
           }
         } else {
+          if (peg$silentFails === 0) { peg$fail(peg$e0); }
           peg$currPos = s2;
           s2 = peg$FAILED;
         }
@@ -3314,12 +2972,9 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$parseDecimalDigit();
       }
-    } else {
-      s2 = peg$FAILED;
-    }
-    if (s2 !== peg$FAILED) {
       s1 = input.substring(s1, peg$currPos);
     } else {
+      s2 = peg$FAILED;
       s1 = s2;
     }
     if (s1 !== peg$FAILED) {
@@ -3538,14 +3193,10 @@ function peg$parse(input, options) {
     if (input.charCodeAt(peg$currPos) === 59) {
       s3 = peg$c52;
       peg$currPos++;
-    } else {
-      s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e76); }
-    }
-    if (s3 !== peg$FAILED) {
       s2 = [s2, s3];
       s1 = s2;
     } else {
+      if (peg$silentFails === 0) { peg$fail(peg$e76); }
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -3557,22 +3208,16 @@ function peg$parse(input, options) {
         if (input.charCodeAt(peg$currPos) === 59) {
           s3 = peg$c52;
           peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e76); }
-        }
-        if (s3 !== peg$FAILED) {
           s2 = [s2, s3];
           s1 = s2;
         } else {
+          if (peg$silentFails === 0) { peg$fail(peg$e76); }
           peg$currPos = s1;
           s1 = peg$FAILED;
         }
       }
     } else {
       s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$parse_();
       s2 = peg$parseSingleLineComment();
@@ -3586,8 +3231,6 @@ function peg$parse(input, options) {
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         s1 = peg$parse__();
         s2 = peg$parseEOF();

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -905,6 +905,27 @@ function peg$parse(input, options) {
         s7 = peg$parseActionExpression();
         if (s7 !== peg$FAILED) {
           s3 = s7;
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$currPos;
+            s4 = peg$parse__();
+            if (input.charCodeAt(peg$currPos) === 47) {
+              s5 = peg$c3;
+              peg$currPos++;
+              s6 = peg$parse__();
+              s7 = peg$parseActionExpression();
+              if (s7 !== peg$FAILED) {
+                s3 = s7;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              if (peg$silentFails === 0) { peg$fail(peg$e3); }
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          }
         } else {
           peg$currPos = s3;
           s3 = peg$FAILED;
@@ -913,27 +934,6 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$e3); }
         peg$currPos = s3;
         s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (input.charCodeAt(peg$currPos) === 47) {
-          s5 = peg$c3;
-          peg$currPos++;
-          s6 = peg$parse__();
-          s7 = peg$parseActionExpression();
-          if (s7 !== peg$FAILED) {
-            s3 = s7;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          if (peg$silentFails === 0) { peg$fail(peg$e3); }
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
       }
       peg$savedPos = s0;
       s0 = peg$f4(s1, s2);
@@ -982,21 +982,21 @@ function peg$parse(input, options) {
       s5 = peg$parseLabeledExpression();
       if (s5 !== peg$FAILED) {
         s3 = s5;
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$currPos;
+          s4 = peg$parse__();
+          s5 = peg$parseLabeledExpression();
+          if (s5 !== peg$FAILED) {
+            s3 = s5;
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        }
       } else {
         peg$currPos = s3;
         s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        s5 = peg$parseLabeledExpression();
-        if (s5 !== peg$FAILED) {
-          s3 = s5;
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
       }
       peg$savedPos = s0;
       s0 = peg$f6(s1, s2);
@@ -1625,6 +1625,33 @@ function peg$parse(input, options) {
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
           s3 = s4;
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$currPos;
+            s4 = peg$currPos;
+            peg$silentFails++;
+            if (input.substr(peg$currPos, 2) === peg$c29) {
+              s5 = peg$c29;
+              peg$currPos += 2;
+            } else {
+              s5 = peg$FAILED;
+            }
+            peg$silentFails--;
+            if (s5 === peg$FAILED) {
+              s4 = undefined;
+              s5 = peg$parseSourceCharacter();
+              if (s5 !== peg$FAILED) {
+                s4 = [s4, s5];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s4;
+              s3 = peg$FAILED;
+            }
+          }
         } else {
           peg$currPos = s3;
           s3 = peg$FAILED;
@@ -1632,33 +1659,6 @@ function peg$parse(input, options) {
       } else {
         peg$currPos = s4;
         s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$currPos;
-        peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c29) {
-          s5 = peg$c29;
-          peg$currPos += 2;
-        } else {
-          s5 = peg$FAILED;
-        }
-        peg$silentFails--;
-        if (s5 === peg$FAILED) {
-          s4 = undefined;
-          s5 = peg$parseSourceCharacter();
-          if (s5 !== peg$FAILED) {
-            s4 = [s4, s5];
-            s3 = s4;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s4;
-          s3 = peg$FAILED;
-        }
       }
       if (input.substr(peg$currPos, 2) === peg$c29) {
         s3 = peg$c29;
@@ -1702,6 +1702,33 @@ function peg$parse(input, options) {
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
           s3 = s4;
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$currPos;
+            s4 = peg$currPos;
+            peg$silentFails++;
+            if (input.substr(peg$currPos, 2) === peg$c29) {
+              s5 = peg$c29;
+              peg$currPos += 2;
+            } else {
+              s5 = peg$parseLineTerminator();
+            }
+            peg$silentFails--;
+            if (s5 === peg$FAILED) {
+              s4 = undefined;
+              s5 = peg$parseSourceCharacter();
+              if (s5 !== peg$FAILED) {
+                s4 = [s4, s5];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s4;
+              s3 = peg$FAILED;
+            }
+          }
         } else {
           peg$currPos = s3;
           s3 = peg$FAILED;
@@ -1709,33 +1736,6 @@ function peg$parse(input, options) {
       } else {
         peg$currPos = s4;
         s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$currPos;
-        peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c29) {
-          s5 = peg$c29;
-          peg$currPos += 2;
-        } else {
-          s5 = peg$parseLineTerminator();
-        }
-        peg$silentFails--;
-        if (s5 === peg$FAILED) {
-          s4 = undefined;
-          s5 = peg$parseSourceCharacter();
-          if (s5 !== peg$FAILED) {
-            s4 = [s4, s5];
-            s3 = s4;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s4;
-          s3 = peg$FAILED;
-        }
       }
       if (input.substr(peg$currPos, 2) === peg$c29) {
         s3 = peg$c29;
@@ -1774,6 +1774,28 @@ function peg$parse(input, options) {
         if (s5 !== peg$FAILED) {
           s4 = [s4, s5];
           s3 = s4;
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$currPos;
+            s4 = peg$currPos;
+            peg$silentFails++;
+            s5 = peg$parseLineTerminator();
+            peg$silentFails--;
+            if (s5 === peg$FAILED) {
+              s4 = undefined;
+              s5 = peg$parseSourceCharacter();
+              if (s5 !== peg$FAILED) {
+                s4 = [s4, s5];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s4;
+              s3 = peg$FAILED;
+            }
+          }
         } else {
           peg$currPos = s3;
           s3 = peg$FAILED;
@@ -1781,28 +1803,6 @@ function peg$parse(input, options) {
       } else {
         peg$currPos = s4;
         s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$currPos;
-        peg$silentFails++;
-        s5 = peg$parseLineTerminator();
-        peg$silentFails--;
-        if (s5 === peg$FAILED) {
-          s4 = undefined;
-          s5 = peg$parseSourceCharacter();
-          if (s5 !== peg$FAILED) {
-            s4 = [s4, s5];
-            s3 = s4;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s4;
-          s3 = peg$FAILED;
-        }
       }
       s1 = [s1, s2];
       s0 = s1;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1418,7 +1418,6 @@ function peg$parse(input, options) {
         peg$savedPos = s0;
         s0 = peg$f20(s1);
       } else {
-        peg$currPos = s2;
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -2336,7 +2335,6 @@ function peg$parse(input, options) {
           peg$savedPos = s0;
           s0 = peg$f29();
         } else {
-          peg$currPos = s2;
           peg$currPos = s0;
           s0 = peg$FAILED;
         }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1633,7 +1633,6 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
-        peg$currPos = s4;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -1660,7 +1659,6 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
-          peg$currPos = s4;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -1713,7 +1711,6 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
-        peg$currPos = s4;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -1740,7 +1737,6 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
-          peg$currPos = s4;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -1788,7 +1784,6 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
-        peg$currPos = s4;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -1810,7 +1805,6 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
-          peg$currPos = s4;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -2077,7 +2071,6 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
-      peg$currPos = s2;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2139,7 +2132,6 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
-      peg$currPos = s2;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2285,7 +2277,6 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
-      peg$currPos = s2;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2514,7 +2505,6 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
-      peg$currPos = s2;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2762,7 +2752,6 @@ function peg$parse(input, options) {
         s3 = peg$FAILED;
       }
     } else {
-      peg$currPos = s4;
       peg$currPos = s3;
       s3 = peg$FAILED;
     }
@@ -2790,7 +2779,6 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
-          peg$currPos = s4;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -2841,7 +2829,6 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
-        peg$currPos = s4;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -2869,7 +2856,6 @@ function peg$parse(input, options) {
               s3 = peg$FAILED;
             }
           } else {
-            peg$currPos = s4;
             peg$currPos = s3;
             s3 = peg$FAILED;
           }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -811,7 +811,6 @@ function peg$parse(input, options) {
       }
     } else {
       if (peg$silentFails === 0) { peg$fail(peg$e0); }
-      peg$currPos = s0;
       s0 = peg$FAILED;
     }
 
@@ -1235,7 +1234,6 @@ function peg$parse(input, options) {
             }
           } else {
             if (peg$silentFails === 0) { peg$fail(peg$e13); }
-            peg$currPos = s7;
             s7 = peg$FAILED;
           }
           if (s7 === peg$FAILED) {
@@ -1374,7 +1372,6 @@ function peg$parse(input, options) {
                 }
               } else {
                 if (peg$silentFails === 0) { peg$fail(peg$e15); }
-                peg$currPos = s0;
                 s0 = peg$FAILED;
               }
             }
@@ -1633,7 +1630,7 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
-        peg$currPos = s3;
+        peg$currPos = s4;
         s3 = peg$FAILED;
       }
       while (s3 !== peg$FAILED) {
@@ -1659,7 +1656,7 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
-          peg$currPos = s3;
+          peg$currPos = s4;
           s3 = peg$FAILED;
         }
       }
@@ -1675,7 +1672,6 @@ function peg$parse(input, options) {
       }
     } else {
       if (peg$silentFails === 0) { peg$fail(peg$e33); }
-      peg$currPos = s0;
       s0 = peg$FAILED;
     }
 
@@ -1711,7 +1707,7 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
-        peg$currPos = s3;
+        peg$currPos = s4;
         s3 = peg$FAILED;
       }
       while (s3 !== peg$FAILED) {
@@ -1737,7 +1733,7 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
-          peg$currPos = s3;
+          peg$currPos = s4;
           s3 = peg$FAILED;
         }
       }
@@ -1753,7 +1749,6 @@ function peg$parse(input, options) {
       }
     } else {
       if (peg$silentFails === 0) { peg$fail(peg$e33); }
-      peg$currPos = s0;
       s0 = peg$FAILED;
     }
 
@@ -1784,7 +1779,7 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
-        peg$currPos = s3;
+        peg$currPos = s4;
         s3 = peg$FAILED;
       }
       while (s3 !== peg$FAILED) {
@@ -1805,7 +1800,7 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
-          peg$currPos = s3;
+          peg$currPos = s4;
           s3 = peg$FAILED;
         }
       }
@@ -1813,7 +1808,6 @@ function peg$parse(input, options) {
       s0 = s1;
     } else {
       if (peg$silentFails === 0) { peg$fail(peg$e35); }
-      peg$currPos = s0;
       s0 = peg$FAILED;
     }
 
@@ -1871,7 +1865,6 @@ function peg$parse(input, options) {
           }
         } else {
           if (peg$silentFails === 0) { peg$fail(peg$e38); }
-          peg$currPos = s0;
           s0 = peg$FAILED;
         }
       }
@@ -2004,7 +1997,6 @@ function peg$parse(input, options) {
         s0 = peg$FAILED;
       }
     } else {
-      peg$currPos = s0;
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
@@ -2028,7 +2020,6 @@ function peg$parse(input, options) {
           s0 = peg$FAILED;
         }
       } else {
-        peg$currPos = s0;
         s0 = peg$FAILED;
       }
     }
@@ -2071,7 +2062,7 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
-      peg$currPos = s1;
+      peg$currPos = s2;
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
@@ -2091,7 +2082,6 @@ function peg$parse(input, options) {
         }
       } else {
         if (peg$silentFails === 0) { peg$fail(peg$e38); }
-        peg$currPos = s0;
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
@@ -2132,7 +2122,7 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
-      peg$currPos = s1;
+      peg$currPos = s2;
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
@@ -2152,7 +2142,6 @@ function peg$parse(input, options) {
         }
       } else {
         if (peg$silentFails === 0) { peg$fail(peg$e38); }
-        peg$currPos = s0;
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
@@ -2205,7 +2194,6 @@ function peg$parse(input, options) {
         s0 = peg$FAILED;
       }
     } else {
-      peg$currPos = s0;
       s0 = peg$FAILED;
     }
     peg$silentFails--;
@@ -2277,7 +2265,7 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
-      peg$currPos = s1;
+      peg$currPos = s2;
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
@@ -2297,7 +2285,6 @@ function peg$parse(input, options) {
         }
       } else {
         if (peg$silentFails === 0) { peg$fail(peg$e38); }
-        peg$currPos = s0;
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
@@ -2325,7 +2312,6 @@ function peg$parse(input, options) {
       }
     } else {
       if (peg$silentFails === 0) { peg$fail(peg$e38); }
-      peg$currPos = s0;
       s0 = peg$FAILED;
     }
 
@@ -2356,7 +2342,6 @@ function peg$parse(input, options) {
         }
       } else {
         if (peg$silentFails === 0) { peg$fail(peg$e51); }
-        peg$currPos = s0;
         s0 = peg$FAILED;
       }
       if (s0 === peg$FAILED) {
@@ -2505,7 +2490,7 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
     } else {
-      peg$currPos = s1;
+      peg$currPos = s2;
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
@@ -2577,7 +2562,6 @@ function peg$parse(input, options) {
       }
     } else {
       if (peg$silentFails === 0) { peg$fail(peg$e58); }
-      peg$currPos = s0;
       s0 = peg$FAILED;
     }
 
@@ -2630,7 +2614,6 @@ function peg$parse(input, options) {
       }
     } else {
       if (peg$silentFails === 0) { peg$fail(peg$e59); }
-      peg$currPos = s0;
       s0 = peg$FAILED;
     }
 
@@ -2701,7 +2684,6 @@ function peg$parse(input, options) {
         s0 = peg$FAILED;
       }
     } else {
-      peg$currPos = s0;
       s0 = peg$FAILED;
     }
     peg$silentFails--;
@@ -2752,7 +2734,7 @@ function peg$parse(input, options) {
         s3 = peg$FAILED;
       }
     } else {
-      peg$currPos = s3;
+      peg$currPos = s4;
       s3 = peg$FAILED;
     }
     if (s3 !== peg$FAILED) {
@@ -2779,7 +2761,7 @@ function peg$parse(input, options) {
             s3 = peg$FAILED;
           }
         } else {
-          peg$currPos = s3;
+          peg$currPos = s4;
           s3 = peg$FAILED;
         }
       }
@@ -2801,7 +2783,6 @@ function peg$parse(input, options) {
         }
       } else {
         if (peg$silentFails === 0) { peg$fail(peg$e0); }
-        peg$currPos = s2;
         s2 = peg$FAILED;
       }
     }
@@ -2829,7 +2810,7 @@ function peg$parse(input, options) {
           s3 = peg$FAILED;
         }
       } else {
-        peg$currPos = s3;
+        peg$currPos = s4;
         s3 = peg$FAILED;
       }
       if (s3 !== peg$FAILED) {
@@ -2856,7 +2837,7 @@ function peg$parse(input, options) {
               s3 = peg$FAILED;
             }
           } else {
-            peg$currPos = s3;
+            peg$currPos = s4;
             s3 = peg$FAILED;
           }
         }
@@ -2878,7 +2859,6 @@ function peg$parse(input, options) {
           }
         } else {
           if (peg$silentFails === 0) { peg$fail(peg$e0); }
-          peg$currPos = s2;
           s2 = peg$FAILED;
         }
       }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -773,7 +773,6 @@ function peg$parse(input, options) {
       peg$savedPos = s0;
       s0 = peg$f0(s2, s3, s4);
     } else {
-      s4 = peg$FAILED;
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -960,7 +959,6 @@ function peg$parse(input, options) {
         s2 = s4;
       } else {
         peg$currPos = s2;
-        s2 = peg$FAILED;
         s2 = null;
       }
       peg$savedPos = s0;
@@ -1406,7 +1404,6 @@ function peg$parse(input, options) {
         s5 = s6;
       } else {
         peg$currPos = s5;
-        s5 = peg$FAILED;
         s5 = null;
       }
       if (input.charCodeAt(peg$currPos) === 61) {
@@ -1415,7 +1412,6 @@ function peg$parse(input, options) {
         s4 = [s4, s5, s6];
         s3 = s4;
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e2); }
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -1426,7 +1422,6 @@ function peg$parse(input, options) {
         s0 = peg$f20(s1);
       } else {
         peg$currPos = s2;
-        s2 = peg$FAILED;
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -1503,32 +1498,26 @@ function peg$parse(input, options) {
       s0 = peg$c17;
       peg$currPos++;
     } else {
-      if (peg$silentFails === 0) { peg$fail(peg$e19); }
       if (input.charCodeAt(peg$currPos) === 11) {
         s0 = peg$c18;
         peg$currPos++;
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e20); }
         if (input.charCodeAt(peg$currPos) === 12) {
           s0 = peg$c19;
           peg$currPos++;
         } else {
-          if (peg$silentFails === 0) { peg$fail(peg$e21); }
           if (input.charCodeAt(peg$currPos) === 32) {
             s0 = peg$c20;
             peg$currPos++;
           } else {
-            if (peg$silentFails === 0) { peg$fail(peg$e22); }
             if (input.charCodeAt(peg$currPos) === 160) {
               s0 = peg$c21;
               peg$currPos++;
             } else {
-              if (peg$silentFails === 0) { peg$fail(peg$e23); }
               if (input.charCodeAt(peg$currPos) === 65279) {
                 s0 = peg$c22;
                 peg$currPos++;
               } else {
-                if (peg$silentFails === 0) { peg$fail(peg$e24); }
                 s0 = peg$parseZs();
               }
             }
@@ -1567,28 +1556,23 @@ function peg$parse(input, options) {
       s0 = peg$c23;
       peg$currPos++;
     } else {
-      if (peg$silentFails === 0) { peg$fail(peg$e27); }
       if (input.substr(peg$currPos, 2) === peg$c24) {
         s0 = peg$c24;
         peg$currPos += 2;
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e28); }
         if (input.charCodeAt(peg$currPos) === 13) {
           s0 = peg$c25;
           peg$currPos++;
         } else {
-          if (peg$silentFails === 0) { peg$fail(peg$e29); }
           if (input.charCodeAt(peg$currPos) === 8232) {
             s0 = peg$c26;
             peg$currPos++;
           } else {
-            if (peg$silentFails === 0) { peg$fail(peg$e30); }
             if (input.charCodeAt(peg$currPos) === 8233) {
               s0 = peg$c27;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e31); }
             }
           }
         }
@@ -1636,7 +1620,6 @@ function peg$parse(input, options) {
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e34); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -1651,7 +1634,6 @@ function peg$parse(input, options) {
         }
       } else {
         peg$currPos = s4;
-        s4 = peg$FAILED;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -1665,7 +1647,6 @@ function peg$parse(input, options) {
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e34); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -1680,7 +1661,6 @@ function peg$parse(input, options) {
           }
         } else {
           peg$currPos = s4;
-          s4 = peg$FAILED;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -1719,7 +1699,6 @@ function peg$parse(input, options) {
         s5 = peg$c29;
         peg$currPos += 2;
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e34); }
         s5 = peg$parseLineTerminator();
       }
       peg$silentFails--;
@@ -1735,7 +1714,6 @@ function peg$parse(input, options) {
         }
       } else {
         peg$currPos = s4;
-        s4 = peg$FAILED;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -1748,7 +1726,6 @@ function peg$parse(input, options) {
           s5 = peg$c29;
           peg$currPos += 2;
         } else {
-          if (peg$silentFails === 0) { peg$fail(peg$e34); }
           s5 = peg$parseLineTerminator();
         }
         peg$silentFails--;
@@ -1764,7 +1741,6 @@ function peg$parse(input, options) {
           }
         } else {
           peg$currPos = s4;
-          s4 = peg$FAILED;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -1813,7 +1789,6 @@ function peg$parse(input, options) {
         }
       } else {
         peg$currPos = s4;
-        s4 = peg$FAILED;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -1836,7 +1811,6 @@ function peg$parse(input, options) {
           }
         } else {
           peg$currPos = s4;
-          s4 = peg$FAILED;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
@@ -1995,7 +1969,6 @@ function peg$parse(input, options) {
         s2 = peg$c35;
         peg$currPos++;
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e42); }
         s2 = null;
       }
       peg$savedPos = s0;
@@ -2033,12 +2006,10 @@ function peg$parse(input, options) {
         peg$savedPos = s0;
         s0 = peg$f24(s2);
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e44); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     } else {
-      if (peg$silentFails === 0) { peg$fail(peg$e44); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -2059,12 +2030,10 @@ function peg$parse(input, options) {
           peg$savedPos = s0;
           s0 = peg$f25(s2);
         } else {
-          if (peg$silentFails === 0) { peg$fail(peg$e45); }
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e45); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
@@ -2089,12 +2058,10 @@ function peg$parse(input, options) {
       s3 = peg$c36;
       peg$currPos++;
     } else {
-      if (peg$silentFails === 0) { peg$fail(peg$e44); }
       if (input.charCodeAt(peg$currPos) === 92) {
         s3 = peg$c32;
         peg$currPos++;
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e38); }
         s3 = peg$parseLineTerminator();
       }
     }
@@ -2111,7 +2078,6 @@ function peg$parse(input, options) {
       }
     } else {
       peg$currPos = s2;
-      s2 = peg$FAILED;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2154,12 +2120,10 @@ function peg$parse(input, options) {
       s3 = peg$c37;
       peg$currPos++;
     } else {
-      if (peg$silentFails === 0) { peg$fail(peg$e45); }
       if (input.charCodeAt(peg$currPos) === 92) {
         s3 = peg$c32;
         peg$currPos++;
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e38); }
         s3 = peg$parseLineTerminator();
       }
     }
@@ -2176,7 +2140,6 @@ function peg$parse(input, options) {
       }
     } else {
       peg$currPos = s2;
-      s2 = peg$FAILED;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2220,7 +2183,6 @@ function peg$parse(input, options) {
         s2 = peg$c39;
         peg$currPos++;
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e48); }
         s2 = null;
       }
       s3 = [];
@@ -2242,18 +2204,15 @@ function peg$parse(input, options) {
           s5 = peg$c35;
           peg$currPos++;
         } else {
-          if (peg$silentFails === 0) { peg$fail(peg$e42); }
           s5 = null;
         }
         peg$savedPos = s0;
         s0 = peg$f26(s2, s3, s5);
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e49); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     } else {
-      if (peg$silentFails === 0) { peg$fail(peg$e47); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -2307,12 +2266,10 @@ function peg$parse(input, options) {
       s3 = peg$c40;
       peg$currPos++;
     } else {
-      if (peg$silentFails === 0) { peg$fail(peg$e49); }
       if (input.charCodeAt(peg$currPos) === 92) {
         s3 = peg$c32;
         peg$currPos++;
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e38); }
         s3 = peg$parseLineTerminator();
       }
     }
@@ -2329,7 +2286,6 @@ function peg$parse(input, options) {
       }
     } else {
       peg$currPos = s2;
-      s2 = peg$FAILED;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2404,7 +2360,6 @@ function peg$parse(input, options) {
           s0 = peg$f29();
         } else {
           peg$currPos = s2;
-          s2 = peg$FAILED;
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
@@ -2560,7 +2515,6 @@ function peg$parse(input, options) {
       }
     } else {
       peg$currPos = s2;
-      s2 = peg$FAILED;
       peg$currPos = s1;
       s1 = peg$FAILED;
     }
@@ -2753,12 +2707,10 @@ function peg$parse(input, options) {
         peg$currPos++;
         s0 = s2;
       } else {
-        if (peg$silentFails === 0) { peg$fail(peg$e1); }
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
     } else {
-      if (peg$silentFails === 0) { peg$fail(peg$e0); }
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
@@ -2797,7 +2749,6 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s5 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e64); }
     }
     peg$silentFails--;
     if (s5 === peg$FAILED) {
@@ -2812,7 +2763,6 @@ function peg$parse(input, options) {
       }
     } else {
       peg$currPos = s4;
-      s4 = peg$FAILED;
       peg$currPos = s3;
       s3 = peg$FAILED;
     }
@@ -2827,7 +2777,6 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e64); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -2842,13 +2791,11 @@ function peg$parse(input, options) {
           }
         } else {
           peg$currPos = s4;
-          s4 = peg$FAILED;
           peg$currPos = s3;
           s3 = peg$FAILED;
         }
       }
     } else {
-      s2 = peg$FAILED;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
         s3 = peg$c0;
@@ -2881,7 +2828,6 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e64); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -2896,7 +2842,6 @@ function peg$parse(input, options) {
         }
       } else {
         peg$currPos = s4;
-        s4 = peg$FAILED;
         peg$currPos = s3;
         s3 = peg$FAILED;
       }
@@ -2911,7 +2856,6 @@ function peg$parse(input, options) {
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e64); }
           }
           peg$silentFails--;
           if (s5 === peg$FAILED) {
@@ -2926,13 +2870,11 @@ function peg$parse(input, options) {
             }
           } else {
             peg$currPos = s4;
-            s4 = peg$FAILED;
             peg$currPos = s3;
             s3 = peg$FAILED;
           }
         }
       } else {
-        s2 = peg$FAILED;
         s2 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 123) {
           s3 = peg$c0;
@@ -2973,13 +2915,11 @@ function peg$parse(input, options) {
         s3 = peg$parseDecimalDigit();
       }
       s1 = input.substring(s1, peg$currPos);
+      peg$savedPos = s0;
+      s1 = peg$f40(s1);
     } else {
       s2 = peg$FAILED;
       s1 = s2;
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$f40(s1);
     }
     s0 = s1;
 
@@ -3195,12 +3135,6 @@ function peg$parse(input, options) {
       peg$currPos++;
       s2 = [s2, s3];
       s1 = s2;
-    } else {
-      if (peg$silentFails === 0) { peg$fail(peg$e76); }
-      peg$currPos = s1;
-      s1 = peg$FAILED;
-    }
-    if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
         s1 = peg$currPos;
@@ -3217,7 +3151,8 @@ function peg$parse(input, options) {
         }
       }
     } else {
-      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e76); }
+      peg$currPos = s1;
       s0 = peg$currPos;
       s1 = peg$parse_();
       s2 = peg$parseSingleLineComment();
@@ -3230,7 +3165,6 @@ function peg$parse(input, options) {
         s0 = s1;
       } else {
         peg$currPos = s0;
-        s0 = peg$FAILED;
         s0 = peg$currPos;
         s1 = peg$parse__();
         s2 = peg$parseEOF();
@@ -3257,7 +3191,6 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e17); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -466,6 +466,14 @@ export namespace parser {
    */
   function parse(grammar: string, options?: Options): ast.Grammar;
 
+  type OutputType =
+    | "ast"
+    | "parser"
+    | "source-and-map"
+    | "source-with-inline-map"
+    | "source"
+    ;
+
   /** Options, accepted by the parser of PEG grammar. */
   interface Options {
     /**
@@ -481,6 +489,9 @@ export namespace parser {
     reservedWords: string[];
     /** The only acceptable rule is `"Grammar"`, all other values leads to the exception */
     startRule?: "Grammar";
+
+    /** The kind of output to produce */
+    output?: OutputType;
   }
 
   /** Specific sequence of symbols is expected in the parsed source. */

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -466,14 +466,6 @@ export namespace parser {
    */
   function parse(grammar: string, options?: Options): ast.Grammar;
 
-  type OutputType =
-    | "ast"
-    | "parser"
-    | "source-and-map"
-    | "source-with-inline-map"
-    | "source"
-    ;
-
   /** Options, accepted by the parser of PEG grammar. */
   interface Options {
     /**
@@ -489,9 +481,6 @@ export namespace parser {
     reservedWords: string[];
     /** The only acceptable rule is `"Grammar"`, all other values leads to the exception */
     startRule?: "Grammar";
-
-    /** The kind of output to produce */
-    output?: OutputType;
   }
 
   /** Specific sequence of symbols is expected in the parsed source. */

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "env": {
     "commonjs": true,
-    "mocha": true
+    "jest": true
   },
   "parserOptions": {
     "project": "test/tsconfig.json"

--- a/test/unit/compiler/interp-state.spec.js
+++ b/test/unit/compiler/interp-state.spec.js
@@ -1,0 +1,302 @@
+// @ts-check
+"use strict";
+
+const chai = require("chai");
+const { TypeTag, InterpState } = require("../../../lib/compiler/interp-state");
+const op = require("../../../lib/compiler/opcodes");
+
+const expect = chai.expect;
+
+describe("class InterpState", () => {
+  describe("for an empty stack", () => {
+    const state = new InterpState("empty");
+
+    describe("throws an error when attempting", () => {
+      it("`POP_CURR_POS`", () => {
+        expect(() => state.clone().run([op.POP_CURR_POS])).to.throw(
+          RangeError,
+          "Rule 'empty': Trying to pop from an empty stack."
+        );
+      });
+
+      it("`POP`", () => {
+        expect(() => state.clone().run([op.POP])).to.throw(
+          RangeError,
+          "Rule 'empty': Trying to pop 1 elements, but only 0 available."
+        );
+      });
+
+      it("`POP_N`", () => {
+        expect(() => state.clone().run([op.POP_N, 5])).to.throw(
+          RangeError,
+          "Rule 'empty': Trying to pop 5 elements, but only 0 available."
+        );
+        expect(() => state.clone().run([op.PUSH_NULL, op.POP_N, 5])).to.throw(
+          RangeError,
+          "Rule 'empty': Trying to pop 5 elements, but only 1 available."
+        );
+      });
+
+      it("`WRAP`", () => {
+        expect(() => state.clone().run([op.WRAP, 2])).to.throw(
+          RangeError,
+          "Rule 'empty': Trying to pop 2 elements, but only 0 available."
+        );
+      });
+
+      it("`PLUCK`", () => {
+        expect(() => state.clone().run([op.PLUCK, 3, 1, 2])).to.throw(
+          RangeError,
+          "Rule 'empty': Trying to inspect element 2 in a stack of size 0"
+        );
+        expect(
+          () => state.clone().run([op.PUSH_NULL, op.PLUCK, 3, 1, 0])
+        ).to.throw(
+          RangeError,
+          "Rule 'empty': Trying to pop 3 elements, but only 1 available."
+        );
+        expect(
+          () => state.clone().run([op.PUSH_NULL, op.PLUCK, -3, 1, 0])
+        ).to.throw(
+          RangeError,
+          "Rule 'empty': Trying to discard -3 elements."
+        );
+      });
+
+      it("`APPEND`", () => {
+        expect(() => state.clone().run([op.PUSH_NULL, op.APPEND, 2])).to.throw(
+          RangeError,
+          "Rule 'empty': Trying to access the top of an empty stack."
+        );
+      });
+
+      it("`IF`", () => {
+        expect(() => state.clone().run([op.IF])).to.throw(
+          RangeError,
+          "Rule 'empty': Trying to access the top of an empty stack."
+        );
+      });
+    });
+  });
+
+  describe("things that can't happen with correct bytecode", () => {
+    const state = new InterpState("rule");
+    it("throws an error when attempting to merge inconsistent states", () => {
+      const state2 = state.clone();
+      state2.run([op.PUSH_NULL]);
+
+      expect(() => state2.merge(state)).to.throw(
+        Error,
+        "Rule 'rule': Merging states with mis-matched stacks."
+      );
+
+      const state3 = state.clone();
+      state3.run([op.SILENT_FAILS_ON]);
+
+      expect(() => state3.merge(state)).to.throw(
+        Error,
+        "Rule 'rule': Merging states with mis-matched silentFails."
+      );
+    });
+
+    it("throws an error when handling unexpected byte codes", () => {
+      expect(
+        () => InterpState.getConditionalArgCount(op.PUSH_NULL)
+      ).to.throw(
+        Error,
+        `Expected a conditional bytecode, but got: ${op.PUSH_NULL}.`
+      );
+
+      expect(() => state.clone().interp([-1], 0)).to.throw(
+        Error,
+        "rule: Invalid opcode: -1."
+      );
+    });
+
+    it("throws when trying to set currPos to an invalid value", () => {
+      expect(
+        () => state.clone().setCurrPos({ type: TypeTag.NULL })
+      ).to.throw(
+        Error,
+        "Rule 'rule': Invalid value assigned to currPos."
+      );
+    });
+
+    it("throws when trying to pop an invalid value into currPos", () => {
+      expect(
+        () => state.clone().run([op.PUSH_NULL, op.POP_CURR_POS])
+      ).to.throw(
+        Error,
+        "Rule 'rule': Invalid value assigned to currPos."
+      );
+    });
+
+    it("APPEND gets an ARRAY", () => {
+      expect(() => state.clone().run(
+        [op.PUSH_NULL, op.PUSH_EMPTY_STRING, op.APPEND]
+      )).to.throw(
+        Error,
+        "Rule 'rule': Attempting to append to a non-array."
+      );
+    });
+
+    it("TEXT gets an OFFSET", () => {
+      expect(() => state.clone().run(
+        [op.PUSH_NULL, op.TEXT]
+      )).to.throw(
+        Error,
+        `Rule 'rule': TEXT bytecode got an incorrect type: ${TypeTag.NULL}.`
+      );
+    });
+
+    it("IF thats always true and always false throws", () => {
+      jest.spyOn(InterpState, "mustBeTrue").mockReturnValue(true);
+      jest.spyOn(InterpState, "mustBeFalse").mockReturnValue(true);
+      expect(
+        () => state.clone().run([op.PUSH_NULL, op.IF, 1, 1, op.POP, op.POP])
+      ).to.throw(
+        Error,
+        "Rule 'rule': Conditional cannot be both always true and always false."
+      );
+      jest.resetAllMocks();
+    });
+  });
+
+  describe("consistency", () => {
+    it("keeps track of currPos", () => {
+      const state = new InterpState("rule");
+      expect(state.currPos.value).to.not.equal(undefined);
+
+      let state2 = state.clone();
+      expect(state2.currPos.value).to.equal(state.currPos.value);
+      state2.run([op.ACCEPT_N, 0]);
+      expect(state2.currPos.value).to.not.equal(state.currPos.value);
+
+      state2 = state.clone();
+      state2.run([op.RULE, 0]);
+      expect(state2.currPos.value).to.not.equal(state.currPos.value);
+
+      state2 = state.clone();
+      state2.run([op.CALL, 0, 0]);
+      expect(state2.currPos.value).to.not.equal(state.currPos.value);
+
+      state2 = state.clone();
+      state2.postInterp = function(bc, ip, result) {
+        if (bc[ip] === op.ACCEPT_N) {
+          expect(this.currPos.value).to.not.equal(state.currPos.value);
+        } else if (bc[ip] === op.FAIL) {
+          expect(this.currPos.value).to.equal(state.currPos.value);
+        }
+        return result;
+      };
+      state2.run([op.MATCH_STRING, 1, 2, 2, op.ACCEPT_N, 0, op.FAIL, 0]);
+      expect(state2.currPos.value).to.not.equal(state.currPos.value);
+    });
+
+    it("getConditionalArgCount", () => {
+      expect(InterpState.getConditionalArgCount(op.IF_GE)).to.equal(1);
+    });
+  });
+
+  describe("transformation", () => {
+    const state = new InterpState("rule");
+    it("reduces always true ifs to then clause", () => {
+      expect(state.clone().run([
+        op.PUSH_EMPTY_ARRAY,
+        op.IF, 2, 2,
+        /* */ op.ACCEPT_N, 1,
+        /* */ op.FAIL, 1,
+      ])).to.deep.equal([op.PUSH_EMPTY_ARRAY, op.ACCEPT_N, 1]);
+      expect(state.clone().run([
+        op.PUSH_FAILED,
+        op.IF_ERROR, 2, 2,
+        /* */ op.ACCEPT_N, 1,
+        /* */ op.FAIL, 1,
+      ])).to.deep.equal([op.PUSH_FAILED, op.ACCEPT_N, 1]);
+      expect(state.clone().run([
+        op.PUSH_NULL,
+        op.IF_NOT_ERROR, 2, 2,
+        /* */ op.ACCEPT_N, 1,
+        /* */ op.FAIL, 1,
+      ])).to.deep.equal([op.PUSH_NULL, op.ACCEPT_N, 1]);
+    });
+    it("reduces always false ifs to else clause", () => {
+      expect(state.clone().run([
+        op.PUSH_NULL,
+        op.IF, 2, 2,
+        /* */ op.ACCEPT_N, 1,
+        /* */ op.FAIL, 1,
+      ])).to.deep.equal([op.PUSH_NULL, op.FAIL, 1]);
+      expect(state.clone().run([
+        op.PUSH_NULL,
+        op.IF_ERROR, 2, 2,
+        /* */ op.ACCEPT_N, 1,
+        /* */ op.FAIL, 1,
+      ])).to.deep.equal([op.PUSH_NULL, op.FAIL, 1]);
+      expect(state.clone().run([
+        op.PUSH_FAILED,
+        op.IF_NOT_ERROR, 2, 2,
+        /* */ op.ACCEPT_N, 1,
+        /* */ op.FAIL, 1,
+      ])).to.deep.equal([op.PUSH_FAILED, op.FAIL, 1]);
+    });
+
+    it("removes never executed loops", () => {
+      expect(state.clone().run([
+        op.PUSH_FAILED,
+        op.WHILE_NOT_ERROR, 2,
+        /* */ op.POP,
+        /* */ op.PUSH_NULL,
+      ])).to.deep.equal([op.PUSH_FAILED]);
+    });
+
+    it("iterates to convergence before modifying code", () => {
+      expect(state.clone().run([
+        op.PUSH_NULL,
+        op.WHILE_NOT_ERROR, 7,
+        /* */ op.IF, 2, 2,
+        /*   */ op.POP, op.PUSH_FAILED,
+        /*   */ op.POP, op.PUSH_EMPTY_ARRAY,
+      ])).to.equal(null);
+    });
+  });
+
+  describe("code coverage", () => {
+    it("prints bytecode", () => {
+      expect(InterpState.print([
+        op.MATCH_CHAR_CLASS, 0, 2, 2,
+        /* */ op.ACCEPT_N, 1,
+        /* */ op.FAIL, 1,
+      ], "test")
+        .replace(/stack:.*/g, "")
+        .replace(/\s+/g, " ")
+        .trim()).to.equal(
+        "MATCH_CHAR_CLASS ACCEPT_N -- FAIL --"
+      );
+    });
+
+    it("source mapping bytecodes", () => {
+      const state = new InterpState("rule");
+      expect(state.run([
+        op.SOURCE_MAP_PUSH, 0,
+        op.SOURCE_MAP_POP,
+        op.SOURCE_MAP_LABEL_PUSH, 0, 0, 0,
+        op.SOURCE_MAP_LABEL_POP,
+      ])).to.equal(null);
+    });
+
+    it("equality tests", () => {
+      // These are never hit in practice because we're comparing the result of a
+      // state with a merged state, and merge would have thrown
+      const state = new InterpState("rule");
+      const s2 = state.clone();
+      s2.silentFails++;
+      expect(state.equal(s2)).to.be.equal(false);
+      s2.silentFails--;
+      s2.push({ type: TypeTag.NULL });
+      expect(state.equal(s2)).to.be.equal(false);
+      s2.pop();
+      expect(state.equal(s2)).to.be.equal(true);
+    });
+  });
+});

--- a/test/unit/compiler/passes/optimize-bytecode.spec.js
+++ b/test/unit/compiler/passes/optimize-bytecode.spec.js
@@ -1,0 +1,394 @@
+// @ts-check
+"use strict";
+
+const chai = require("chai");
+// X const { TypeTag, InterpState } = require("../../../../lib/compiler/interp-state");
+const op = require("../../../../lib/compiler/opcodes");
+const { optimizeBlock } = require("../../../../lib/compiler/passes/optimize-bytecode");
+const { InterpState } = require("../../../../lib/compiler/interp-state");
+
+const expect = chai.expect;
+
+/**
+ * @typedef {[number, FormattedBytecode, FormattedBytecode]} Cond0Element
+ * @typedef {[number, number, FormattedBytecode, FormattedBytecode]} Cond1Element
+ * @typedef {[number, FormattedBytecode]} LoopElement
+ * @typedef {number[]|Cond0Element|Cond1Element|LoopElement} FormattedElement
+ * @typedef {FormattedElement[]} FormattedBytecode
+ */
+
+/**
+ *
+ * @param {FormattedBytecode} fbc
+ * @returns {number[]}
+ */
+function flattenBc(fbc) {
+  /** @type {number[]} */
+  const result = [];
+  fbc.forEach(e => {
+    for (let i = 0; i < e.length; i++) {
+      const x = e[i];
+      if (Array.isArray(x)) {
+        const bodies = e.slice(i).map(b => {
+          if (!Array.isArray(b)) {
+            throw new Error(
+              "Incorrect formatted bytecode. Expected an Array"
+            );
+          }
+          return flattenBc(b);
+        });
+        if (bodies.length === 1) {
+          if (e[0] !== op.WHILE_NOT_ERROR) {
+            throw new Error(
+              `Incorrect formatted bytecode. Expected '${
+                op.WHILE_NOT_ERROR
+              }', but got ${e[0]}`
+            );
+          }
+        } else {
+          const args = InterpState.getConditionalArgCount(e[0]);
+          if (i !== args + 1) {
+            throw new Error(
+              `Incorrect formatted bytecode. Expected ${
+                args
+              } arguments for ${e[0]}, but got ${bodies.length}`
+            );
+          }
+          if (bodies.length !== 2) {
+            throw new Error(
+              `Incorrect formatted bytecode. Expected 2 bodies for ${
+                e[0]
+              }, but got ${bodies.length}`
+            );
+          }
+        }
+        bodies.forEach(b => result.push(b.length));
+        bodies.forEach(b => result.push(...b));
+        break;
+      }
+      result.push(x);
+    }
+  });
+  return result;
+}
+
+describe("compiler pass |optimizeBytecode|", () => {
+  describe("combine consecutive ifs", () => {
+    it("conditional => op.IF no swap", () => {
+      expect(optimizeBlock(flattenBc([
+        [
+          op.MATCH_CHAR_CLASS, 0, [
+            [op.PUSH_EMPTY_ARRAY],
+          ], [
+            [op.PUSH_NULL],
+          ],
+        ],
+        [
+          op.IF, [
+            [op.ACCEPT_N, 1],
+          ], [
+            [op.FAIL, 0],
+          ],
+        ],
+      ]), "combine-with-IF")).to.deep.equal(flattenBc([
+        [
+          op.MATCH_CHAR_CLASS, 0, [
+            [op.PUSH_EMPTY_ARRAY],
+            [op.ACCEPT_N, 1],
+          ], [
+            [op.PUSH_NULL],
+            [op.FAIL, 0],
+          ],
+        ],
+      ]));
+    });
+    it("conditional => op.IF swapped", () => {
+      expect(optimizeBlock(flattenBc([
+        [
+          op.MATCH_CHAR_CLASS, 0, [
+            [op.PUSH_NULL],
+          ], [
+            [op.PUSH_EMPTY_ARRAY],
+          ],
+        ],
+        [
+          op.IF, [
+            [op.ACCEPT_N, 1],
+          ], [
+            [op.FAIL, 0],
+          ],
+        ],
+      ]), "combine-with-IF")).to.deep.equal(flattenBc([
+        [
+          op.MATCH_CHAR_CLASS, 0, [
+            [op.PUSH_NULL],
+            [op.FAIL, 0],
+          ], [
+            [op.PUSH_EMPTY_ARRAY],
+            [op.ACCEPT_N, 1],
+          ],
+        ],
+      ]));
+    });
+
+    it("conditional => op.IF_ERROR no swap", () => {
+      expect(optimizeBlock(flattenBc([
+        [
+          op.MATCH_STRING, 0, [
+            [op.PUSH_FAILED],
+          ], [
+            [op.PUSH_NULL],
+          ],
+        ],
+        [
+          op.IF_ERROR, [
+            [op.ACCEPT_N, 1],
+          ], [
+            [op.FAIL, 0],
+          ],
+        ],
+      ]), "combine-with-IF_ERROR")).to.deep.equal(flattenBc([
+        [
+          op.MATCH_STRING, 0, [
+            [op.PUSH_FAILED],
+            [op.ACCEPT_N, 1],
+          ], [
+            [op.PUSH_NULL],
+            [op.FAIL, 0],
+          ],
+        ],
+      ]));
+    });
+    it("conditional => op.IF_ERROR swapped", () => {
+      expect(optimizeBlock(flattenBc([
+        [
+          op.MATCH_STRING, 0, [
+            [op.PUSH_NULL],
+          ], [
+            [op.PUSH_FAILED],
+          ],
+        ],
+        [
+          op.IF_ERROR, [
+            [op.ACCEPT_N, 1],
+          ], [
+            [op.FAIL, 0],
+          ],
+        ],
+      ]), "combine-with-IF_ERROR")).to.deep.equal(flattenBc([
+        [
+          op.MATCH_STRING, 0, [
+            [op.PUSH_NULL],
+            [op.FAIL, 0],
+          ], [
+            [op.PUSH_FAILED],
+            [op.ACCEPT_N, 1],
+          ],
+        ],
+      ]));
+    });
+
+    it("conditional => op.IF_NOT_ERROR no swap", () => {
+      expect(optimizeBlock(flattenBc([
+        [
+          op.MATCH_STRING_IC, 0, [
+            [op.PUSH_FAILED],
+          ], [
+            [op.PUSH_NULL],
+          ],
+        ],
+        [
+          op.IF_NOT_ERROR, [
+            [op.ACCEPT_N, 1],
+          ], [
+            [op.FAIL, 0],
+          ],
+        ],
+      ]), "combine-with-IF_NOT_ERROR")).to.deep.equal(flattenBc([
+        [
+          op.MATCH_STRING_IC, 0, [
+            [op.PUSH_FAILED],
+            [op.FAIL, 0],
+          ], [
+            [op.PUSH_NULL],
+            [op.ACCEPT_N, 1],
+          ],
+        ],
+      ]));
+    });
+    it("conditional => op.IF_NOT_ERROR swapped", () => {
+      expect(optimizeBlock(flattenBc([
+        [
+          op.MATCH_STRING_IC, 0, [
+            [op.PUSH_NULL],
+          ], [
+            [op.PUSH_FAILED],
+          ],
+        ],
+        [
+          op.IF_NOT_ERROR, [
+            [op.ACCEPT_N, 1],
+          ], [
+            [op.FAIL, 0],
+          ],
+        ],
+      ]), "combine-with-IF_NOT_ERROR")).to.deep.equal(flattenBc([
+        [
+          op.MATCH_STRING_IC, 0, [
+            [op.PUSH_NULL],
+            [op.ACCEPT_N, 1],
+          ], [
+            [op.PUSH_FAILED],
+            [op.FAIL, 0],
+          ],
+        ],
+      ]));
+    });
+  });
+  describe("Optimize FAIL opcodes", () => {
+    it("to PUSH_FAILURE when SILENT_FAILS is on", () => {
+      expect(optimizeBlock([
+        op.SILENT_FAILS_ON,
+        op.FAIL, 1,
+        op.SILENT_FAILS_OFF,
+      ], "fail-in-silent").includes(op.PUSH_FAILED)).to.equal(true);
+    });
+    it("to NOP when discarded and SILENT_FAILS is on", () => {
+      expect(optimizeBlock([
+        op.SILENT_FAILS_ON,
+        op.FAIL, 1,
+        op.POP,
+        op.SILENT_FAILS_OFF,
+      ], "dead-fail-in-silent").length).to.be.lessThanOrEqual(2);
+    });
+  });
+  describe("Optimize PUSH/POP pairs", () => {
+    it("with separate POPs", () => {
+      expect(optimizeBlock([
+        op.PUSH_NULL,
+        op.PUSH_UNDEFINED,
+        op.PUSH_EMPTY_ARRAY,
+        op.PUSH_EMPTY_STRING,
+        op.POP,
+        op.POP,
+        op.POP,
+        op.POP,
+      ], "dead-push-pops")).to.deep.equal([]);
+    });
+    it("with POP_N", () => {
+      expect(optimizeBlock([
+        op.PUSH_NULL,
+        op.PUSH_UNDEFINED,
+        op.PUSH_EMPTY_ARRAY,
+        op.PUSH_EMPTY_STRING,
+        op.POP_N, 4,
+      ], "dead-push-pops")).to.deep.equal([]);
+    });
+  });
+  describe("kill useless POP_CURR_POS", () => {
+    it("when currPos is unchanged", () => {
+      expect(optimizeBlock([
+        op.PUSH_CURR_POS,
+        op.FAIL, 1,
+        op.POP,
+        op.POP_CURR_POS,
+      ], "unchanged-curr-pos").includes(op.POP_CURR_POS)).to.equal(false);
+    });
+    it("when currPos subsequently killed", () => {
+      expect(optimizeBlock([
+        op.PUSH_CURR_POS,
+        op.ACCEPT_N, 1,
+        op.PUSH_CURR_POS,
+        op.ACCEPT_N, 1,
+        op.PUSH_CURR_POS,
+        op.ACCEPT_N, 1,
+        op.POP,
+        op.POP_CURR_POS,
+        op.FAIL, 1,
+        op.POP,
+        op.POP,
+        op.POP_CURR_POS,
+        op.POP,
+        op.POP_CURR_POS,
+      ], "unchanged-curr-pos").filter(
+        b => b === op.POP_CURR_POS
+      ).length).to.equal(1);
+    });
+  });
+  describe("WHILE_NOT_FAILED", () => {
+    it("is removed when always fails", () => {
+      expect(optimizeBlock(flattenBc([
+        [op.PUSH_FAILED],
+        [op.WHILE_NOT_ERROR, [
+          [op.POP],
+          [op.ACCEPT_N, 1],
+        ]],
+        [op.POP],
+      ]), "dead-while-loop")).to.deep.equal([]);
+    });
+    it("is hoisted when one if branch always fails", () => {
+      expect(optimizeBlock(flattenBc([
+        [
+          op.MATCH_STRING_IC, 0, [
+            [op.ACCEPT_N, 1],
+          ], [
+            [op.PUSH_FAILED],
+          ],
+        ],
+        [op.WHILE_NOT_ERROR, [
+          [op.POP],
+          [
+            op.MATCH_STRING_IC, 0, [
+              [op.ACCEPT_N, 1],
+            ], [
+              [op.PUSH_FAILED],
+            ],
+          ],
+        ]],
+        [op.POP],
+      ]), "hoisted-while-loop")).to.deep.equal(flattenBc([
+        [
+          op.MATCH_STRING_IC, 0, [
+            [op.ACCEPT_N, 1],
+            [op.WHILE_NOT_ERROR, [
+              [op.POP],
+              [
+                op.MATCH_STRING_IC, 0, [
+                  [op.ACCEPT_N, 1],
+                ], [
+                  [op.PUSH_FAILED],
+                ],
+              ],
+            ]],
+          ], [
+            [op.PUSH_FAILED],
+          ],
+        ],
+        [op.POP],
+      ]));
+    });
+  });
+  describe("SILENT_FAILS", () => {
+    it("are killed when nested", () => {
+      expect(optimizeBlock([
+        op.SILENT_FAILS_ON,
+        op.SILENT_FAILS_ON,
+        op.RULE, 1,
+        op.SILENT_FAILS_OFF,
+        op.SILENT_FAILS_OFF,
+      ], "nested-silent")).to.be.deep.equal([
+        op.SILENT_FAILS_ON,
+        op.RULE, 1,
+        op.SILENT_FAILS_OFF,
+      ]);
+    });
+  });
+  describe("logging", () => {
+    const spy = jest.spyOn(console, "log");
+    expect(optimizeBlock([
+      op.PUSH_NULL,
+      op.POP,
+    ], "logging", true)).to.deep.equal([]);
+    expect(spy.mock.calls.length).to.be.equal(4);
+  });
+});


### PR DESCRIPTION
This stack implements a framework for performing optimizations to the bytecode (file `interp-state.js`), and then implements a number of fairly simple transformations via a new pass, `optimize-bytecode.js`.

After the initial commits of `interp-state.js` and its tests, I've committed each optimization separately, with an "artifacts" diff to show how it affects `lib/parser.js`, to make it easy to review/discuss. I plan to remove all the artifacts diffs, and add a single "Build Artifacts" commit once the pull request settles down.

Most of what I've implemented so far is pretty local, and depends on recognizing simple patterns (like PUSH_NULL, POP). If this framework is accepted I plan to add some more global analysis, so that eg an unused PUSH_CURR_POS can be removed, even when the POP is hidden behind a lot of more complex code; or immediately dropping unused elements from a plucked sequence, rather than generating them all, then ignoring the ones that aren't plucked (obviously their side effects still have to be executed); or not bothering to build an array for a sequence wrapped in a `text` node.
