### PR TITLE
Get rid of tsd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Released: TBD
 
 ### Minor Changes
 
+- [#436](https://github.com/peggyjs/peggy/pull/436) Get rid of tsd
 - [#430](https://github.com/peggyjs/peggy/pull/430) Make generate-js.js ts clean
 - [#446](https://github.com/peggyjs/peggy/pull/446) Add a right-associative `ExponentiationExpression` rule (operator `**`) to `javascript.pegjs` example grammar.
 - [#427](https://github.com/peggyjs/peggy/pull/427) Avoid double extraction of

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "source-map": "^0.8.0-beta.0",
         "terser": "^5.19.2",
         "ts-jest": "^29.1.1",
-        "tsd": "^0.28.1",
         "tslib": "^2.6.1",
         "typescript": "^5.1.6"
       },
@@ -1621,12 +1620,6 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@tsd/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-YQi2lvZSI+xidKeUjlbv6b6Zw7qB3aXHw5oGJLs5OOGAEqKIOvz5UIAkWyg0bJbkSUWPBEtaOHpVxU4EYBO1Jg==",
-      "dev": true
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
@@ -1673,16 +1666,6 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
       "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
       "dev": true
-    },
-    "node_modules/@types/eslint": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
-      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.1",
@@ -1739,22 +1722,10 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
-    "node_modules/@types/minimist": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-      "dev": true
-    },
     "node_modules/@types/node": {
       "version": "20.4.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
       "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==",
-      "dev": true
-    },
-    "node_modules/@types/normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -2115,15 +2086,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -2400,23 +2362,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2704,40 +2649,6 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decamelize-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-      "dev": true,
-      "dependencies": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decamelize-keys/node_modules/map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
@@ -2974,34 +2885,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/eslint-formatter-pretty": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
-      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "^7.2.13",
-        "ansi-escapes": "^4.2.1",
-        "chalk": "^4.1.0",
-        "eslint-rule-docs": "^1.1.5",
-        "log-symbols": "^4.0.0",
-        "plur": "^4.0.0",
-        "string-width": "^4.2.0",
-        "supports-hyperlinks": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-rule-docs": {
-      "version": "1.1.235",
-      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
-      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
-      "dev": true
     },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
@@ -3649,15 +3532,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/hard-rejection": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3702,36 +3576,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/hosted-git-info/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -3829,15 +3673,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3861,15 +3696,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/irregular-plurals": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.5.0.tgz",
-      "integrity": "sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-arrayish": {
@@ -3968,15 +3794,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -3993,18 +3810,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4811,15 +4616,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4890,22 +4686,6 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
     },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/loupe": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
@@ -4966,18 +4746,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/map-obj": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/matched": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/matched/-/matched-5.0.1.tgz",
@@ -5021,53 +4789,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/meow": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize": "^1.2.0",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/meow/node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/meow/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/merge-descriptors": {
@@ -5155,15 +4876,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -5174,20 +4886,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimist-options": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "dev": true,
-      "dependencies": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/minipass": {
@@ -5258,21 +4956,6 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "~1.0.31"
-      }
-    },
-    "node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/normalize-path": {
@@ -5609,21 +5292,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/plur": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
-      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
-      "dev": true,
-      "dependencies": {
-        "irregular-plurals": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5751,15 +5419,6 @@
         }
       ]
     },
-    "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -5790,135 +5449,6 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
-    "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "dev": true,
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "dev": true
-    },
-    "node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -5929,19 +5459,6 @@
         "inherits": "~2.0.1",
         "isarray": "0.0.1",
         "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/require-directory": {
@@ -6348,38 +5865,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "dev": true,
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
-      "dev": true
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6507,18 +5992,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6538,19 +6011,6 @@
       "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -6742,15 +6202,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
@@ -6804,27 +6255,6 @@
         "esbuild": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tsd": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.28.1.tgz",
-      "integrity": "sha512-FeYrfJ05QgEMW/qOukNCr4fAJHww4SaKnivAXRv4g5kj4FeLpNV7zH4dorzB9zAfVX4wmA7zWu/wQf7kkcvfbw==",
-      "dev": true,
-      "dependencies": {
-        "@tsd/typescript": "~5.0.2",
-        "eslint-formatter-pretty": "^4.1.0",
-        "globby": "^11.0.1",
-        "jest-diff": "^29.0.3",
-        "meow": "^9.0.0",
-        "path-exists": "^4.0.0",
-        "read-pkg-up": "^7.0.0"
-      },
-      "bin": {
-        "tsd": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
       }
     },
     "node_modules/tslib": {
@@ -6983,16 +6413,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
-    },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -76,16 +76,12 @@
     "source-map": "^0.8.0-beta.0",
     "terser": "^5.19.2",
     "ts-jest": "^29.1.1",
-    "tsd": "^0.28.1",
     "tslib": "^2.6.1",
     "typescript": "^5.1.6"
   },
   "dependencies": {
     "commander": "^11.0.0",
     "source-map-generator": "0.8.0"
-  },
-  "tsd": {
-    "directory": "test/types"
   },
   "engines": {
     "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "examples": "node bin/peggy.js -c docs/js/options.js docs/js/examples.peggy",
     "set_version": "node ./tools/set_version",
     "lint": "eslint . --ext js,ts,mjs",
-    "ts": "tsc --build tsconfig.json",
+    "ts": "tsc --build tsconfig.json test/tsconfig.json",
     "docs": "cd docs && npm run build",
     "test": "jest",
     "test:web": "cd web-test && npm test",

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -9,12 +9,13 @@
     "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "outDir": "./build/ts/",                        /* Redirect output structure to the directory. */
     "removeComments": true,                         /* Do not emit comments to output. */
-    "rootDir": "./",                                /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDirs": ["./", "../bin"],                  /* Specify the root directories of input files. Use to control the output directory structure with --outDir. */
     "skipLibCheck": true,                           /* Skip type checking of declaration files. */
     "sourceMap": true,                              /* Generates corresponding '.map' file. */
     "strict": true,                                 /* Enable all strict type-checking options. */
-    "target": "es5"                                 /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es5",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
+    "noEmit": true
 
   /* over time we will enable these */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -1,5 +1,4 @@
 import * as peggy from "../..";
-import tsd, { expectType } from "tsd";
 import type { SourceNode } from "source-map-generator";
 import { join } from "path";
 import { readFileSync } from "fs";
@@ -15,6 +14,15 @@ const src = readFileSync(
 );
 
 const problems: peggy.Problem[] = [];
+
+function expectExact<T>() {
+  return function<U extends T>(
+    tValue: U
+  ): [T] extends [U] ? () => U : ["Argument of type", U, "does not match", T] {
+    // @ts-expect-error Just for type checking
+    return () => tValue;
+  };
+}
 
 function error(
   stage: peggy.Stage,
@@ -45,34 +53,34 @@ function warning(
 
 describe("peg.d.ts", () => {
   it("executes a grammar", () => {
-    expectType<string>(src);
+    expectExact<string>()(src)();
     expect(src.length).toBeGreaterThan(0);
 
     const parser = peggy.generate(src);
-    expectType<peggy.Parser>(parser);
+    expectExact<peggy.Parser>()(parser)();
 
     let res = parser.parse("1\n");
-    expectType<any>(res);
+    expectExact<any>()(res)();
     expect(res).toStrictEqual([1]);
 
     res = parser.parse("buzz\n11\nfizz\n", { start: 10 });
     expect(res).toStrictEqual(["buzz", 11, "fizz"]);
 
     res = peggy.generate("foo='a'", { unknown: { more: 12 } });
-    expectType<peggy.Parser>(parser);
+    expectExact<peggy.Parser>()(parser)();
   });
 
   it("types SyntaxError correctly", () => {
     const parser = peggy.generate(src);
 
-    expectType<peggy.parser.SyntaxErrorConstructor>(parser.SyntaxError);
-    expectType<peggy.parser.SyntaxError>(new parser.SyntaxError("", null, null, {
+    expectExact<peggy.parser.SyntaxErrorConstructor>()(parser.SyntaxError)();
+    expectExact<peggy.parser.SyntaxError>()(new parser.SyntaxError("", null, null, {
       source: null,
       start: { line: 0, column: 0, offset: 0 },
       end: { line: 0, column: 0, offset: 0 },
-    }));
+    }))();
 
-    expectType<string>(parser.SyntaxError.buildMessage([], ""));
+    expectExact<string>()(parser.SyntaxError.buildMessage([], ""))();
   });
 
   it("takes a valid tracer", () => {
@@ -82,18 +90,18 @@ describe("peg.d.ts", () => {
       info,
       warning,
     });
-    expectType<peggy.Parser>(parser);
+    expectExact<peggy.Parser>()(parser)();
 
     parser.parse(" /**/ 1\n", {
       startRule: "top",
       tracer: {
         trace(event) {
-          expectType<peggy.ParserTracerEvent>(event);
-          expectType<"rule.enter" | "rule.fail" | "rule.match">(event.type);
-          expectType<string>(event.rule);
-          expectType<peggy.LocationRange>(event.location);
+          expectExact<peggy.ParserTracerEvent>()(event)();
+          expectExact<"rule.enter" | "rule.fail" | "rule.match">()(event.type)();
+          expectExact<string>()(event.rule)();
+          expectExact<peggy.LocationRange>()(event.location)();
           if (event.type === "rule.match") {
-            expectType<any>(event.result);
+            expectExact<any>()(event.result)();
           }
         },
       },
@@ -102,55 +110,55 @@ describe("peg.d.ts", () => {
 
   it("takes an output and grammarSource", () => {
     const p1 = peggy.generate(src, { output: "parser", grammarSource: "src" });
-    expectType<peggy.Parser>(p1);
+    expectExact<peggy.Parser>()(p1)();
 
     const p2 = peggy.generate(src, { output: "source", grammarSource: { foo: "src" } });
-    expectType<string>(p2);
+    expectExact<string>()(p2)();
 
     const p3 = peggy.generate(src, { output: "ast", grammarSource: { foo: "src" } });
-    expectType<peggy.ast.Grammar>(p3);
+    expectExact<peggy.ast.Grammar>()(p3)();
   });
 
   it("generates a source map", () => {
     const p1 = peggy.generate(src, { output: "source" });
-    expectType<string>(p1);
+    expectExact<string>()(p1)();
 
     const p2 = peggy.generate(src, {
       output: "source-and-map",
       grammarSource: "src.peggy",
     });
-    expectType<SourceNode>(p2);
+    expectExact<SourceNode>()(p2)();
 
     const p3 = peggy.generate(src, {
       output: true as boolean ? "source-and-map" : "source",
       grammarSource: "src.peggy",
     });
-    expectType<SourceNode | string>(p3);
+    expectExact<SourceNode | string>()(p3)();
 
     const p4 = peggy.generate(src, {
       output: "source-with-inline-map",
       grammarSource: "src.peggy",
     });
-    expectType<string>(p4);
+    expectExact<string>()(p4)();
   });
 
   it("compiles with source map", () => {
     const ast = peggy.parser.parse(src);
-    expectType<peggy.ast.Grammar>(ast);
+    expectExact<peggy.ast.Grammar>()(ast)();
 
     const p1 = peggy.compiler.compile(
       ast,
       peggy.compiler.passes,
       { output: "source" }
     );
-    expectType<string>(p1);
+    expectExact<string>()(p1)();
 
     const p2 = peggy.compiler.compile(
       ast,
       peggy.compiler.passes,
       { output: "source-and-map", grammarSource: "src.peggy" }
     );
-    expectType<SourceNode>(p2);
+    expectExact<SourceNode>()(p2)();
 
     const p3 = peggy.compiler.compile(
       ast,
@@ -160,7 +168,7 @@ describe("peg.d.ts", () => {
         grammarSource: "src.peggy",
       }
     );
-    expectType<SourceNode | string>(p3);
+    expectExact<SourceNode | string>()(p3)();
 
     const p4 = peggy.compiler.compile(
       ast,
@@ -170,12 +178,12 @@ describe("peg.d.ts", () => {
         grammarSource: "src.peggy",
       }
     );
-    expectType<string>(p4);
+    expectExact<string>()(p4)();
   });
 
   it("creates an AST", () => {
     const grammar = peggy.parser.parse(src);
-    expectType<peggy.ast.Grammar>(grammar);
+    expectExact<peggy.ast.Grammar>()(grammar)();
     const visited: { [typ: string]: number } = {};
     function add(typ: string): void {
       if (!visited[typ]) {
@@ -188,25 +196,27 @@ describe("peg.d.ts", () => {
     const visit = peggy.compiler.visitor.build({
       grammar(node) {
         add(node.type);
-        expectType<peggy.ast.Grammar>(node);
-        expectType<"grammar">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<peggy.ast.TopLevelInitializer | undefined>(
+        expectExact<peggy.ast.Grammar>()(node)();
+        expectExact<"grammar">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<peggy.ast.TopLevelInitializer | undefined>()(
           node.topLevelInitializer
-        );
-        expectType<peggy.ast.Initializer | undefined>(node.initializer);
-        expectType<peggy.ast.Rule[]>(node.rules);
-        expectType<string[] | undefined>(node.literals);
-        expectType<peggy.ast.GrammarCharacterClass[] | undefined>(node.classes);
-        expectType<peggy.ast.GrammarExpectation[] | undefined>(
+        )();
+        expectExact<peggy.ast.Initializer | undefined>()(node.initializer)();
+        expectExact<peggy.ast.Rule[]>()(node.rules)();
+        expectExact<string[] | undefined>()(node.literals)();
+        expectExact<peggy.ast.GrammarCharacterClass[] | undefined>()(
+          node.classes
+        )();
+        expectExact<peggy.ast.GrammarExpectation[] | undefined>()(
           node.expectations
-        );
-        expectType<peggy.ast.FunctionConst[] | undefined>(
+        )();
+        expectExact<peggy.ast.FunctionConst[] | undefined>()(
           node.functions
-        );
-        expectType<peggy.LocationRange[] | undefined>(
+        )();
+        expectExact<peggy.LocationRange[] | undefined>()(
           node.locations
-        );
+        )();
 
         if (node.topLevelInitializer) {
           visit(node.topLevelInitializer);
@@ -218,215 +228,219 @@ describe("peg.d.ts", () => {
       },
       top_level_initializer(node) {
         add(node.type);
-        expectType<peggy.ast.TopLevelInitializer>(node);
-        expectType<"top_level_initializer">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<string>(node.code);
-        expectType<peggy.LocationRange>(node.codeLocation);
+        expectExact<peggy.ast.TopLevelInitializer>()(node)();
+        expectExact<"top_level_initializer">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<string>()(node.code)();
+        expectExact<peggy.LocationRange>()(node.codeLocation)();
       },
       initializer(node) {
         add(node.type);
-        expectType<peggy.ast.Initializer>(node);
-        expectType<"initializer">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<string>(node.code);
-        expectType<peggy.LocationRange>(node.codeLocation);
+        expectExact<peggy.ast.Initializer>()(node)();
+        expectExact<"initializer">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<string>()(node.code)();
+        expectExact<peggy.LocationRange>()(node.codeLocation)();
       },
       rule(node) {
         add(node.type);
-        expectType<peggy.ast.Rule>(node);
-        expectType<"rule">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<string>(node.name);
-        expectType<peggy.LocationRange>(node.nameLocation);
-        expectType<peggy.ast.Expression | peggy.ast.Named>(node.expression);
+        expectExact<peggy.ast.Rule>()(node)();
+        expectExact<"rule">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<string>()(node.name)();
+        expectExact<peggy.LocationRange>()(node.nameLocation)();
+        expectExact<peggy.ast.Expression | peggy.ast.Named>()(
+          node.expression
+        )();
         visit(node.expression);
       },
       named(node) {
         add(node.type);
-        expectType<peggy.ast.Named>(node);
-        expectType<"named">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<string>(node.name);
-        expectType<peggy.ast.Expression>(node.expression);
+        expectExact<peggy.ast.Named>()(node)();
+        expectExact<"named">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<string>()(node.name)();
+        expectExact<peggy.ast.Expression>()(node.expression)();
         visit(node.expression);
       },
       choice(node) {
         add(node.type);
-        expectType<peggy.ast.Choice>(node);
-        expectType<"choice">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<peggy.ast.Alternative[]>(node.alternatives);
+        expectExact<peggy.ast.Choice>()(node)();
+        expectExact<"choice">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<peggy.ast.Alternative[]>()(node.alternatives)();
         node.alternatives.forEach(visit);
       },
       action(node) {
         add(node.type);
-        expectType<peggy.ast.Action>(node);
-        expectType<"action">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<string>(node.code);
-        expectType<peggy.LocationRange>(node.codeLocation);
-        expectType<
+        expectExact<peggy.ast.Action>()(node)();
+        expectExact<"action">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<string>()(node.code)();
+        expectExact<peggy.LocationRange>()(node.codeLocation)();
+        expectExact<
           peggy.ast.Labeled |
           peggy.ast.Prefixed |
           peggy.ast.Primary |
           peggy.ast.Repeated |
           peggy.ast.Sequence |
-          peggy.ast.Suffixed>(node.expression);
+          peggy.ast.Suffixed>()(node.expression)();
         visit(node.expression);
       },
       sequence(node) {
         add(node.type);
-        expectType<peggy.ast.Sequence>(node);
-        expectType<"sequence">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<peggy.ast.Element[]>(node.elements);
+        expectExact<peggy.ast.Sequence>()(node)();
+        expectExact<"sequence">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<peggy.ast.Element[]>()(node.elements)();
         node.elements.forEach(visit);
       },
       labeled(node) {
         add(node.type);
-        expectType<peggy.ast.Labeled>(node);
-        expectType<"labeled">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<true | undefined>(node.pick);
-        expectType<string | null>(node.label);
-        expectType<peggy.LocationRange>(node.labelLocation);
-        expectType<
+        expectExact<peggy.ast.Labeled>()(node)();
+        expectExact<"labeled">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<true | undefined>()(node.pick)();
+        expectExact<string | null>()(node.label)();
+        expectExact<peggy.LocationRange>()(node.labelLocation)();
+        expectExact<
           peggy.ast.Prefixed |
           peggy.ast.Primary |
           peggy.ast.Repeated |
-          peggy.ast.Suffixed>(node.expression);
+          peggy.ast.Suffixed>()(node.expression)();
         visit(node.expression);
       },
       text(node) {
         add(node.type);
-        expectType<peggy.ast.Prefixed>(node);
-        expectType<"simple_and" | "simple_not" | "text">(node.type);
+        expectExact<peggy.ast.Prefixed>()(node)();
+        expectExact<"simple_and" | "simple_not" | "text">()(node.type)();
         expect(node.type).toBe("text");
-        expectType<peggy.LocationRange>(node.location);
-        expectType<
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<
           peggy.ast.Primary |
           peggy.ast.Repeated |
-          peggy.ast.Suffixed>(node.expression);
+          peggy.ast.Suffixed>()(node.expression)();
         visit(node.expression);
       },
       simple_and(node) {
         add(node.type);
-        expectType<peggy.ast.Prefixed>(node);
-        expectType<"simple_and" | "simple_not" | "text">(node.type);
+        expectExact<peggy.ast.Prefixed>()(node)();
+        expectExact<"simple_and" | "simple_not" | "text">()(node.type)();
         expect(node.type).toBe("simple_and");
-        expectType<peggy.LocationRange>(node.location);
-        expectType<
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<
           peggy.ast.Primary |
           peggy.ast.Repeated |
-          peggy.ast.Suffixed>(node.expression);
+          peggy.ast.Suffixed>()(node.expression)();
         visit(node.expression);
       },
       simple_not(node) {
         add(node.type);
-        expectType<peggy.ast.Prefixed>(node);
-        expectType<"simple_and" | "simple_not" | "text">(node.type);
+        expectExact<peggy.ast.Prefixed>()(node)();
+        expectExact<"simple_and" | "simple_not" | "text">()(node.type)();
         expect(node.type).toBe("simple_not");
-        expectType<
+        expectExact<
           peggy.ast.Primary |
           peggy.ast.Repeated |
-          peggy.ast.Suffixed>(node.expression);
+          peggy.ast.Suffixed>()(node.expression)();
         visit(node.expression);
       },
       optional(node) {
         add(node.type);
-        expectType<peggy.ast.Suffixed>(node);
-        expectType<"one_or_more" | "optional" | "zero_or_more">(node.type);
+        expectExact<peggy.ast.Suffixed>()(node)();
+        expectExact<"one_or_more" | "optional" | "zero_or_more">()(node.type)();
         expect(node.type).toBe("optional");
-        expectType<peggy.LocationRange>(node.location);
-        expectType<peggy.ast.Primary>(node.expression);
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<peggy.ast.Primary>()(node.expression)();
         visit(node.expression);
       },
       zero_or_more(node) {
         add(node.type);
-        expectType<peggy.ast.Suffixed>(node);
-        expectType<"one_or_more" | "optional" | "zero_or_more">(node.type);
+        expectExact<peggy.ast.Suffixed>()(node)();
+        expectExact<"one_or_more" | "optional" | "zero_or_more">()(node.type)();
         expect(node.type).toBe("zero_or_more");
-        expectType<peggy.LocationRange>(node.location);
-        expectType<peggy.ast.Primary>(node.expression);
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<peggy.ast.Primary>()(node.expression)();
         visit(node.expression);
       },
       one_or_more(node) {
         add(node.type);
-        expectType<peggy.ast.Suffixed>(node);
-        expectType<"one_or_more" | "optional" | "zero_or_more">(node.type);
+        expectExact<peggy.ast.Suffixed>()(node)();
+        expectExact<"one_or_more" | "optional" | "zero_or_more">()(node.type)();
         expect(node.type).toBe("one_or_more");
-        expectType<peggy.LocationRange>(node.location);
-        expectType<peggy.ast.Primary>(node.expression);
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<peggy.ast.Primary>()(node.expression)();
         visit(node.expression);
       },
       repeated(node) {
         add(node.type);
-        expectType<peggy.ast.Repeated>(node);
-        expectType<"repeated">(node.type);
+        expectExact<peggy.ast.Repeated>()(node)();
+        expectExact<"repeated">()(node.type)();
         expect(node.type).toBe("repeated");
-        expectType<peggy.LocationRange>(node.location);
-        expectType<peggy.ast.RepeatedBoundary | null>(node.min);
-        expectType<peggy.ast.RepeatedBoundary>(node.max);
-        expectType<peggy.ast.Expression | null>(node.delimiter);
-        expectType<peggy.ast.Primary>(node.expression);
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<peggy.ast.RepeatedBoundary | null>()(node.min)();
+        expectExact<peggy.ast.RepeatedBoundary>()(node.max)();
+        expectExact<peggy.ast.Expression | null>()(node.delimiter)();
+        expectExact<peggy.ast.Primary>()(node.expression)();
         visit(node.expression);
       },
       group(node) {
         add(node.type);
-        expectType<peggy.ast.Group>(node);
-        expectType<"group">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<peggy.ast.Labeled | peggy.ast.Sequence>(node.expression);
+        expectExact<peggy.ast.Group>()(node)();
+        expectExact<"group">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<peggy.ast.Labeled | peggy.ast.Sequence>()(
+          node.expression
+        )();
         visit(node.expression);
       },
       semantic_and(node) {
         add(node.type);
-        expectType<peggy.ast.SemanticPredicate>(node);
-        expectType<"semantic_and" | "semantic_not">(node.type);
+        expectExact<peggy.ast.SemanticPredicate>()(node)();
+        expectExact<"semantic_and" | "semantic_not">()(node.type)();
         expect(node.type).toBe("semantic_and");
-        expectType<peggy.LocationRange>(node.location);
-        expectType<string>(node.code);
-        expectType<peggy.LocationRange>(node.codeLocation);
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<string>()(node.code)();
+        expectExact<peggy.LocationRange>()(node.codeLocation)();
       },
       semantic_not(node) {
         add(node.type);
-        expectType<peggy.ast.SemanticPredicate>(node);
-        expectType<"semantic_and" | "semantic_not">(node.type);
+        expectExact<peggy.ast.SemanticPredicate>()(node)();
+        expectExact<"semantic_and" | "semantic_not">()(node.type)();
         expect(node.type).toBe("semantic_not");
-        expectType<peggy.LocationRange>(node.location);
-        expectType<string>(node.code);
-        expectType<peggy.LocationRange>(node.codeLocation);
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<string>()(node.code)();
+        expectExact<peggy.LocationRange>()(node.codeLocation)();
       },
       rule_ref(node) {
         add(node.type);
-        expectType<peggy.ast.RuleReference>(node);
-        expectType<"rule_ref">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<string>(node.name);
+        expectExact<peggy.ast.RuleReference>()(node)();
+        expectExact<"rule_ref">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<string>()(node.name)();
       },
       literal(node) {
         add(node.type);
-        expectType<peggy.ast.Literal>(node);
-        expectType<"literal">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<string>(node.value);
-        expectType<boolean>(node.ignoreCase);
+        expectExact<peggy.ast.Literal>()(node)();
+        expectExact<"literal">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<string>()(node.value)();
+        expectExact<boolean>()(node.ignoreCase)();
       },
       class(node) {
         add(node.type);
-        expectType<peggy.ast.CharacterClass>(node);
-        expectType<"class">(node.type);
-        expectType<peggy.LocationRange>(node.location);
-        expectType<boolean>(node.inverted);
-        expectType<boolean>(node.ignoreCase);
-        expectType<(string[] | string)[]>(node.parts);
+        expectExact<peggy.ast.CharacterClass>()(node)();
+        expectExact<"class">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
+        expectExact<boolean>()(node.inverted)();
+        expectExact<boolean>()(node.ignoreCase)();
+        expectExact<(string[] | string)[]>()(node.parts)();
       },
       any(node) {
         add(node.type);
-        expectType<peggy.ast.Any>(node);
-        expectType<"any">(node.type);
-        expectType<peggy.LocationRange>(node.location);
+        expectExact<peggy.ast.Any>()(node)();
+        expectExact<"any">()(node.type)();
+        expectExact<peggy.LocationRange>()(node.location)();
       },
     });
 
@@ -464,7 +478,7 @@ describe("peg.d.ts", () => {
       grammarSource: "it compiles",
       reservedWords: peggy.RESERVED_WORDS.slice(),
     });
-    expectType<peggy.ast.Grammar>(ast);
+    expectExact<peggy.ast.Grammar>()(ast)();
     const parser = peggy.compiler.compile(
       ast,
       peggy.compiler.passes,
@@ -474,26 +488,8 @@ describe("peg.d.ts", () => {
         warning,
       }
     );
-    expectType<peggy.Parser>(parser);
-    expectType<peggy.ast.MatchResult | undefined>(ast.rules[0].match);
+    expectExact<peggy.Parser>()(parser)();
+    expectExact<peggy.ast.MatchResult | undefined>()(ast.rules[0].match)();
     expect(ast.rules[0].match).toBe(0);
-  });
-});
-
-describe("run tsd", () => {
-  it("has no strict diagnostic warnings", async() => {
-    // This is slow because it causes another typescript compilation, but
-    // tsd catches things like ensuring string types are narrowed to their
-    // set of correct choices.  It could be that setting a few more flags in
-    // tsconfig.json would also catch these.
-    //
-    // To check, change this line:
-    // expectType<"text" | "simple_and" | "simple_not">(node.type);
-    // to:
-    // expectType<string>(node.type);
-    const diagnostics = await tsd();
-    if (diagnostics.length > 0) {
-      throw new Error(JSON.stringify(diagnostics));
-    }
   });
 });


### PR DESCRIPTION
Get rid of `tsd` by rewriting `expectType` in a way that lets vanilla typescript check the types with the same precision.