### PR TITLE
Fix vscode-eslint settings

### DIFF
--- a/peggy.code-workspace
+++ b/peggy.code-workspace
@@ -6,7 +6,9 @@
   ],
   "settings": {
     "eslint.format.enable": true,
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    "[javascript][typescript]": {
+      "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
   },
   "extensions": {
     "recommendations": [

--- a/peggy.code-workspace
+++ b/peggy.code-workspace
@@ -1,17 +1,17 @@
 {
-	"folders": [
-		{
-			"path": "."
-		}
-	],
-	"settings": {
-		"eslint.format.enable": true,
-		"editor.defaultFormatter": "dbaeumer.vscode-eslint"
-	},
-	"extensions": {
-		"recommendations": [
-			"dbaeumer.vscode-eslint",
-			"peggyjs.peggy-language"
-		]
-	}
+  "folders": [
+    {
+      "path": "."
+    }
+  ],
+  "settings": {
+    "eslint.format.enable": true,
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "extensions": {
+    "recommendations": [
+      "dbaeumer.vscode-eslint",
+      "peggyjs.peggy-language"
+    ]
+  }
 }

--- a/peggy.code-workspace
+++ b/peggy.code-workspace
@@ -6,6 +6,7 @@
   ],
   "settings": {
     "eslint.format.enable": true,
+    "eslint.experimental.useFlatConfig": true,
     "[javascript][typescript]": {
       "editor.defaultFormatter": "dbaeumer.vscode-eslint"
     },


### PR DESCRIPTION
I ran into a few papercuts with peggy.code-workspace:

1. [vscode-eslint][] wasn't using the settings from `eslint.config.js`, so I fixed that
2. the workspace had vscode-eslint set as the default formatter for all languages, so I fixed that
3. peggy.code-workspace was indented with tabs, but .editorconfig said to use spaces for all files, so I reindented the file

Then, of course, I painstakingly committed each of those changes in the opposite order.

[vscode-eslint]: https://github.com/microsoft/vscode-eslint