### PR TITLE
fix unprintable characters in error messages

### DIFF
--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -942,18 +942,35 @@ function generateJS(ast, options) {
       "  if (this.location) {",
       "    var src = null;",
       "    var k;",
-      "    for (k = 0; k < sources.length; k++) {",
-      "      if (sources[k].source === this.location.source) {",
-      "        src = sources[k].text.split(/\\r\\n|\\n|\\r/g);",
-      "        break;",
-      "      }",
-      "    }",
+      "    var text_contains_nonprintable_characters;",
+      `   
+            let regExpNonPrintableCharacter = /[^\\x20-\\x7E]/; 
+            
+            for (k = 0; k < sources.length; k++) {
+              if (sources[k].source === this.location.source) {
+                // check if unprintable characters are in file
+                text_contains_nonprintable_characters = sources[k].text.split("").some(char => regExpNonPrintableCharacter.test(char));
+                
+                if (text_contains_nonprintable_characters) {
+                  // keep text unchanged so we can handle it as hex later
+                  src = sources[k].text;
+                } else {
+                  // handle line-by-line as readable text
+                  src = sources[k].text.split(/\\r\\n|\\n|\\r/g);
+                }
+
+                break
+              }
+            }
+      `,
       "    var s = this.location.start;",
       "    var offset_s = (this.location.source && (typeof this.location.source.offset === \"function\"))",
       "      ? this.location.source.offset(s)",
       "      : s;",
       "    var loc = this.location.source + \":\" + offset_s.line + \":\" + offset_s.column;",
       "    if (src) {",
+      "       if (!text_contains_nonprintable_characters) { ",
+      "         // process as plain text line-by-line ",
       "      var e = this.location.end;",
       "      var filler = peg$padEnd(\"\", offset_s.line.toString().length, ' ');",
       "      var line = src[s.line - 1];",
@@ -964,6 +981,113 @@ function generateJS(ast, options) {
       "          + offset_s.line + \" | \" + line + \"\\n\"",
       "          + filler + \" | \" + peg$padEnd(\"\", s.column - 1, ' ')",
       "          + peg$padEnd(\"\", hatLen, \"^\");",
+      "       } else {",  
+      `
+                // text has non-printable characters
+                // replace unprintable characters with hex value
+                // display where error happened in a way that is safe for console output
+
+                // number of characters to show left and right of where the error happened
+                let num_bytes_context = 50;
+
+                // calculate snippet start and end
+                let offset_snippet_start = Math.max(0, this.location.start.offset - num_bytes_context);
+                let offset_snippet_end = Math.min(this.location.end.offset + num_bytes_context, src.length);
+
+                // javascript uses utf16 strings internally, convert to utf8
+                let arr_bytes_before_error_position = new TextEncoder().encode(src.slice(offset_snippet_start, this.location.start.offset));
+                let arr_bytes_at_error_position = new TextEncoder().encode(src.slice(this.location.start.offset, this.location.end.offset));
+                let arr_bytes_after_error_position = new TextEncoder().encode(src.slice(this.location.start.offset, offset_snippet_end));
+
+                // old offset position does not work for new string
+                let offset_error_start_in_new_array = arr_bytes_before_error_position.length;
+                let offset_error_end_in_new_array = offset_error_start_in_new_array + arr_bytes_at_error_position.length
+
+                // combine byte arrays to one large array. this also converts Uint8Array to normal array, 
+                // but this is okay because as the array only contains the string charcode numbers 
+                let arr_bytes_with_error_context = [...arr_bytes_before_error_position, ...arr_bytes_at_error_position, ...arr_bytes_after_error_position]
+
+                // this will be the error context for printing to console
+                let str_error_context_as_string = ""
+                let str_error_context_as_hex = ""
+
+                // this will be the visual pointer that shows where exactly the error happened
+                let str_error_context_pointer = ""
+
+                // create snippet which shows exactly where error has happened
+                for (var position = 0; position <= arr_bytes_with_error_context.length; position++) {
+                  // read one character at a time
+                  let charcode_at_current_position = arr_bytes_with_error_context[position];
+
+                  // store printable character
+                  let str_printable_character;
+
+                  // check if character is printable or not
+                  if (charcode_at_current_position < 32 || charcode_at_current_position > 126) {
+                    // character not printable, convert to hex
+                    str_printable_character = charcode_at_current_position.toString(16).toUpperCase().padStart(2, "0")
+
+                    // add hex to error context string
+                    str_error_context_as_hex += str_printable_character
+
+                    // add two spaces to normal error context string and to visual pointer string
+                    // in order to ensure proper spacing
+                    str_error_context_as_string += " ".repeat(str_printable_character.length)
+                  } else {
+                    // convert charcode to string
+                    str_printable_character = String.fromCharCode(charcode_at_current_position);
+
+                    // character is printable, so no need to transform it to hex
+                    // just add it to context string
+                    str_error_context_as_string += str_printable_character
+
+                    // add space to hex string to ensure proper spacing
+                    str_error_context_as_hex += " ".repeat(str_printable_character.length)
+                  }
+
+                  // add visual pointer to exact error location if needed
+                  if (position < offset_error_start_in_new_array) {
+                    // pointer not needed YET because position is left of where error happened
+                    // add spaces so pointer will be properly placed
+                    // ensure two spaces are added when hex conversion was done
+                    str_error_context_pointer += " ".repeat(str_printable_character.length)
+                  } else if (position <= offset_error_end_in_new_array) {
+                    // position is within start and end of error offset
+                    // add visual pointer to error
+                    // ensure two pointers are added when hex conversion was done
+                    str_error_context_pointer += "X".repeat(str_printable_character.length)
+                  } else {
+                    // we have passed error location, so we won't add anything to the pointer string
+                  }
+                }
+
+                // in case we're in terminal, ensure we stay smaller than the terminal width
+                if (typeof process !== "undefined" &&  typeof process.stdout !== "undefined" && process.stdout.isTTY) {
+                  let terminal_width = process.stdout.columns;
+
+                  if (typeof terminal_width !== "undefined" && str_error_context_as_string.length > terminal_width) {
+                    // reduce length of strings if terminal width is not enough
+                    do {  
+                      // remove one item from front and one item from back
+                      str_error_context_as_string = str_error_context_as_string.slice(1,-1)
+                      str_error_context_as_hex = str_error_context_as_hex.slice(1,-1)
+                      arr_bytes_with_error_context = arr_bytes_with_error_context.slice(1,-1)
+
+                      // only remove one item for left side from pointer
+                      str_error_context_pointer = str_error_context_pointer.slice(1)
+                    } while (str_error_context_as_string.length > terminal_width);
+                  }
+                }
+
+                // output to console
+                str += ("\\n\\nError starts at offset " + this.location.start.offset
+                  + " and ends after " + (this.location.end.offset-this.location.start.offset) + " bytes in file " + this.location.source + "\\n");
+                str += ("\\n\\n" + str_error_context_pointer + "\\n" + str_error_context_as_string + "\\n" 
+                  + str_error_context_as_hex + "\\n" + str_error_context_pointer + "\\n\\n");
+
+                // console.log("arr_bytes_with_error_context", arr_bytes_with_error_context);
+              }
+      `,
       "    } else {",
       "      str += \"\\n at \" + loc;",
       "    }",


### PR DESCRIPTION
when working with binary files on the command line, e.g. `peggy -T` the error messages are often unreadable due to special characters such as `\r`.

This PR fixes the problem and outputs HEX when things are not readable.

Output will have a ASCII pointer where exactly the error location is, and a mix of hex / printable characters.
Output will check terminal width and will not exceed terminal width.
Error message will report `offset` in file instead of `line` and `position` .

```                                                                                                                XX
           c    sz                                                              endstream  endobj  2 0 obj  << //Length 47   >>  stream  q 595.20 0 0 840.96 
FBFBDEFBFBD DBB3  EFBFBDEFBFBDEFBFBDEFBFBD1EEFBFBD00EFBFBDEFBFBD007FEFBFBDEFBFBD         0D      0D       0D               0D  0D      0D                    
                                                                                                               XX
```


 Working on `generate-js.js` was a PITA and not nice.