### PR TITLE
Add peggy.code-workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn.lock
 .nyc_output
 *.map
 docs/_site
+.vscode/

--- a/.npmignore
+++ b/.npmignore
@@ -20,6 +20,7 @@ rollup.config.mjs
 src
 test
 tools
-tsconfig.json
+tsconfig*.json
 web-test/
 yarn.lock
+peggy.code-workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Released: TBD
 
 ### Minor Changes
 
+- [#432](https://github.com/peggyjs/peggy/pull/432) Add peggy.code-workspace
 - [#451](https://github.com/peggyjs/peggy/pull/451) Make stack.js ts clean
 - [#439](https://github.com/peggyjs/peggy/pull/439) Make peg$computePosDetails a little faster
 - [#437](https://github.com/peggyjs/peggy/pull/437) Better type checking for visitor

--- a/peggy.code-workspace
+++ b/peggy.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"eslint.format.enable": true,
+		"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+	},
+	"extensions": {
+		"recommendations": [
+			"dbaeumer.vscode-eslint",
+			"peggyjs.peggy-language"
+		]
+	}
+}


### PR DESCRIPTION
See discussion on #42 

It turns out that you can include recommended extensions directly in the .code-workspace file, so I didn't need to add a .vscode/extensions.json file.

To test this:

 - I downloaded the insiders build of vscode. This has its own global settings, and list of installed extensions, so I was effectively starting from a fresh vscode install
 - I cloned a fresh copy of `@markw65/peggy`, and checked out `origin/peggy-code-workspace`.
 - I ran `npm install`, then opened the peggy folder from vscode-insiders.
 - It popped up a non-blocking notice that the folder contains a code-workspace file, and offered to open it, which I did.
 - It popped up a non-blocking notice asking if I wanted to install the recommended extensions, which I did (there was also an option to just show the recommended extensions).
 - I opened `generate-js.js`, and made some changes that eslint didn't like, and hit Shift-Option-F to format, and it fixed them for me, without modifying the rest of the file.
 - To confirm that the code-workspace settings can be overridden, I went to settings, and set `defaulltFormatter` to `Typescript and Javascript Language Features` in the `peggy` folder. This created a .vscode/settings.json file (which was hidden from git by the new .gitignore). I formatted `generate-js.js` again, and it changed lots of things in ways that lint didn't like (so that formatter isn't actually useful, but demonstrates that people can still choose to use something other than the default).

Given that settings can be overridden via .vscode/settings.json, I'm inclined to turn on `Format on Save` in `peggy.code-workspace` too.