### PR TITLE
Add newlines around function bodys

### DIFF
--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -303,10 +303,10 @@ function generateJS(ast, options) {
      */
     function buildFunc(a, i) {
       return wrapInSourceNode(
-        `\n  function ${f(i)}(${a.params.join(", ")}) {`,
+        `\n  function ${f(i)}(${a.params.join(", ")}) {\n`,
         reIndent(a.body, "    "),
         a.location,
-        "  }"
+        "\n  }"
       );
     }
 


### PR DESCRIPTION
Currently, the generater creates code like following.

```
  function peg$f21() {    return '';  }
```

There is no newlines around body, but statements inside are indented. This seems like a mistake. Adding the newlines will make the code looks like:

```
  function peg$f21() {
    return '';
  }
```
