### PR TITLE
Fix broken text input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 
 ### Bug fixes
 - [#507](https://github.com/peggyjs/peggy/pull/507) Remove stray semicolon in CSS
+- [#508](https://github.com/peggyjs/peggy/pull/508) Fix broken text input
 
 ### Documentation
 - [#506](https://github.com/peggyjs/peggy/pull/506) Added END OF INPUT (`!.`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ Unreleased
 ### New features
 
 ### Bug fixes
+- [#507](https://github.com/peggyjs/peggy/pull/507) Remove stray semicolon in CSS
 
 ### Documentation
-- Added END OF INPUT (`!.`).
+- [#506](https://github.com/peggyjs/peggy/pull/506) Added END OF INPUT (`!.`).
 
 4.0.2
 -----

--- a/docs/js/online.js
+++ b/docs/js/online.js
@@ -213,7 +213,7 @@ $(document).ready(function() {
     }
   }
 
-  $("#parser-var, #option-cache")
+  $("#option-cache")
     .change(rebuildGrammar)
     .mousedown(rebuildGrammar)
     .mouseup(rebuildGrammar)


### PR DESCRIPTION
This input has been broken for some time.  The problem was it disabled itself every time there was a mouse or keyboard effect.  This caused it to lose focus and not accept any input.