### PR TITLE
Better type checking for visitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Released: TBD
 
 ### Minor Changes
 
+- [#437](https://github.com/peggyjs/peggy/pull/437) Better type checking for visitor
 - [#435](https://github.com/peggyjs/peggy/pull/435) Setup tsconfig to detect use of library functions from es6 or later
 - [#438](https://github.com/peggyjs/peggy/pull/438) Make test build deterministic
 - [#436](https://github.com/peggyjs/peggy/pull/436) Get rid of tsd

--- a/lib/peg.d.ts
+++ b/lib/peg.d.ts
@@ -68,6 +68,15 @@ declare namespace ast {
     | GrammarCharacterClass & { type: "class" }
     ;
 
+  type AllNodes =
+    | Expression
+    | Grammar
+    | Initializer
+    | Named
+    | Rule
+    | TopLevelInitializer
+    ;
+
   /** The main Peggy AST class returned by the parser. */
   interface Grammar extends Node<"grammar"> {
     /** Initializer that run once when importing generated parser module. */

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -184,14 +184,7 @@ describe("peg.d.ts", () => {
   it("creates an AST", () => {
     const grammar = peggy.parser.parse(src);
     expectExact<peggy.ast.Grammar>()(grammar)();
-    type AstTypes = (
-      peggy.ast.Expression |
-      peggy.ast.Grammar |
-      peggy.ast.Initializer |
-      peggy.ast.Named |
-      peggy.ast.Rule |
-      peggy.ast.TopLevelInitializer
-    )["type"];
+    type AstTypes = peggy.ast.AllNodes["type"];
     const visited: { [typ in AstTypes]?: number } = {};
     function add(typ: AstTypes): void {
       const v = visited[typ] || 0;
@@ -449,16 +442,10 @@ describe("peg.d.ts", () => {
       },
     });
 
-    // Extract the visitor object
-    type VisitorArg
-    = typeof visit extends peggy.compiler.visitor.Visitor<infer U>
-      ? U : never;
-
-    // Extract the functions that don't return `any`
-    type DefinedKeys = keyof {
-      [K in keyof VisitorArg as VisitorArg[K] extends (...args: any) => any
-        ? unknown extends ReturnType<VisitorArg[K]> ? never : K : never]: true
-    };
+    // Extract the keys from the visitor object
+    type DefinedKeys
+      = typeof visit extends peggy.compiler.visitor.Visitor<infer U>
+      ? keyof U : never;
 
     visit(grammar);
 
@@ -486,11 +473,11 @@ describe("peg.d.ts", () => {
       "text",
       "top_level_initializer",
       "zero_or_more",
-    ] satisfies AstTypes[];
+    ] satisfies AstTypes[] satisfies DefinedKeys[];
 
     expect(Object.keys(visited).sort()).toStrictEqual(astKeys);
-    expectType<AstTypes[]>(astKeys);
-    expectType<DefinedKeys[]>(astKeys);
+    expectExact<AstTypes[]>()(astKeys)();
+    expectExact<DefinedKeys[]>()(astKeys)();
   });
 
   it("compiles", () => {

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -184,13 +184,18 @@ describe("peg.d.ts", () => {
   it("creates an AST", () => {
     const grammar = peggy.parser.parse(src);
     expectExact<peggy.ast.Grammar>()(grammar)();
-    const visited: { [typ: string]: number } = {};
-    function add(typ: string): void {
-      if (!visited[typ]) {
-        visited[typ] = 1;
-      } else {
-        visited[typ]++;
-      }
+    type AstTypes = (
+      peggy.ast.Expression |
+      peggy.ast.Grammar |
+      peggy.ast.Initializer |
+      peggy.ast.Named |
+      peggy.ast.Rule |
+      peggy.ast.TopLevelInitializer
+    )["type"];
+    const visited: { [typ in AstTypes]?: number } = {};
+    function add(typ: AstTypes): void {
+      const v = visited[typ] || 0;
+      visited[typ] = v + 1;
     }
 
     const visit = peggy.compiler.visitor.build({
@@ -446,7 +451,7 @@ describe("peg.d.ts", () => {
 
     visit(grammar);
 
-    expect(Object.keys(visited).sort()).toStrictEqual([
+    const astKeys = [
       "action",
       "any",
       "choice",
@@ -470,7 +475,12 @@ describe("peg.d.ts", () => {
       "text",
       "top_level_initializer",
       "zero_or_more",
-    ]);
+    ] as const;
+
+    expect(Object.keys(visited).sort()).toStrictEqual(astKeys);
+    for (const key of astKeys) {
+      expectType<AstTypes>(key);
+    }
   });
 
   it("compiles", () => {

--- a/test/types/peg.test-d.ts
+++ b/test/types/peg.test-d.ts
@@ -449,6 +449,17 @@ describe("peg.d.ts", () => {
       },
     });
 
+    // Extract the visitor object
+    type VisitorArg
+    = typeof visit extends peggy.compiler.visitor.Visitor<infer U>
+      ? U : never;
+
+    // Extract the functions that don't return `any`
+    type DefinedKeys = keyof {
+      [K in keyof VisitorArg as VisitorArg[K] extends (...args: any) => any
+        ? unknown extends ReturnType<VisitorArg[K]> ? never : K : never]: true
+    };
+
     visit(grammar);
 
     const astKeys = [
@@ -475,12 +486,11 @@ describe("peg.d.ts", () => {
       "text",
       "top_level_initializer",
       "zero_or_more",
-    ] as const;
+    ] satisfies AstTypes[];
 
     expect(Object.keys(visited).sort()).toStrictEqual(astKeys);
-    for (const key of astKeys) {
-      expectType<AstTypes>(key);
-    }
+    expectType<AstTypes[]>(astKeys);
+    expectType<DefinedKeys[]>(astKeys);
   });
 
   it("compiles", () => {


### PR DESCRIPTION
I noticed some of the checking was just `string` rather than the actual node types.

This ensures that every node type is actually implemented in the visitor by checking that the set of "visited" types matches the set of declared types.

It looks like we could also just look at `ReturnType<typeof visit>` which will be `any` if we missed any node types in the visitor, and `void` otherwise. But it would be hard (I think) to generate a meaningful error beyond "not all the node types were handled".