### PR TITLE
perf(codegen): Use char codes for simple classes

### DIFF
--- a/lib/compiler/passes/generate-js.js
+++ b/lib/compiler/passes/generate-js.js
@@ -325,6 +325,46 @@ function generateJS(ast, options) {
   }
 
   /**
+   * @param {PEG.ast.GrammarCharacterClass} cls
+   * @returns {boolean}
+   */
+  function canUseCharCodeClass(cls) {
+    return !cls.ignoreCase
+      && !cls.unicode
+      && cls.value.every(part => (
+        Array.isArray(part)
+          ? part[0].length === 1 && part[1].length === 1
+          : part.length === 1
+      ));
+  }
+
+  /**
+   * @param {PEG.ast.GrammarCharacterClass} cls
+   * @param {string} inputChunk
+   * @returns {string}
+   */
+  function buildCharCodeClassCondition(cls, inputChunk) {
+    const charCode = "peg$charCode";
+    const tests = cls.value.map(part => {
+      if (Array.isArray(part)) {
+        const begin = part[0].charCodeAt(0);
+        const end = part[1].charCodeAt(0);
+        return begin === end
+          ? `${charCode} === ${begin}`
+          : `(${charCode} >= ${begin} && ${charCode} <= ${end})`;
+      }
+
+      return `${charCode} === ${part.charCodeAt(0)}`;
+    });
+    const condition = tests.length > 0 ? tests.join(" || ") : "false";
+    const assignedCondition = `(peg$charCode = ${inputChunk}.charCodeAt(0), ${condition})`;
+
+    return cls.inverted
+      ? `${inputChunk} !== "" && !${assignedCondition}`
+      : assignedCondition;
+  }
+
+  /**
    * @param {string} ruleNameCode
    * @param {number} ruleIndexCode
    */
@@ -747,8 +787,17 @@ function generateJS(ast, options) {
 
           case op.MATCH_CHAR_CLASS: { // MATCH_CHAR_CLASS c, a, f, ...
             const regNum = bc[ip + 1];
+            const cls = classes[regNum];
             compileInputChunkCondition(
-              inputChunk => `${r(regNum)}.test(${inputChunk})`, 1, 1
+              inputChunk => {
+                if (canUseCharCodeClass(cls)) {
+                  return buildCharCodeClassCondition(cls, inputChunk);
+                }
+
+                return `${r(regNum)}.test(${inputChunk})`;
+              },
+              1,
+              1
             );
             break;
           }
@@ -1195,6 +1244,7 @@ function generateJS(ast, options) {
 
     parts.push(
       "  let peg$result;",
+      "  let peg$charCode;",
       "",
       "  if (options.startRule) {",
       "    if (!(options.startRule in peg$startRuleFunctions)) {",

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -670,6 +670,7 @@ function peg$parse(input, options) {
   let peg$silentFails = options.peg$silentFails | 0;
 
   let peg$result;
+  let peg$charCode;
 
   if (options.startRule) {
     if (!(options.startRule in peg$startRuleFunctions)) {
@@ -1823,7 +1824,7 @@ function peg$parse(input, options) {
     let s0;
 
     s0 = input.charAt(peg$currPos);
-    if (peg$r0.test(s0)) {
+    if ((peg$charCode = s0.charCodeAt(0), peg$charCode === 33 || peg$charCode === 36 || peg$charCode === 38)) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
@@ -1866,7 +1867,7 @@ function peg$parse(input, options) {
     let s0;
 
     s0 = input.charAt(peg$currPos);
-    if (peg$r1.test(s0)) {
+    if ((peg$charCode = s0.charCodeAt(0), (peg$charCode >= 42 && peg$charCode <= 43) || peg$charCode === 63)) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
@@ -2195,7 +2196,7 @@ function peg$parse(input, options) {
     let s0;
 
     s0 = input.charAt(peg$currPos);
-    if (peg$r2.test(s0)) {
+    if ((peg$charCode = s0.charCodeAt(0), peg$charCode === 33 || peg$charCode === 38)) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
@@ -2220,7 +2221,7 @@ function peg$parse(input, options) {
     let s0;
 
     s0 = input.charAt(peg$currPos);
-    if (peg$r3.test(s0)) {
+    if ((peg$charCode = s0.charCodeAt(0), (peg$charCode >= 0 && peg$charCode <= 55295) || (peg$charCode >= 57344 && peg$charCode <= 65535))) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
@@ -2236,7 +2237,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     s2 = input.charAt(peg$currPos);
-    if (peg$r4.test(s2)) {
+    if ((peg$charCode = s2.charCodeAt(0), (peg$charCode >= 55296 && peg$charCode <= 56319))) {
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
@@ -2244,7 +2245,7 @@ function peg$parse(input, options) {
     }
     if (s2 !== peg$FAILED) {
       s3 = input.charAt(peg$currPos);
-      if (peg$r5.test(s3)) {
+      if ((peg$charCode = s3.charCodeAt(0), (peg$charCode >= 56320 && peg$charCode <= 57343))) {
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
@@ -2268,7 +2269,7 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = input.charAt(peg$currPos);
-      if (peg$r6.test(s0)) {
+      if ((peg$charCode = s0.charCodeAt(0), (peg$charCode >= 55296 && peg$charCode <= 57343))) {
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
@@ -2303,7 +2304,7 @@ function peg$parse(input, options) {
     let s0;
 
     s0 = input.charAt(peg$currPos);
-    if (peg$r8.test(s0)) {
+    if ((peg$charCode = s0.charCodeAt(0), peg$charCode === 10 || peg$charCode === 13 || peg$charCode === 8232 || peg$charCode === 8233)) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
@@ -2334,7 +2335,7 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = input.charAt(peg$currPos);
-        if (peg$r9.test(s0)) {
+        if ((peg$charCode = s0.charCodeAt(0), peg$charCode === 13 || (peg$charCode >= 8232 && peg$charCode <= 8233))) {
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
@@ -2843,7 +2844,7 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     peg$silentFails++;
     s3 = input.charAt(peg$currPos);
-    if (peg$r12.test(s3)) {
+    if ((peg$charCode = s3.charCodeAt(0), peg$charCode === 10 || peg$charCode === 13 || peg$charCode === 34 || peg$charCode === 92 || (peg$charCode >= 8232 && peg$charCode <= 8233))) {
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
@@ -2911,7 +2912,7 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     peg$silentFails++;
     s3 = input.charAt(peg$currPos);
-    if (peg$r13.test(s3)) {
+    if ((peg$charCode = s3.charCodeAt(0), peg$charCode === 10 || peg$charCode === 13 || peg$charCode === 39 || peg$charCode === 92 || (peg$charCode >= 8232 && peg$charCode <= 8233))) {
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
@@ -3373,7 +3374,7 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     peg$silentFails++;
     s3 = input.charAt(peg$currPos);
-    if (peg$r15.test(s3)) {
+    if ((peg$charCode = s3.charCodeAt(0), peg$charCode === 10 || peg$charCode === 13 || (peg$charCode >= 92 && peg$charCode <= 93) || (peg$charCode >= 8232 && peg$charCode <= 8233))) {
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
@@ -3522,7 +3523,7 @@ function peg$parse(input, options) {
     let s0, s1;
 
     s0 = input.charAt(peg$currPos);
-    if (peg$r16.test(s0)) {
+    if ((peg$charCode = s0.charCodeAt(0), peg$charCode === 34 || peg$charCode === 39 || peg$charCode === 92)) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
@@ -3668,7 +3669,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleEscapeCharacter();
     if (s0 === peg$FAILED) {
       s0 = input.charAt(peg$currPos);
-      if (peg$r17.test(s0)) {
+      if ((peg$charCode = s0.charCodeAt(0), (peg$charCode >= 48 && peg$charCode <= 57) || peg$charCode === 112 || peg$charCode === 117 || peg$charCode === 120)) {
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
@@ -3853,7 +3854,7 @@ function peg$parse(input, options) {
     let s0;
 
     s0 = input.charAt(peg$currPos);
-    if (peg$r18.test(s0)) {
+    if ((peg$charCode = s0.charCodeAt(0), (peg$charCode >= 48 && peg$charCode <= 57))) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
@@ -3959,7 +3960,7 @@ function peg$parse(input, options) {
     s4 = peg$currPos;
     peg$silentFails++;
     s5 = input.charAt(peg$currPos);
-    if (peg$r20.test(s5)) {
+    if ((peg$charCode = s5.charCodeAt(0), peg$charCode === 123 || peg$charCode === 125)) {
       peg$currPos++;
     } else {
       s5 = peg$FAILED;
@@ -3992,7 +3993,7 @@ function peg$parse(input, options) {
         s4 = peg$currPos;
         peg$silentFails++;
         s5 = input.charAt(peg$currPos);
-        if (peg$r20.test(s5)) {
+        if ((peg$charCode = s5.charCodeAt(0), peg$charCode === 123 || peg$charCode === 125)) {
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
@@ -4059,7 +4060,7 @@ function peg$parse(input, options) {
       s4 = peg$currPos;
       peg$silentFails++;
       s5 = input.charAt(peg$currPos);
-      if (peg$r20.test(s5)) {
+      if ((peg$charCode = s5.charCodeAt(0), peg$charCode === 123 || peg$charCode === 125)) {
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
@@ -4092,7 +4093,7 @@ function peg$parse(input, options) {
           s4 = peg$currPos;
           peg$silentFails++;
           s5 = input.charAt(peg$currPos);
-          if (peg$r20.test(s5)) {
+          if ((peg$charCode = s5.charCodeAt(0), peg$charCode === 123 || peg$charCode === 125)) {
             peg$currPos++;
           } else {
             s5 = peg$FAILED;

--- a/test/api/pegjs-api.spec.js
+++ b/test/api/pegjs-api.spec.js
@@ -182,6 +182,13 @@ describe("Peggy API", () => {
           // eslint-disable-next-line no-eval -- Required
           expect(eval(source).parse("a")).to.equal("a");
         });
+
+        it("uses charCodeAt for simple character class checks", () => {
+          const source = peg.generate("start = [a-z]", { output: "source" });
+
+          expect(source).to.contain("peg$charCode = s0.charCodeAt(0)");
+          expect(source).to.not.contain("peg$r0.test(s0)");
+        });
       });
 
       describe("when |output| is set to |\"ast\"|", () => {
@@ -367,7 +374,7 @@ describe("Peggy API", () => {
           it("labelled rule name", () => check("RULE_2 'named'", source, "RULE_2", "peg$parseRULE_2() {"));
           it("literal expression", () => check("'a'", source, null, "input.charCodeAt(peg$currPos) === 97"));
           it("multichar literal", () => check("'def'", source, null, "input.substr(peg$currPos, 3) === peg$c3"));
-          it("chars expression", () => check("[abc]", source, null, /s\d = input\.charAt\(peg\$currPos\);\s*if \(peg\$r0\.test\(s\d\)\)/));
+          it("chars expression", () => check("[abc]", source, null, /s\d = input\.charAt\(peg\$currPos\);\s*if \(\(peg\$charCode = s\d\.charCodeAt\(0\)/));
           it("rule expression", () => check("RULE_2", source, null, "peg$parseRULE_2();"));
           it("choice expression", () => check(
             "RULE_1 / RULE_2",


### PR DESCRIPTION
This optimizes generated parser code for simple character classes.

A lot of grammars have hot loops that look like this:

```peggy
identifier = [a-zA-Z_$] [a-zA-Z0-9_$]*
number = [0-9]+ ("." [0-9]+)?
whitespace = [ \t\n\r]*
```

Peggy currently emits a regexp test for each character consumed by those classes. This PR emits direct `charCodeAt` comparisons when the class is simple enough to do that exactly: no `i` flag, no unicode mode, and only single-code-unit ranges/characters.

Anything more complicated still uses the existing regexp path.

As one real-world benchmark, I used Sentry’s search grammar, which is the grammar we use for parsing search bar queries: https://github.com/getsentry/sentry/blob/master/static/app/components/searchSyntax/grammar.pegjs. That grammar has a lot of key/value filters, so longer searches spend plenty of time in these character-class loops.

| Input | Before | After | Speedup |
|---|---:|---:|---:|
| 200 short search strings, cycling through common filter/query shapes | 3.1664 ms | 2.5784 ms | 18.6% |
| one 2.7 KB query with 120 mixed free-text, filter, and grouped terms | 0.7804 ms | 0.6653 ms | 14.7% |
| two copies of the long query joined with `AND`, about 5.4 KB | 1.6284 ms | 1.4060 ms | 13.7% |
| the long query plus a parenthesized copy joined with `OR`, about 5.4 KB | 1.6405 ms | 1.3890 ms | 15.3% |

For that generated parser, repeated class-check code went from 177 `charCodeAt` calls to 76 because each check computes the character code once and reuses it.