### PR TITLE
Fix a bug with named NEVER_MATCH expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Released: TBD (Not before 2025-05-01)
 - Small measures to try to get `deno run -A npm:peggy` to work.  We will not
   know if these were successful until the package is published next.  Testing
   with `--format es -t foo` will still not work in Deno.
+- Fix a bug with named NEVER_MATCH expressions.
+  [#454](https://github.com/peggyjs/peggy/pull/454)
 
 ### Documentation
 

--- a/docs/js/examples.js
+++ b/docs/js/examples.js
@@ -210,7 +210,6 @@ function peg$parse(input, options) {
   const peg$e12 = peg$literalExpectation("c", false);
   const peg$e13 = peg$classExpectation([["a", "c"]], false, false);
   const peg$e14 = peg$literalExpectation("f", false);
-  const peg$e15 = peg$otherExpectation("The rest of the input");
 
   function peg$f0(match, rest) {    return {match, rest};  }
   function peg$f1(match, rest) {    return {match, rest};  }
@@ -1594,8 +1593,6 @@ function peg$parse(input, options) {
     }
     s0 = input.substring(s0, peg$currPos);
     peg$silentFails--;
-    s1 = peg$FAILED;
-    if (peg$silentFails === 0) { peg$fail(peg$e15); }
 
     return s0;
   }

--- a/lib/compiler/passes/generate-bytecode.js
+++ b/lib/compiler/passes/generate-bytecode.js
@@ -696,8 +696,8 @@ function generateBytecode(ast, options) {
 
     named(node, context) {
       const match = node.match || 0;
-      // Expectation not required if node always fail
-      const nameIndex = (match === NEVER_MATCH)
+      // Expectation not required if node always match
+      const nameIndex = (match === ALWAYS_MATCH)
         ? -1
         : expectations.add({ type: "rule", value: node.name });
 
@@ -709,7 +709,7 @@ function generateBytecode(ast, options) {
         [op.SILENT_FAILS_ON],
         generate(node.expression, context),
         [op.SILENT_FAILS_OFF],
-        buildCondition(match, [op.IF_ERROR], [op.FAIL, nameIndex], [])
+        buildCondition(-match, [op.IF_ERROR], [op.FAIL, nameIndex], [])
       );
     },
 

--- a/test/behavior/generated-parser-behavior.spec.js
+++ b/test/behavior/generated-parser-behavior.spec.js
@@ -215,11 +215,11 @@ describe("generated parser behavior", () => {
             });
           });
 
-          it("reports match failure and doesn't records any expectations when expression never match", () => {
+          it("reports match failure and records an expectation of type \"other\" when expression never match", () => {
             const parser = peg.generate("start 'start' = []", options);
 
             expect(parser).to.failToParse("b", {
-              expected: [],
+              expected: [{ type:"other", description: "start" }],
             });
           });
 


### PR DESCRIPTION
Found while working on #452.

The condition was backwards, so the error got misreported:

Before the fix:
```
% echo 'start "start" = []' | node bin/peggy.js -t "x"
Error running test
Error: Expected , or undefined but "x" found.
 --> command line:1:1
  |
1 | x
  | ^
```

After the fix:
```
% echo 'start "start" = []' | node bin/peggy.js -t "x"
Error running test
Error: Expected start but "x" found.
 --> command line:1:1
  |
1 | x
  | ^
```

There was already a test, but it was testing for the incorrect result...