### PR TITLE
Add missing console log for recovering failed test sessions

### DIFF
--- a/test/cli/run.spec.ts
+++ b/test/cli/run.spec.ts
@@ -813,6 +813,7 @@ Options:
     expect(() => {
       // Make sure the file isn't there before we start
       fs.statSync(test_output);
+      console.log(`Delete file: "${path.resolve(__dirname, "..", "..", test_output)}"`);
     }).toThrow();
 
     await exec({


### PR DESCRIPTION
Inform the user to remove test_output.js