### PR TITLE
Adequate fix for #457.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Released: TBD (Not before 2025-05-01)
 - Minor changes in code generation for parsers.  More consistent indentation,
   trailing commas (for consistency with the Peggy house style).
   [#593](https://github.com/peggyjs/peggy/pull/593)
+- Avoid performance cliff for deeply-nested grammars when checking for
+  infinite recursion.  Previously, nesting more than about 30 layers deep
+  caused drastically increasing processing time.  Now, nesting more than 700
+  layers deep causes "Maximum call stack size exceeded"; hopefully this is
+  deep enough in practice. [#600](https://github.com/peggyjs/peggy/pull/600)
 
 ### Documentation
 

--- a/lib/compiler/passes/report-infinite-recursion.js
+++ b/lib/compiler/passes/report-infinite-recursion.js
@@ -22,10 +22,7 @@ function reportInfiniteRecursion(ast, options, session) {
 
   const check = visitor.build({
     rule(node) {
-      if (session.errors > 0) {
-        return;
-      }
-      if (seen.has(node.name)) {
+      if ((session.errors > 0) || seen.has(node.name)) {
         return;
       }
       seen.add(node.name);
@@ -83,7 +80,7 @@ function reportInfiniteRecursion(ast, options, session) {
           backtraceRefs.map((ref, i, a) => ({
             message: i + 1 !== a.length
               ? `Step ${i + 1}: call of the rule "${ref.name}" without input consumption`
-              : `Step ${i + 1}: call itself without input consumption - left recursion`,
+              : `Step ${i + 1}: calls itself without input consumption - left recursion`,
             location: ref.location,
           }))
         );

--- a/lib/compiler/passes/report-infinite-recursion.js
+++ b/lib/compiler/passes/report-infinite-recursion.js
@@ -18,12 +18,18 @@ function reportInfiniteRecursion(ast, options, session) {
   const visitedRules = [];
   // Array with rule_refs for diagnostic
   const backtraceRefs = [];
+  const seen = new Set();
 
   const check = visitor.build({
     rule(node) {
       if (session.errors > 0) {
         return;
       }
+      if (seen.has(node.name)) {
+        return;
+      }
+      seen.add(node.name);
+
       visitedRules.push(node.name);
       check(node.expression);
       visitedRules.pop();

--- a/test/unit/compiler/passes/helpers.js
+++ b/test/unit/compiler/passes/helpers.js
@@ -21,6 +21,24 @@ module.exports = function(chai, utils) {
     new Assertion(ast).like(props);
   });
 
+  Assertion.addMethod("haveErrors", function(grammar, props) {
+    const ast = parser.parse(grammar);
+
+    const session = new Session();
+    utils.flag(this, "object")(ast, {}, session);
+
+    switch (typeof props) {
+      case "number":
+        new Assertion(session.errors).equal(props);
+        break;
+      case "object":
+        new Assertion(session.problems).like(props);
+        break;
+      default:
+        break;
+    }
+  });
+
   Assertion.addMethod("reportError", function(grammar, props) {
     const ast = parser.parse(grammar);
 

--- a/test/unit/compiler/passes/report-infinite-recursion.spec.js
+++ b/test/unit/compiler/passes/report-infinite-recursion.spec.js
@@ -170,4 +170,25 @@ describe("compiler pass |reportInfiniteRecursion|", () => {
       });
     });
   });
+
+  it("does not fail on deeply-nested grammars", () => {
+    let src = "";
+    const max = 500; // Used to bonk at ~30.  Now bonks over 700.
+    for (let i = 0; i < max; i++) {
+      src += `foo${i} = foo${i + 1} / foo${i + 2}\n`;
+    }
+    src += `foo${max} = "a"\n`;
+    src += `foo${max + 1} = "a"\n`;
+    src += "bar = 'c'\n";
+    expect(pass).to.not.reportError(src);
+  });
+
+  it("does not continue after finding an error", () => {
+    // "reportError" stops on first error.
+
+    expect(pass).to.haveErrors("foo = foo 'b'", 1);
+    expect(pass).to.haveErrors("foo = foo / ([a] 'b')", 1);
+    expect(pass).to.haveErrors("foo = foo / ('b'|..|)", 1);
+    expect(pass).to.haveErrors("foo = foo / (bar)", 1);
+  });
 });


### PR DESCRIPTION
This is a quick hack to see if we are traversing the same node a lot.  We are.

This takes the depth that can be processed on my box from about 30 to about 700 (where we run out of stack space), which may be enough in practice.

This can be sped up a little by using two sets, I think.

Also, we could use a state array instead of being as aggressively recursive, which might get us a little more scale.