### PR TITLE
Detect `*.peggy` files as `PEG` in GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@ bin/* text eol=lf
 *.png binary
 *.jpg binary
 *.ico binary
+*.peggy linguist-language=PEG.js


### PR DESCRIPTION
Thank goodness I stumbled on this! I was about to give up on using the (unmaintained) PEG.js.

[Linguist](https://github.com/github-linguist/linguist) is the tool that GitHub uses to detect languages. This adds an override to `.gitattributes` to make Linguist detect files with the `.peggy` extension as PEG.js. This adds syntax highlighting to those files, and makes sure that they're included in the language stats.

Unfortunately, `.peggy` doesn't seem to be popular enough yet to "officially" be made a PEG.js extension. I'll make a PR there just in case. So for now, using the language override seems to be the best way to get `.peggy` files detected as code. Vim or Emacs modelines can also be used.